### PR TITLE
Malformed JSON in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
                <p>A simple example of a JSON object expressing Linked Data:</p>
                <pre>
 { 
-  "@context": "http://purl.org/jsonld/Person"
+  "@context": "http://purl.org/jsonld/Person",
   "@subject": "http://dbpedia.org/resource/John_Lennon",
   "name": "John Lennon",
   "birthday": "10-09",


### PR DESCRIPTION
A "," was missing after the first line in the example.
