### PR TITLE
Fix indentation on context processing algorithm (§3.3)

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -789,41 +789,41 @@ language-native data structures MUST be used where applicable.</p>
             <li>Merge the of <tref>local context</tref> into the <tref>active context</tref>.</li>
           </ol>
         </li>
-      </ol>
-    </li>
-    <li>If <em>value</em> is a <tref>JSON object</tref>, perform the following steps:
-      <ol class="algorithm">
-        <li>If <em>value</em> has a <code>@language</code> key, it MUST have a value of a
-          simple <tref>string</tref> or <code>null</code>. Add the language to the <tref>local context</tref>.</li>
-        <li>Otherwise, for each key in <em>value</em> having the lexical form of <cite><a
-          href="http://www.w3.org/TR/2009/REC-xml-names-20091208/#NT-NCName">NCName</a></cite> (see [[XML-NAMES]]),
-          or is an empty string,
+        <li>If <em>value</em> is a <tref>JSON object</tref>, perform the following steps:
           <ol class="algorithm">
-            <li>If the key's value is a simple <tref>string</tref>, the value MUST have the form of
-              <tref>term</tref>, <tref>prefix</tref>:suffix, absolute IRI. Determine the IRI mapping value by
-              performing <a href="#iri-expansion">IRI Expansion</a> on the associated value. If the result of the IRI
-              mapping is an absolute IRI, merge the key-value pair into the <tref>local context</tref>
-              <tref>term mapping</tref>.</li>
-            <li id="object-context">Otherwise, the key's value MUST be a <tref>JSON object</tref>.
+            <li>If <em>value</em> has a <code>@language</code> key, it MUST have a value of a
+              simple <tref>string</tref> or <code>null</code>. Add the language to the <tref>local context</tref>.</li>
+            <li>Otherwise, for each key in <em>value</em> having the lexical form of <cite><a
+              href="http://www.w3.org/TR/2009/REC-xml-names-20091208/#NT-NCName">NCName</a></cite> (see [[XML-NAMES]]),
+              or is an empty string,
               <ol class="algorithm">
-                <li>The value MUST have a <code>@id</code> key with a string value, the value MUST have the
-                  form of <tref>term</tref>, <tref>prefix</tref>:suffix, absolute IRI. Determine the IRI mapping value
-                  by performing <a href="#iri-expansion">IRI Expansion</a> on the associated value. If the result of
-                  the IRI mapping is an absolute IRI, merge the key-value pair into the <tref>local context</tref>
+                <li>If the key's value is a simple <tref>string</tref>, the value MUST have the form of
+                  <tref>term</tref>, <tref>prefix</tref>:suffix, absolute IRI. Determine the IRI mapping value by
+                  performing <a href="#iri-expansion">IRI Expansion</a> on the associated value. If the result of the IRI
+                  mapping is an absolute IRI, merge the key-value pair into the <tref>local context</tref>
                   <tref>term mapping</tref>.</li>
-                <li>If the value has a <code>@type</code> key, the value MUST have the form of <tref>term</tref>,
-                  <tref>prefix</tref>:suffix, absolute IRI or the <tref>keyword</tref> <code>@id</code>. Determine the IRI by
-                  performing <a href="#iri-expansion">IRI Expansion</a> on the associated value. If the result of the
-                  IRI mapping is an absolute IRI or <code>@id</code>, merge into the <tref>local context</tref>
-                  <tref>coercion mapping</tref>.</li>
-                <li>If the value has a <code>@list</code> key, the value MUST be
-                  <code>true</code> or <code>false</code>. Merge into the <tref>local context</tref> <tref>list
-                  mapping</tref>.</li>
+                <li id="object-context">Otherwise, the key's value MUST be a <tref>JSON object</tref>.
+                  <ol class="algorithm">
+                    <li>The value MUST have a <code>@id</code> key with a string value, the value MUST have the
+                      form of <tref>term</tref>, <tref>prefix</tref>:suffix, absolute IRI. Determine the IRI mapping value
+                      by performing <a href="#iri-expansion">IRI Expansion</a> on the associated value. If the result of
+                      the IRI mapping is an absolute IRI, merge the key-value pair into the <tref>local context</tref>
+                      <tref>term mapping</tref>.</li>
+                    <li>If the value has a <code>@type</code> key, the value MUST have the form of <tref>term</tref>,
+                      <tref>prefix</tref>:suffix, absolute IRI or the <tref>keyword</tref> <code>@id</code>. Determine the IRI by
+                      performing <a href="#iri-expansion">IRI Expansion</a> on the associated value. If the result of the
+                      IRI mapping is an absolute IRI or <code>@id</code>, merge into the <tref>local context</tref>
+                      <tref>coercion mapping</tref>.</li>
+                    <li>If the value has a <code>@list</code> key, the value MUST be
+                      <code>true</code> or <code>false</code>. Merge into the <tref>local context</tref> <tref>list
+                      mapping</tref>.</li>
+                  </ol>
+                </li>
+                <li>Merge the <tref>local context</tref> into the <tref>active context</tref>.</li>
+                <li>Repeat <a href="#object-context">Step 3.2</a> until no entries are added to the <tref>local
+                  context</tref>.</li>
               </ol>
             </li>
-            <li>Merge the <tref>local context</tref> into the <tref>active context</tref>.</li>
-            <li>Repeat <a href="#object-context">Step 3.2</a> until no entries are added to the <tref>local
-              context</tref>.</li>
           </ol>
         </li>
       </ol>


### PR DESCRIPTION
It looks like the indentation here is incorrect. Step #3 should be step #2.3, since it parallels the case analysis of "value" in #2.1 and #2.2.
