### PR TITLE
Fix Playground's "param" behaviors + permalinks

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -62,8 +62,10 @@
                </div>
                <textarea id="markup" class="compressed process"
                   placeholder="Enter your JSON-LD markup here..."></textarea>
-               <textarea id="param" class="compressed process"
-                  placeholder="Enter your JSON-LD context or frame here..."></textarea>
+               <textarea id="context" class="compressed process"
+                  placeholder="Enter your JSON-LD context here..."></textarea>
+               <textarea id="frame" class="compressed process hidden"
+                  placeholder="Enter your JSON-LD frame here..."></textarea>
             </div>
 
             <div id="permalink"></div>

--- a/playground/playground-examples.js
+++ b/playground/playground-examples.js
@@ -10,7 +10,8 @@
 
   // setup the examples and params
   playground.examples = {};
-  playground.params = {};
+  playground.frames = {};
+  playground.contexts = {};
 
   // add the example of a Person
   playground.examples["Person"] = {
@@ -161,7 +162,7 @@
   };
 
   // add the frame example of a Library
-  playground.params["Library"] = {
+  playground.frames["Library"] = {
     "@context": {
       "dc": "http://purl.org/dc/elements/1.1/",
       "ex": "http://example.org/vocab#"

--- a/playground/playground.css
+++ b/playground/playground.css
@@ -95,3 +95,5 @@ li.button:active span {
   font-size: 0.8em;
   overflow: auto;
 }
+
+#frame {display: none;}


### PR DESCRIPTION
The Playground currently uses a single field to keep track of a user's `context` _or_ `frame`.  The behavior of this field changes depending on which tab is active, leading to very strange behavior when switching tabs.  

This pull request:
- Explicitly separates `context` from `frame` (in UI elements + code)
- Updates permalinks to supply these fields separately while maintaining backwards compatibility
- Adds a `startTab` parameter to the permalink to ensure that sharing a link really does communicate a shared view.

An example of previous strange behavior is:  if I define a frame and switch to the compact views, my old frame gets assigned as a context...

``` javascript
{
    "@context": {
        "@context": {
            "dc": "http://purl.org/dc/terms/"
        },

[remainder snipped]
```
