### PR TITLE
Allow a single subject to be re-embedded in each top-level frame match.  (I hope this behavior is intentional.)

### DIFF
--- a/test-suite/tests/frame-0019-frame.jsonld
+++ b/test-suite/tests/frame-0019-frame.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "ex": "http://example.org/terms#"
+  },
+  "@type": "ex:Node"
+}

--- a/test-suite/tests/frame-0019-in.jsonld
+++ b/test-suite/tests/frame-0019-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {
+    "ex": "http://example.org/terms#",
+    "ex:sees": {
+      "@type": "@id"
+    }
+  },
+  "@graph": [
+  {
+    "@id": "ex:node1",
+    "@type": "ex:Node",
+    "ex:sees": "ex:node2",
+    "ex:color": "blue"
+  }, {
+    "@id": "ex:node2",
+    "@type": "ex:Node",
+    "ex:sees": "ex:node1",
+    "ex:color": "red"
+  }]
+}

--- a/test-suite/tests/frame-0019-out.jsonld
+++ b/test-suite/tests/frame-0019-out.jsonld
@@ -1,0 +1,31 @@
+{
+    "@context": {
+        "ex": "http://example.org/terms#"
+    },
+    "@graph": [{
+        "@id": "ex:node1",
+        "@type": "ex:Node",
+        "ex:color": "blue",
+        "ex:sees": {
+            "@id": "ex:node2",
+            "@type": "ex:Node",
+            "ex:sees": {
+                "@id": "ex:node1"
+            },
+            "ex:color": "red"
+        }
+    }, {
+        "@id": "ex:node2",
+        "@type": "ex:Node",
+        "ex:color": "red",
+        "ex:sees": {
+            "@id": "ex:node1",
+            "@type": "ex:Node",
+            "ex:sees": {
+                "@id": "ex:node2"
+            },
+            "ex:color": "blue"
+        }
+    }]
+}
+

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -112,5 +112,11 @@
       "input": "frame-0018-in.jsonld",
       "frame": "frame-0018-frame.jsonld",
       "expect": "frame-0018-out.jsonld"
+   }, {
+      "@type": ["test:TestCase", "jld:FrameTest"],
+      "name": "Resources can be re-embedded again in each top-level frame match",
+      "input": "frame-0019-in.jsonld",
+      "frame": "frame-0019-frame.jsonld",
+      "expect": "frame-0019-out.jsonld"
    }]
 }


### PR DESCRIPTION
[Example in playground](http://tinyurl.com/c63bge8)

I _really_ like this new behavior, but I didn't notice any positive test coverage, so I wanted to make sure it's real.

(Note:  I'd _really, really_ like a more generalized approach to re-embeds that allowed arbitrary re-embedding of a subject as long as the direct path from embed-to-root didn't include that subject.  This could generate some verbose frame matches, but would still avoid circularity.  My alternative is to fashion this kind of graph in-memory, using a framed result as a starting point...)
