### PR TITLE
Fix missing </a>.

### DIFF
--- a/spec/latest/json-ld-syntax/index.html
+++ b/spec/latest/json-ld-syntax/index.html
@@ -2130,7 +2130,7 @@ processor will use direct string comparison when looking up
 
 <p>At times, it becomes necessary to be able to express information without
 being able to specify the subject. Typically, this type of node is called
-an <tdef>unlabeled node</tdef> or a blank node (see [[!RDF-CONCEPTS]] <cite><a href="http://www.w3.org/TR/rdf11-concepts/#section-blank-nodes">Section 3.4: Blank Nodes</cite>).
+an <tdef>unlabeled node</tdef> or a blank node (see [[!RDF-CONCEPTS]] <cite><a href="http://www.w3.org/TR/rdf11-concepts/#section-blank-nodes">Section 3.4: Blank Nodes</a></cite>).
 In JSON-LD, <tref>unlabeled node</tref> identifiers are
 automatically created if a subject is not specified using the
 <code>@id</code> <tref>keyword</tref>. However, authors may provide identifiers for


### PR DESCRIPTION
A missing closing tag turns section 4.11 into one giant link.
