### PR TITLE
Conformance section and grammar updates

### DIFF
--- a/spec/latest/json-ld-syntax/index.html
+++ b/spec/latest/json-ld-syntax/index.html
@@ -442,7 +442,7 @@ case-sensitive.</p>
 
 <p>The JSON-LD Syntax specification describes the conformance criteria for JSON-LD documents (relevant to authors and authoring tool implementors).</p>
 
-<p>A <tdef>JSON-LD document</tdef> is a JSON document that expresses <tref>Linked Data</tref> in JSON. A JSON-LD document complies with this specification if it follows the normative statements for documents defined in sections <a href="#referencing-contexts-from-json-documents"></a> and <a href="#json-ld-grammar"></a>. For convenience, normative statements for documents are often phrased as statements on the properties of the document.</p>
+<p>A <tdef>JSON-LD document</tdef> complies with this specification if it follows the normative statements for documents defined in sections <a href="#referencing-contexts-from-json-documents"></a> and <a href="#json-ld-grammar"></a>. For convenience, normative statements for documents are often phrased as statements on the properties of the document.</p>
 
 <p>The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED, NOT RECOMMENDED, MAY, and OPTIONAL in this Recommendation have the meaning defined in [[!RFC2119]].</p>
 


### PR DESCRIPTION
- Conformance section added as proposed in #166.
- Normative statements in Terminology, Basic Concepts and Advanced Concepts sections moved to the grammar (except those in "Referencing an external context from a JSON-LD document") or dropped if they were already there.
- Grammar re-written in a more consistent way. Reader may now follow grammar constructs without being taken back to the terminology section.
- Several typos. 
