### PR TITLE
Moving examples away from grammar

### DIFF
--- a/spec/latest/json-ld-syntax/index.html
+++ b/spec/latest/json-ld-syntax/index.html
@@ -585,13 +585,13 @@ is used as an external JSON-LD context document
 <!--
 [
   {
-    "@context": "http://example.org/contexts/person.jsonld",
+    ****"@context": "http://example.org/contexts/person.jsonld",****
     "name": "Manu Sporny",
     "homepage": "http://manu.sporny.org/",
     "depiction": "http://twitter.com/account/profile_image/manusporny"
   },
   {
-    "@context": "http://example.org/contexts/place.jsonld",
+    ****"@context": "http://example.org/contexts/place.jsonld",****
     "name": "The Empire State Building",
     "description": "The Empire State Building is a 102-story landmark in New York City.",
     "geo": {
@@ -603,9 +603,7 @@ is used as an external JSON-LD context document
 -->
 </pre>
 
-<p>A <tref>node definition</tref> may specify multiple contexts, using an
-  <tref>array</tref>, processed in order.
-  This is useful when an author would like to use an existing context
+<p>This is useful when an author would like to use an existing context
   and add application-specific terms to the existing context. Duplicate context
   <tref title="term">terms</tref> are overridden using a last-defined-overrides
   mechanism.</p>
@@ -642,7 +640,8 @@ is used as an external JSON-LD context document
   the <tref>term</tref> is effectively removed from the list of
   <tref title="term">terms</tref> defined in the <tref>active context</tref>.</p>
 
-<p>The set of contexts defined within a specific <tref>node definition</tref> are
+<p>A <tref>node definition</tref> may specify multiple contexts, using an
+  <tref>array</tref>, processed in order. The set of contexts defined within a specific <tref>node definition</tref> are
   referred to as <tdef title="local context">local contexts</tdef>. Setting the context to <code>null</code>
   effectively resets the <tref>active context</tref> to an empty context. The
   <tdef>active context</tdef> refers to the accumulation of <tref title="local context">local contexts</tref>
@@ -2281,7 +2280,7 @@ are looked up in a <tref>context</tref> using direct string comparison before th
     is not desirable to the application. For example:</p>
 
   <pre class="example" data-transform="updateExample"
-    title="Multiple node definitions with a single context using @graph">
+    title="Using @graph to explicitly express the default graph">
   <!--
   {
     "@context": ...,


### PR DESCRIPTION
A few editorial updates.

As resolved in #114, I removed the examples that were in the Grammar section:
- dropping examples that already appeared elsewhere in the spec
- moving other examples to "Basic Concepts" and "Advanced Concepts" sections, possibly adding with a line of introduction when necessary.

I did not link to examples from the Grammar because:
- it already links back to the relevant sections for "further discussion" and I'm not sure how to introduce links to examples in a reader-friendly way
- ReSpec.js does not create IDs automatically for examples for the time being which makes it a bit of a pain to link to examples anyway

One thing that could be worth noting is that there is no real section that could serve as target for further discussion for the "Node definition" (soon to be renamed "Node object") section.

I also took that opportunity to set a title to examples that didn't have any (#163).
