### PR TITLE
Fixed up incorrect @type for flatten-0043

### DIFF
--- a/test-suite/tests/flatten-manifest.jsonld
+++ b/test-suite/tests/flatten-manifest.jsonld
@@ -260,7 +260,7 @@
       "expect": "flatten-0042-out.jsonld"
     }, {
       "@id": "#t0043",
-      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "@type": ["jld:PositiveEvaluationTest", "jld:FlattenTest"],
       "name": "Sample test manifest extract",
       "input": "flatten-0043-in.jsonld",
       "expect": "flatten-0043-out.jsonld"


### PR DESCRIPTION
The `@type` for the newly added flatten test is wrongly `jld:ExpandTest` (probably due to copy and paste from the previous ones).
