### PR TITLE
David Booth's API edits to avoid implying that JSON-LD is not RDF

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -184,7 +184,7 @@
     <li>Support relative IRIs in <code>@base</code></li>
     <li>Remove default value of <code class="idlMemberName"><a href="#idl-def-JsonLdOptions">JsonLdOption's</a></code>
       <code class="idlMemberName"><a href="#widl-JsonLdOptions-base">base</a></code> member</li>
-    <li>Support lists of lists when serializing from RDF to JSON-LD</li>
+    <li>Support lists of lists when serializing RDF as JSON-LD</li>
     <li>Support for relative URLs in <code>@base</code> and documents that
       do not have a base value</li>
   </ul>
@@ -193,19 +193,19 @@
     <a href="http://www.w3.org/TR/2013/WD-json-ld-api-20130516/">16&nbsp;May&nbsp;2013 Last Call Working Draft</a>:</p>
 
   <ul>
-    <li>Ensure determinism of the Deserialize to RDF Algorithm by specifying the processing order</li>
-    <li>Change the default value of the <em>use native types</em> flag in the Serialize from RDF Algorithm
-      to <code>false</code></li>
+    <li>Ensure determinism of the Deserialize JSON-LD to RDF algorithm by specifying the processing order</li>
+    <li>Change the default value of the <em>use native types</em> flag in the Serialize RDF as JSON-LD
+      algorithm to <code>false</code></li>
     <li>Clarify that the <i>identifier map</i> and the <i>counter</i> used by the
       Generate Blank Node Identifier algorithm are reset before running the Flattening
-      and the Deserialize to RDF algorithms</li>
+      and the Deserialize JSON-LD to RDF algorithms</li>
     <li>Raise an error if a blank node is used as data type</li>
     <li>Clarify that blank node identifier are supported as value of <code>@vocab</code></li>
     <li>When generating RDF, exclude <tref title="rdf triple">triples</tref> containing a
       <tref>blank node</tref> <tref title="rdf predicate">predicate</tref>, unless the
       <i>produce generalized RDF</i> flag is set</li>
     <li>Update reference to DOM Promises (have been called DOM Futures)</li>
-    <li>Fix bug in <a href="#serialize-from-rdf-algorithm">Serialize from RDF algorithm</a> to
+    <li>Fix bug in <a href="#serialize-rdf-as-json-ld-algorithm">Serialize RDF to JSON-LD algorithm</a> to
       handle lists correctly</li>
     <li>Support processing of documents with a <code>+json</code> media type as defined in
       [[RFC6839]]</li>
@@ -572,8 +572,8 @@
     -->
     </pre>
 
-    <p>Using the <a href="#serialize-from-rdf-algorithm">Serialize from RDF algorithm</a> a
-      developer could transform this document into expanded JSON-LD:</p>
+    <p>Using the <a href="#serialize-rdf-as-json-ld-algorithm">Serialize RDF as JSON-LD algorithm</a>
+      a developer could transform this document into expanded JSON-LD:</p>
 
     <pre class="example" data-transform="updateExample"
          title="Sample Turtle document converted to JSON-LD">
@@ -594,7 +594,7 @@
 
     <p>Note that the output above could easily be compacted using the technique outlined
       in the previous section. It is also possible to deserialize the JSON-LD document back
-      to RDF using the <a href="#deserialize-to-rdf-algorithm">Deserialize to RDF algorithm</a>.</p>
+      to RDF using the <a href="#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF algorithm</a>.</p>
   </section> <!-- end of RDF Serialization/Deserialization -->
 </section> <!-- end of Features section -->
 
@@ -613,7 +613,7 @@
   <p>There are three classes of products that can claim conformance to this
     specification: <tref title="JSON-LD Processor">JSON-LD Processors</tref>,
     <tref title="JSON-LD API Implementation">JSON-LD API Implementations</tref>,
-    and <tref title="JSON-LD-RDF Serializer/Deserializer">JSON-LD-RDF Serializers/Deserializers</tref>.</p>
+    and <tref title="RDF Serializer/Deserializer">RDF Serializers/Deserializers</tref>.</p>
 
   <p>A conforming <tdef>JSON-LD Processor</tdef> is a system which can perform the
     <a href="#expansion-algorithm">Expansion</a>, <a href="#compaction-algorithm">Compaction</a>,
@@ -633,9 +633,10 @@
     than conversion between <tref title="relative IRI">relative</tref> and
     <tref title="absolute IRI">absolute IRIs</tref>.</p>
 
-  <p>A conforming <tdef>JSON-LD-RDF Serializer/Deserializer</tdef> is a system that can perform
-    <a href="#deserialize-to-rdf-algorithm">deserialization to RDF</a> and
-    <a href="#serialize-from-rdf-algorithm">serialization from RDF</a>.</p>
+  <p>A conforming <tdef>RDF Serializer/Deserializer</tdef> is a system that can
+    <a href="#deserialize-json-ld-to-rdf-algorithm">deserialize JSON-LD to RDF</a> and
+    <a href="#serialize-rdf-as-json-ld-algorithm">serialize RDF as JSON-LD</a> as
+    defined in this specification.</p>
 
   <p>The algorithms in this specification are generally written with more concern for clarity
     than efficiency. Thus, <tref title="JSON-LD Processor">JSON-LD Processors</tref>
@@ -3106,7 +3107,7 @@
 
 
 <section>
-  <h1>RDF Serialization-Deserialization Algorithms</h1>
+  <h1>RDF Serialization/Deserialization Algorithms</h1>
 
   <p>This section describes algorithms to deserialize a JSON-LD document to an
     <tref>RDF dataset</tref> and vice versa. The algorithms are designed for in-memory
@@ -3138,35 +3139,13 @@
   </table>
 
   <section>
-    <h2>Deserialize to RDF Algorithm</h2>
+    <h2>Deserialize JSON-LD to RDF algorithm</h2>
 
     <p>This algorithm deserializes a JSON-LD document to an <tref>RDF dataset</tref>.
       Please note that RDF does not allow a <tref>blank node</tref> to be used
       as a <tref>property</tref>, while JSON-LD does.  Therefore, by default
       RDF triples that would have contained blank nodes as properties are
-      discarded when interpreting JSON-LD as RDF. For authors and developers
-      working with <tref title="blank node">blank nodes</tref> as
-      <tref title="property">properties</tref> when deserializing to RDF,
-      three potential approaches are suggested (in descending order of preference):</p>
-
-    <ol>
-      <li>If the author is not yet ready to commit to a stable IRI, the
-        property should be mapped to an IRI that is documented as unstable.</li>
-      <li>If the developer wishes to use <tref title="blank node">blank nodes</tref>
-        as <tref title="property">properties</tref> and also wishes to interpret
-        the data as a (non-standard)
-        <tref href="http://www.w3.org/TR/rdf11-concepts/#fn-generalized-rdf-dataset">generalized RDF Dataset</tref>,
-        there is an option, <i>produce generalized RDF</i>, to do so.</li>
-      <li>If the author or developer wishes to use <tref title="blank node">blank nodes</tref>
-        as <tref title="property">properties</tref> and wishes to interpret
-        the data as a standard (non-generalized) RDF Dataset, it is possible
-        to losslessly interpret JSON-LD as RDF by transforming
-        <tref title="blank node">blank nodes</tref> used as
-        <tref title="property">properties</tref> to <tref title="IRI">IRIs</tref>,
-        by minting new "Skolem IRIs" as per
-        <cite><a href="http://www.w3.org/TR/rdf11-concepts/#section-skolemization">Replacing Blank Nodes with IRIs</a></cite>
-        of [[RDF11-CONCEPTS]].</li>
-    </ol>
+      discarded when interpreting JSON-LD as RDF.</p>
 
     <div class="issue atrisk" data-number="3" title="Allow blank nodes to be used as properties">
       <p class="atrisk-head">Note: This feature is
@@ -3281,7 +3260,7 @@
         <li>Return <i>dataset</i>.</li>
       </ol>
     </section>
-  </section> <!-- end of Deserialize to RDF Algorithm -->
+  </section> <!-- end of Deserialize JSON-LD to RDF algorithm -->
 
   <section>
     <h3>Object to RDF Conversion</h3>
@@ -3408,7 +3387,7 @@
   </section> <!-- end of List to RDF -->
 
   <section>
-    <h2>Serialize from RDF Algorithm</h2>
+    <h2>Serialize RDF as JSON-LD Algorithm</h2>
 
     <p>This algorithm serializes an <tref>RDF dataset</tref> consisting of a
       <tref>default graph</tref> and zero or more
@@ -3609,7 +3588,7 @@
         <li>Return <i>result</i>.</li>
       </ol>
     </section>
-  </section> <!-- end of Serialize from RDF algorithm -->
+  </section> <!-- end of Serialize RDF as JSON-LD Algorithm -->
 
   <section>
     <h2>RDF to Object Conversion</h2>
@@ -3704,7 +3683,7 @@
   <section>
     <h2>Data Round Tripping</h2>
 
-    <p>When <a href="#deserialize-to-rdf-algorithm">deserializing JSON-LD to RDF</a>
+    <p>When <a href="#deserialize-json-ld-to-rdf-algorithm">deserializing JSON-LD to RDF</a>
       JSON-native <tref title="number">numbers</tref> are automatically
       type-coerced to <code>xsd:integer</code> or <code>xsd:double</code>
       depending on whether the <tref>number</tref> has a non-zero fractional part
@@ -3765,9 +3744,9 @@
 
     <p>When JSON-native <tref title="number">numbers</tref> are deserialized
       to RDF, lossless data round-tripping cannot be guaranteed, as rounding
-      errors might occur. When serializing
-      <a href="#serialize-from-rdf-algorithm">RDF to JSON-LD</a>, similar
-      rounding errors might occur. Furthermore, the datatype or the lexical
+      errors might occur. When
+      <a href="#serialize-rdf-as-json-ld-algorithm">serializing RDF as JSON-LD</a>,
+      similar rounding errors might occur. Furthermore, the datatype or the lexical
       representation might be lost. An <code>xsd:double</code> with a value
       of <code>2.0</code> will, e.g., result in an <code>xsd:integer</code>
       with a value of <code>2</code> in <tref>canonical lexical form</tref>
@@ -3780,7 +3759,7 @@
       space.</p>
 
     <p>To ensure lossless round-tripping the
-      <a href="#serialize-from-rdf-algorithm">Serializing from RDF algorithm</a>
+      <a href="#serialize-rdf-as-json-ld-algorithm">Serialize RDF as JSON-LD algorithm</a>
       specifies a <i>use native types</i> flag which controls whether
       <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal">RDF literals</tref>
       with a <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-datatype-iri">datatype IRI</tref>
@@ -4159,8 +4138,7 @@
         <dd>The document could not be loaded or parsed as JSON.</dd>
         <dt>list of lists</dt>
         <dd>A list of lists was detected. List of lists are not supported in
-          this version of JSON-LD due to the algorithmic complexity associated
-          with deserialization to RDF.</dd>
+          this version of JSON-LD due to the algorithmic complexity.</dd>
         <dt>invalid @index value</dt>
         <dd>An <code>@index</code> member was encountered whose value was
           not a <tref>string</tref>.</dd>


### PR DESCRIPTION
**_[By David Booth](http://lists.w3.org/Archives/Public/public-linked-json/2013Jul/0130.html) ([actual changes](http://lists.w3.org/Archives/Public/public-linked-json/2013Jul/0131.html)):**_
As promised, attached are suggested edits to the "JSON-LD 1.0 Processing Algorithms and API" document at

  http://json-ld.org/spec/latest/json-ld-api/index.html

The purpose of these edits is to avoid implying that JSON-LD is not RDF.

The main strategy was to change phrases like "transforms JSON-LD to RDF" and "converts RDF to JSON-LD" to phrases like "deserializes JSON-LD to RDF" and "serializes RDF to JSON-LD".

Note that some of the section titles changed as a result, and two HTML anchors were also changed:

```
convert-to-rdf-algorithm --> deserialize-to-rdf-algorithm

convert-from-rdf-algorithm --> serialize-from-rdf-algorithm
```

Therefore other documents that reference this document may need to be updated correspondingly.
