### PR TITLE
Syntax doc edits to avoid implying that JSON-LD is not RDF

### DIFF
--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -3246,10 +3246,12 @@ specified. The full <tref>IRI</tref> for
       property should be mapped to an IRI that is documented as unstable.</li>
     <li>If the developer wishes to use <tref title="blank node">blank nodes</tref>
       as <tref title="property">properties</tref> and also wishes to interpret the
-      data as a (non-standard)
+      data as a
       <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-generalized-rdf-dataset">generalized RDF Dataset</tref>,
       there is an option, <i>produce generalized RDF</i>, in the
-      Deserialize JSON-LD to RDF algorithm [[JSON-LD-API]] to do so.</li>
+      Deserialize JSON-LD to RDF algorithm [[JSON-LD-API]] to do so. Note that a
+      <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-generalized-rdf-dataset">generalized RDF Dataset</tref>
+      is an extension of RDF; it does not conform to the RDF standard.</li>
     <li>If the author or developer wishes to use <tref title="blank node">blank nodes</tref>
       as <tref title="property">properties</tref> and wishes to interpret the data
       as a standard (non-generalized)


### PR DESCRIPTION
**_[By David Booth](http://lists.w3.org/Archives/Public/public-linked-json/2013Jul/0132.html):**_

Attached are the corresponding changes that I see that are needed in the syntax document:
http://json-ld.org/spec/latest/json-ld/

Other editorial issues that I noticed but I did not fix in the attached version:
1. The Abstract begins: "JSON is a useful data serialization and messaging format".  Delete "useful" or perhaps delete the whole sentence.  (Other data serialization and messaging formats are _not_ useful?)
2. The Features at Risk section needs to be updated regarding blank nodes as predicates.
