### PR TITLE
"Rock star" and "ninja" are red flags and/or cliches

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,9 +288,9 @@
       <div id="learn-more-description" class="row">
         <p class="offset2 span8" style="text-align: center;">
         This website contains a number of curated
-        video, presentations, tutorials, and documentation about JSON-LD. The
-        tutorials are designed to train novice web developers that have used JSON
-        and transform them into JSON-LD rockstar ninjas (yes, really).<br><br>
+        video, presentations, tutorials, and documentation about JSON-LD. Assuming you
+        are familiar with JSON, these training materials will help you quickly
+        put the power of JSON-LD into your web development efforts.<br><br>
         <a class="btn" href="./learn.html">Learn more about JSON-LD</a>
         </p>
       </div>


### PR DESCRIPTION
Per http://lwn.net/Articles/552848/, terms like "rock star" and "ninja"
may elicit negative reactions from a more diverse community. In
addition, the terms have been overused (a search for "rock star ninja"
will provide evidence of a fair amount of backlash against said terms).

Thus, a more direct statement that also retains the second-person usage
of "you" elsewhere in the same page.

Signed-off-by: Dan Scott dan@coffeecode.net
