### PR TITLE
Adding fullscreen of editor area in playground

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -112,9 +112,6 @@
         </div>
       
         <div class="pull-right">
-          <button class="btn fullscreen">
-            <i class="icon-fullscreen"></i> Fullscreen
-          </button>
           <button class="btn popover-info">
             <i class="icon-magic"></i> Shortcuts
           </button>
@@ -138,6 +135,9 @@
               </tbody>
             </table>
           </div>
+          <button class="btn fullscreen">
+            <i class="icon-fullscreen"></i> Fullscreen
+          </button>
         </div>
       
         <br/><br/>

--- a/playground/index.html
+++ b/playground/index.html
@@ -100,121 +100,124 @@
         is a work in progress.
       </blockquote>
       <br/>
+      <div id="fullscreen-content">
+        <div class="btn-group" data-toggle="buttons-radio">
+          <button class="btn disabled btn-primary">Examples:</button>
+          <button id="btn-person" class="btn button"><span>Person</span></button>
+          <button id="btn-event" class="btn button"><span>Event</span></button>
+          <button id="btn-place" class="btn button"><span>Place</span></button>
+          <button id="btn-product" class="btn button"><span>Product</span></button>
+          <button id="btn-recipe" class="btn button"><span>Recipe</span></button>
+          <button id="btn-library" class="btn button"><span>Library</span></button>
+        </div>
       
-      <div class="btn-group" data-toggle="buttons-radio">
-        <button class="btn disabled btn-primary">Examples:</button>
-        <button id="btn-person" class="btn button"><span>Person</span></button>
-        <button id="btn-event" class="btn button"><span>Event</span></button>
-        <button id="btn-place" class="btn button"><span>Place</span></button>
-        <button id="btn-product" class="btn button"><span>Product</span></button>
-        <button id="btn-recipe" class="btn button"><span>Recipe</span></button>
-        <button id="btn-library" class="btn button"><span>Library</span></button>
-      </div>
+        <div class="pull-right">
+          <button class="btn fullscreen">
+            <i class="icon-fullscreen"></i> Fullscreen
+          </button>
+          <button class="btn popover-info">
+            <i class="icon-magic"></i> Shortcuts
+          </button>
+          <div class="popover-info-content hide">
+            <table class="table table-striped">
+              <thead>
+                <tr>
+                  <th>Key</th>
+                  <th>Autocomplete</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><label class="label">@</label></td>
+                  <td>all of the <b>@</b> keywords</td>
+                </tr>
+                <tr>
+                  <td><label class="label">Ctrl+Space</label></td>
+                  <td>available keys in <b>@context</b></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
       
-      <div class="pull-right">
-        <button class="btn popover-info">
-          <i class="icon-magic"></i> Shortcuts
-        </button>
-        <div class="popover-info-content hide">
-          <table class="table table-striped">
+        <br/><br/>
+        <div class="container-fluid" id="markup-container">
+          <div class="row-fluid">
+            <div id="markup-div" class="span6">
+              <h3>JSON-LD Input</h3>
+              <textarea id="markup" class="compressed process span6 codemirror-input"
+              placeholder="Enter your JSON-LD markup here..." rows="10"></textarea>
+            </div>
+            <div id="context-div" class="span6">
+              <h3>New JSON-LD Context</h3>
+              <textarea id="context" class="compressed process span6 codemirror-input"
+              placeholder="Enter the new JSON-LD context to compact to here..." rows="10">{}</textarea>
+            </div>
+            <div id="frame-div" class="span6">
+              <h3>JSON-LD Frame</h3>
+              <textarea id="frame" class="compressed process span6 codemirror-input"
+              placeholder="Enter your JSON-LD frame here..." rows="10">{}</textarea>
+            </div>
+          </div>
+        </div>
+        <div id="permalink"></div>
+        <div id="markup-errors" class="text-error"></div>
+        <div id="param-errors" class="text-error"></div>
+        <div id="using-context-map" class="hide alert alert-note">
+          <p>NOTE: Schema.org's remote context was detected in your input but, unfortunately,
+            it doesn't resolve to a proper context document yet. The Schema.org team is
+            already working on this issue and it is expected to be resolved in a couple
+            of weeks.</p>
+          <p>In the meantime, if you wish, you can use an alternative context created by
+            the JSON-LD community to process your document.</p>
+          <label class="checkbox">
+            <input type="checkbox" id="use-context-map" value="1"> Use alternative context
+          </label>
+          <table class="table table-condensed">
             <thead>
               <tr>
-                <th>Key</th>
-                <th>Autocomplete</th>
+                <td>Original</td>
+                <td>Alternative</td>
               </tr>
             </thead>
             <tbody>
-              <tr>
-                <td><label class="label">@</label></td>
-                <td>all of the <b>@</b> keywords</td>
-              </tr>
-              <tr>
-                <td><label class="label">Ctrl+Space</label></td>
-                <td>available keys in <b>@context</b></td>
-              </tr>
+              <!-- dynamic rows -->
             </tbody>
           </table>
         </div>
-      </div>
+        <p id="processing-errors" class="text-error"></p>
       
-      <br/><br/>
-      <div class="container" id="markup-container">
-        <div class="row">
-          <div id="markup-div" class="span6">
-            <h3>JSON-LD Input</h3>
-            <textarea id="markup" class="compressed process span6 codemirror-input"
-            placeholder="Enter your JSON-LD markup here..." rows="10"></textarea>
-          </div>
-          <div id="context-div" class="span6">
-            <h3>New JSON-LD Context</h3>
-            <textarea id="context" class="compressed process span6 codemirror-input"
-            placeholder="Enter the new JSON-LD context to compact to here..." rows="10">{}</textarea>
-          </div>
-          <div id="frame-div" class="span6">
-            <h3>JSON-LD Frame</h3>
-            <textarea id="frame" class="compressed process span6 codemirror-input"
-            placeholder="Enter your JSON-LD frame here..." rows="10">{}</textarea>
-          </div>
+        <div>
+          <ul id="tabs" class="nav nav-tabs">
+            <li class="active"><a id="tab-compacted" href="#pane1" data-toggle="tab"><span>Compacted</span></a></li>
+            <li><a id="tab-expanded" href="#pane2" data-toggle="tab"><span>Expanded</span></a></li>
+            <li><a id="tab-flattened" href="#pane3" data-toggle="tab"><span>Flattened</span></a></li>
+            <li><a id="tab-framed" href="#pane4" data-toggle="tab"><span>Framed</span></a></li>
+            <li><a id="tab-nquads" href="#pane5" data-toggle="tab"><span>N-Quads</span></a></li>
+            <li><a id="tab-normalized" href="#pane6" data-toggle="tab"><span>Normalized</span></a></li>
+          </ul>
+          <div class="tab-content">
+            <div id="pane1" class="tab-pane active">
+              <textarea id="compacted" class="codemirror-output"></textarea>
+            </div>
+            <div id="pane2" class="tab-pane">
+              <textarea id="expanded" class="codemirror-output"></textarea>
+            </div>
+            <div id="pane3" class="tab-pane">
+              <textarea id="flattened" class="codemirror-output"></textarea>
+            </div>
+            <div id="pane4" class="tab-pane">
+              <textarea id="framed" class="codemirror-output"></textarea>
+            </div>
+            <div id="pane5" class="tab-pane">
+              <textarea id="nquads" class="codemirror-output"></textarea>
+            </div>
+            <div id="pane6" class="tab-pane">
+              <textarea id="normalized" class="codemirror-output"></textarea>
+            </div>
+          </div><!-- /.tab-content -->
         </div>
-      </div>
-      <div id="permalink"></div>
-      <div id="markup-errors" class="text-error"></div>
-      <div id="param-errors" class="text-error"></div>
-      <div id="using-context-map" class="hide alert alert-note">
-        <p>NOTE: Schema.org's remote context was detected in your input but, unfortunately,
-          it doesn't resolve to a proper context document yet. The Schema.org team is
-          already working on this issue and it is expected to be resolved in a couple
-          of weeks.</p>
-        <p>In the meantime, if you wish, you can use an alternative context created by
-          the JSON-LD community to process your document.</p>
-        <label class="checkbox">
-          <input type="checkbox" id="use-context-map" value="1"> Use alternative context
-        </label>
-        <table class="table table-condensed">
-          <thead>
-            <tr>
-              <td>Original</td>
-              <td>Alternative</td>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- dynamic rows -->
-          </tbody>
-        </table>
-      </div>
-      <p id="processing-errors" class="text-error"></p>
-      
-      <div>
-        <ul id="tabs" class="nav nav-tabs">
-          <li class="active"><a id="tab-compacted" href="#pane1" data-toggle="tab"><span>Compacted</span></a></li>
-          <li><a id="tab-expanded" href="#pane2" data-toggle="tab"><span>Expanded</span></a></li>
-          <li><a id="tab-flattened" href="#pane3" data-toggle="tab"><span>Flattened</span></a></li>
-          <li><a id="tab-framed" href="#pane4" data-toggle="tab"><span>Framed</span></a></li>
-          <li><a id="tab-nquads" href="#pane5" data-toggle="tab"><span>N-Quads</span></a></li>
-          <li><a id="tab-normalized" href="#pane6" data-toggle="tab"><span>Normalized</span></a></li>
-        </ul>
-        <div class="tab-content">
-          <div id="pane1" class="tab-pane active">
-            <textarea id="compacted" class="codemirror-output"></textarea>
-          </div>
-          <div id="pane2" class="tab-pane">
-            <textarea id="expanded" class="codemirror-output"></textarea>
-          </div>
-          <div id="pane3" class="tab-pane">
-            <textarea id="flattened" class="codemirror-output"></textarea>
-          </div>
-          <div id="pane4" class="tab-pane">
-            <textarea id="framed" class="codemirror-output"></textarea>
-          </div>
-          <div id="pane5" class="tab-pane">
-            <textarea id="nquads" class="codemirror-output"></textarea>
-          </div>
-          <div id="pane6" class="tab-pane">
-            <textarea id="normalized" class="codemirror-output"></textarea>
-          </div>
-        </div><!-- /.tab-content -->
-      </div>
-      
+      </div><!-- /.fullscreen-content -->
       <hr>
       <div id="footer">
         <p id="copyright">

--- a/playground/playground.css
+++ b/playground/playground.css
@@ -1,2 +1,6 @@
 #frame-div{ display: none; }
 #tabs{ margin-bottom: 0; }
+#fullscreen-content{
+  width: 100%;
+  height: 100%;
+}

--- a/playground/playground.css
+++ b/playground/playground.css
@@ -3,4 +3,5 @@
 #fullscreen-content{
   width: 100%;
   height: 100%;
+  background-color: #f7f7f7;
 }

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -173,11 +173,10 @@
     
     // show keybaord shortcuts
     $('.popover-info').popover({
-      placement: "left",
+      placement: "bottom",
       html: true,
       content: $(".popover-info-content").html()
     });
-    
     
     CodeMirror.commands.autocomplete = function(cm) {
       CodeMirror.showHint(cm, CodeMirror.hint.jsonld, {

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -195,6 +195,8 @@
     $(".codemirror-input").each(playground.init.editor);
     $(".codemirror-output").each(playground.init.output);
     
+    $("button.fullscreen").click(playground.fullScreen.toggle);
+    
     if(window.location.search) {
       playground.processQueryParameters();
     }
@@ -287,6 +289,46 @@
 
     // perform processing on the data provided in the input boxes
     playground.process();
+  };
+
+
+  /**
+   * Handler to resize the page to include only the editor
+   * http://davidwalsh.name/fullscreen
+   */
+  playground.fullScreen = {
+    toggle: function(){
+      playground.fullScreen.current() ?
+        playground.fullScreen.exit() :
+        playground.fullScreen.enter($("#fullscreen-content")[0]);
+    },
+    enter: function(element){
+      // Find the right method, call on correct element
+      if(element.requestFullscreen) {
+        return element.requestFullscreen();
+      } else if(element.mozRequestFullScreen) {
+        return element.mozRequestFullScreen();
+      } else if(element.webkitRequestFullscreen) {
+        return element.webkitRequestFullscreen();
+      } else if(element.msRequestFullscreen) {
+        return element.msRequestFullscreen();
+      }
+    },
+    exit: function(){
+      if(document.exitFullscreen) {
+        return document.exitFullscreen();
+      } else if(document.mozCancelFullScreen) {
+        return document.mozCancelFullScreen();
+      } else if(document.webkitExitFullscreen) {
+        return document.webkitExitFullscreen();
+      }
+    },
+    current: function(){
+      return document.fullscreenElement ||
+        document.mozFullScreenElement ||
+        document.webkitFullscreenElement ||
+        document.msFullscreenElement;
+    }
   };
 
   /**


### PR DESCRIPTION
This adds a button to toggle fullscreen mode on the playground without the header and footer and introductory text.

Here is a [demo](http://bollwyvl.github.io/json-ld.org/playground-fullscreen/playground/).

This approach gets around some of the limitations of the outer responsive bootstrap `container` by only fullscreening a second, interior `container-fluid`. This does make the "flash of unstyled textareas" issue more pronounced (expecially on a slow connection), so it could be that needs to be solved first.
