### PR TITLE
Refresh editors after playground tab change

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -293,7 +293,6 @@
   playground.tabSelected = function(evt) {
     
     var id = playground.activeTab = evt.target.id;
-
     
     if(['tab-compacted', 'tab-flattened', 'tab-framed'].indexOf(id) > -1) {
       // these options require more UI inputs, so compress UI space


### PR DESCRIPTION
This one-liner forces a refresh of all of the editors on changing tabs, which is a quick fix for #323 problem.

The correct output area will be refreshed anyway, so it is not necessary to do anything for them.
