### PR TITLE
#330: replacing jquery ui tab init with bootstrap

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -143,8 +143,7 @@
 
     var startTab = getParameterByName('startTab');
     if(startTab) {
-      // strip 'tab-' to get the tab's panel's ID
-      //$('#tabs').tabs('select', '#' + startTab.substr(4));
+      $('#' + startTab.slice(0, -1)).tab('show');
     }
 
     // wait for ajax if needed


### PR DESCRIPTION
One liner fix, just hadn't wired up the bootstrap tab behavior.
