### PR TITLE
Playground debounce

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -285,33 +285,29 @@
    * @return the function, which will only be called every `delay` milliseconds,
    *         which will then, in turn, return a $.Deferred
    */
-  playground.debounce = function(func, wait, immediate){
-    var timeout, args, context, callNow, resolve, reject,
-      promise = new Promise (function(_resolve, _reject) {
+  playground.debounce = function(fn, wait, immediate) {
+    var timer = null;
+    return function() {
+      var context = this;
+      var args = arguments;
+      var resolve;
+      var promise = new Promise(function(_resolve) {
         resolve = _resolve;
-        reject = _reject;
-      }),
-      complete = function(){
-        func.apply(context, args).then(resolve, reject);
-      };
-
-    return function(){
-      args = arguments;
-      context = this;
-
-      callNow = !!immediate && !timeout;
-
-      if(timeout){ clearTimeout(timeout); }
-
-      timeout = setTimeout(function(){
-        timeout = null;
-        if(!immediate){
-          complete();
+      }).then(function() {
+        return fn.apply(context, args);
+      });
+      if(!!immediate && !timer) {
+        resolve();
+      }
+      if(timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(function() {
+        timer = null;
+        if(!immediate) {
+          resolve();
         }
       }, wait);
-
-      if(callNow){ complete(); }
-
       return promise;
     };
   };


### PR DESCRIPTION
Restores the per-keystroke delay, as discussed in #344, but only after a failure, to maintain responsiveness under normal conditions.

Includes the content of [es6-promise-debounce](https://github.com/bollwyvl/es6-promise-debounce), and should eventually use this (or whatever it ends being called) from CDN, pending release.

Thanks to @dlongley.
