### PR TITLE
Fixed duplicate json keys in expand-0004 unit test files.

### DIFF
--- a/test-suite/tests/expand-0004-in.jsonld
+++ b/test-suite/tests/expand-0004-in.jsonld
@@ -13,7 +13,7 @@
   "http://example.org/list1": { "@list": [ null ] },
   "http://example.org/list2": { "@list": [ {"@value": null} ] },
   "http://example.org/set1": { "@set": [ ] },
-  "http://example.org/set1": { "@set": [ null ] },
+  "http://example.org/set2": { "@set": [ null ] },
   "http://example.org/set3": [ ],
   "http://example.org/set4": [ null ],
   "http://example.org/set5": "one item",

--- a/test-suite/tests/expand-0004-out.jsonld
+++ b/test-suite/tests/expand-0004-out.jsonld
@@ -7,7 +7,7 @@
   "http://example.org/list1": [ { "@list": [ ] } ],
   "http://example.org/list2": [ { "@list": [ ] } ],
   "http://example.org/set1": [ ],
-  "http://example.org/set1": [ ],
+  "http://example.org/set2": [ ],
   "http://example.org/set3": [ ],
   "http://example.org/set4": [ ],
   "http://example.org/set5": [ {"@value": "one item"} ],


### PR DESCRIPTION
Most implementations of json parsers seem to use dictionaries (hash tables) as representation of json objects. Because of this, when duplicate json key appears while parsing, the value for the last appearance of the key is used in the output dictionary. I found the error in unit test files while working with a parser implementation that uses lists of pairs to represent json objects.
