### PR TITLE
adding basic gist integration

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -124,6 +124,10 @@
             <i class="icon icon-link"></i>
             <span>Permalink</span>
           </a>
+          <a class="btn" id="gist">
+            <i class="icon icon-github"></i>
+            <span>Gist</span>
+          </a>
           <button class="btn popover-info" title="Keyboard shortcuts">
             <i class="icon icon-keyboard"></i> Shortcuts
           </button>


### PR DESCRIPTION
As per a [recent discussion](https://lists.w3.org/Archives/Public/public-linked-json/2015Jan/0030.html) on the mailing list (cc @msporny), this adds (anonymous) gist (de)serialization to the playground.

Here is an example URL for loading a gist:
http://bollwyvl.github.io/json-ld.org/playground/#/gist/12397f939500d17a1a9f

With the supporting gist:
https://gist.github.com/anonymous/12397f939500d17a1a9f

This is really more of a starting point than anything else.

- There is a bit of a mismatch between what is shown vs what is stored: the name, which is just a good idea for the gist, doesn't have anyplace to live.
- At present, there is no way to create a gist as a particular user, which would be nice... last I checked that required a minimal oauth backend to do properly.
- On the list, mentioned comments, etc. not sure how these would come about