### PR TITLE
Add Initial Activity Streams 2.0 Example

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -117,6 +117,10 @@
             <i class="icon icon-book"></i>
             <span>Library</span>
           </button>
+          <button id="btn-activity" class="btn button">
+            <i class="icon icon-comment"></i>
+            <span>Activity</span>
+          </button>
         </div>
 
         <div class="pull-right">
@@ -217,7 +221,7 @@
         <div id="markup-errors" class="text-error"></div>
         <div id="param-errors" class="text-error"></div>
         <div id="using-context-map" class="hide alert alert-note">
-          <p>NOTE: A remote context that is known to be fully working yet was detected in your input.
+          <p>NOTE: A remote context that is not known to be fully working yet was detected in your input.
             If you wish, you can use an alternative context created by the JSON-LD community to
             process your document nevertheless.</p>
           <label class="checkbox">

--- a/playground/playground-examples.js
+++ b/playground/playground-examples.js
@@ -171,4 +171,20 @@
     }
   };
 
+  // add an Activity Streams 2.0 Example
+  playground.examples["Activity"] = {
+    "@context": "http://www.w3.org/ns/activitystreams#",
+    "@type": "Post",
+    "actor": {
+      "@type": "Person",
+      "@id": "acct:sally@example.org",
+      "displayName": "Sally"
+    },
+    "object": {
+      "@type": "Note",
+      "content": "This is a simple note"
+    },
+    "published": "2015-01-25T12:34:56Z"
+  }
+
 })(jQuery);

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -46,6 +46,7 @@
   playground.contextMap = {
     // be careful when working with redirectors as as Chrome (not firefox)
     // will drop Accept: application/ld+json after redirecting
+    'http://www.w3.org/ns/activitystreams#': 'http://asjsonld.mybluemix.net'
   };
 
   // map of currently active mapped contexts for user feedback use


### PR DESCRIPTION
Adds an initial Activity Streams 2.0 example along with a redirection for the 
development context document.