### PR TITLE
Update example to point to dev context

### DIFF
--- a/playground/playground-examples.js
+++ b/playground/playground-examples.js
@@ -172,8 +172,9 @@
   };
 
   // add an Activity Streams 2.0 Example
+  // currently uses the temporary dev location for the context document.
   playground.examples["Activity"] = {
-    "@context": "http://www.w3.org/ns/activitystreams#",
+    "@context": "http://asjsonld.mybluemix.net",
     "@type": "Post",
     "actor": {
       "@type": "Person",


### PR DESCRIPTION
Update example to point to the dev location for the context to avoid the warning. This ought to be temporary