### PR TITLE
Center align "Playground" section on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,9 +134,9 @@
 
     <div class="hero-unit">
       <h2 style="text-align:center;"><span class="icon-beer icon-large"></span> Playground</h2>
-      <div class="container row">
-        <div class="offset2 span8">
-          <p class="text-justify">
+      <div class="container">
+        <div class="row">
+          <p class="text-justify offset2 span8">
             The <strong>JSON-LD Playground</strong> is a web-based JSON-LD viewer and debugger.
             If you are interested in learning JSON-LD, this tool will be of great help
             to you. Developers may also use the tool to debug, visualize, and share


### PR DESCRIPTION
The markup was using the `container` and `row` class on the same element. This patch moves the `row` class to the child `<div>` and moves the `offset` and `span` classes to the `<p>`.