### PR TITLE
fix some broken links in framing spec

### DIFF
--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -113,7 +113,7 @@ enhances the functionality and interoperability of the Web.
 </p> -->
 </section>
 
-<section>
+<section id='introduction'>
 <h1>Introduction</h1>
 <p>A JSON-LD document is a representation of a directed graph. A single
   directed graph can have many different serializations, each expressing

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -365,7 +365,7 @@ language-native data structures MUST be used where applicable.</p>
     <dt><code>@null</code></dt>
     <dd>Used in <a href="#framing">Framing</a> when a value of <tref>null</tref>
       should be returned, which would otherwise be removed when
-      <a href="../json-ld-api/index.html#compaction">Compacting</a>.</dd>
+      <a href="https://www.w3.org/TR/json-ld-api/#compaction">Compacting</a>.</dd>
   </dl>
 
   <p>All JSON-LD tokens and keywords are case-sensitive.</p>
@@ -451,7 +451,7 @@ language-native data structures MUST be used where applicable.</p>
   graph of information, and applying a specific graph layout
   (called a <tref>Frame</tref>).</p>
 
-<p>Framing makes use of the <a href="../json-ld-api/index.html#node-map-generation">Node Map Generation</a> algorithm
+<p>Framing makes use of the <a href="https://www.w3.org/TR/json-ld-api/#node-map-generation">Node Map Generation</a> algorithm
   to place each object defined in the JSON-LD document into a flat list of objects, allowing
   them to be operated upon by the framing algorithm.</p>
 
@@ -483,7 +483,7 @@ language-native data structures MUST be used where applicable.</p>
     should be omitted from the output.</dd>
   <dt><tdef>map of flattened subjects</tdef></dt>
   <dd>a map of subjects that is the result of the
-    <a href="../json-ld-api/index.html#node-map-generation">Node Map Generation algorithm</a>.</dd>
+    <a href="https://www.w3.org/TR/json-ld-api/#node-map-generation">Node Map Generation algorithm</a>.</dd>
 </dl>
 </section>
 
@@ -501,7 +501,7 @@ language-native data structures MUST be used where applicable.</p>
 
 <p>The framing algorithm takes an <tref>JSON-LD input</tref> (<strong>expanded input</strong>)
   and an <tref>input frame</tref> (<strong>expanded frame</strong>) that have been expanded
-  according to the <a href="../json-ld-api/index.html#expansion-algorithm">Expansion Algorithm</a>,
+  according to the <a href="https://www.w3.org/TR/json-ld-api/#expansion-algorithm">Expansion Algorithm</a>,
   and a number of options and produces <tref>JSON-LD output</tref>.</p>
 
 <p>Create <tref>framing context</tref> using <tref>null</tref> for the <tref>map of embeds</tref>,
@@ -509,7 +509,7 @@ language-native data structures MUST be used where applicable.</p>
     <tref>explicit inclusion flag</tref> set to <tref>false</tref>, and the
     <tref>omit default flag</tref> set to <tref>false</tref> along with <tref>map of flattened subjects</tref>
     set to the <code>@merged</code> property of the result of performing the
-    <a href="../json-ld-api/index.html#node-map-generation">Node Map Generation</a> algorithm on
+    <a href="https://www.w3.org/TR/json-ld-api/#node-map-generation">Node Map Generation</a> algorithm on
     <strong>expanded input</strong>. Also create <em>results</em> as an empty <tref>array</tref>.</p>
 
 <p>Invoke the recursive algorithm using <tref>framing context</tref> (<em>state</em>),
@@ -644,7 +644,7 @@ language-native data structures MUST be used where applicable.</p>
   <tref>node definition</tref>s.</p>
 <p>The final two steps of the framing algorithm require
   <em>results</em> to be compacted according to the
-  <a href="../json-ld-api/index.html#compaction-algorithm">Compaction Algorithm</a> by using the
+  <a href="https://www.w3.org/TR/json-ld-api/#compaction-algorithm">Compaction Algorithm</a> by using the
   context provided in the <tref>input frame</tref>. If the frame has no context, compaction
   is performed with an empty context (not a null context). The compaction result MUST use
   the <code>@graph</code> keyword at the top-level, even if the context is empty or if there


### PR DESCRIPTION
so, a frame is like a template of what you want the final json-ld to look like?  Been banging my head on this spec with no luck.

do you happen to know if https://github.com/digitalbazaar/pyld and https://github.com/digitalbazaar/jsonld.js implement the same version of frames?