### PR TITLE
Fix json-schema validation

### DIFF
--- a/schemas/jsonld-schema.json
+++ b/schemas/jsonld-schema.json
@@ -79,7 +79,7 @@
         }
     },
 
-    "anyOf": [
+    "allOf": [
         { "$ref": "#/definitions/context" },
         { "$ref": "#/definitions/graph" },
         { "$ref": "#/definitions/common" }

--- a/schemas/jsonld-schema.json
+++ b/schemas/jsonld-schema.json
@@ -44,8 +44,7 @@
                 },
                 "@type": {
                     "description": "Used to set the data type of a node or typed value.",
-                    "type": ["string", "null"],
-                    "enum": ["@id"]
+                    "type": ["string", "null"]
                 },
                 "@container": {
                     "description": "Used to set the default container type for a term.",

--- a/schemas/jsonld-schema.json
+++ b/schemas/jsonld-schema.json
@@ -1,7 +1,7 @@
-﻿{
+{
     "title": "Schema for JSON-LD",
     "$schema": "http://json-schema.org/draft-04/schema#",
-    
+
     "definitions":{
         "context": {
             "additionalProperties": true,


### PR DESCRIPTION
Hi, I believe I found two small issues on the jsonld-schema.

###  issue 1

A hidden U+FEFF char on the begining of the file was breaking some parsers, for example in ruby: 

```
content  = File.read('./schemas/jsonld-schema.json')
JSON.parse content  # raise an Error
```

### issue 2

The schema definition seems to have a validation mistake. I.e, almost any invalid json-ld would pass.

This happens because we are using a `anyOf` clause on the definitions, so if we provide an invalid `@context`, the validator will check for the next and one of them almost always pass. This way the json would be invalid only if context, common and graph are invalid at the same time. 

To fix, we just have to change to a `allOf` clause, i.e, each of the defintions must be valid at the same time.

To ilustrate this issue, I'm providing a small test below (it uses the `json-schema` rubygem):

```ruby
require 'json-schema'

puts JSON::Validator.validate('../json-ld.org/schemas/jsonld-schema.json', {}) ? 'ok' : 'NOPE!'
puts !JSON::Validator.validate('../json-ld.org/schemas/jsonld-schema.json', {'@id': true, '@context': 42}) ? 'ok' : 'NOPE!'

```

I hope this can help someone,

tks