### PR TITLE
Issue 118 graph framing

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2923,6 +2923,34 @@
       </ol>
     </section>
   </section> <!-- end of Generate Blank Node Identifier -->
+
+  <section>
+    <h3>Merge Node Maps</h3>
+    <p>This algorithm creates a new map of <a>subjects</a> to <a>nodes</a> using all graphs
+      contained in the <em>graph map</em> created using the <a href="#node-map-generation">Node Map Generation algorithm</a>
+      to create merged <a>node objects</a> containing information defined for a given <a>subject</a>
+      in each graph contained in the <em>node map</em>.</p>
+
+    <ol class="algorithm">
+      <li>Create <em>result</em> as an empty <a>dictionary</a></li>
+      <li>For each <em>graph name</em> and <em>node map</em> in <em>graph map</em>
+        and for each <em>id</em> and <em>node</em> in <em>node map</em>:
+        <ol class="algorithm">
+          <li>Set <em>merged node</em> to the value for <em>id</em> in <em>result</em>, initializing it
+            with a new <a>dictionary</a> consisting of a single member <code>@id</code> whose value is <em>id</em>, if it does not exist.</li>
+          <li>For each <em>property</em> and <em>values</em> in <em>node</em>:
+            <ol class="algorithm">
+              <li>If <em>property</em> is a <a>keyword</a>, add <em>property</em> and values to <em>merged node</em>.</li>
+              <li>Otherwise, merge each element from <em>values</em> into the values for <em>property</em>
+                in <em>merged node</em>, initializing it to an empty <a>array</a> if necessary.</li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+      <li>Return <em>result</em>.</li>
+    </ol>
+  </section> <!-- end of Merge Node Maps-->
+
 </section> <!-- end of Flattening section -->
 
 

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -548,7 +548,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   </section>
 
   <section>
-    <h3>Reverse framing</h3>
+    <h3>Reverse Framing</h3>
     <p>A frame may include @reverse, or a value of a term defined using @reverse
       to invert the relationships in the output object. For example, the
       Library example can be inverted using the following frame:</p>
@@ -558,7 +558,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     <!--
     {
       "@context": {
-        "ex": "http://example.org/",
+        "@vocab": "http://example.org/",
         ****"within": {"@reverse": "contains"}****
       },
       ****"@type": "Chapter",
@@ -603,6 +603,95 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     }
     -->
     </pre>
+  </section>
+
+  <section>
+    <h3>Framing Named Graphs</h3>
+    <p>Frames can include <code>@graph</code>, which allows information from <a>named graphs</a>
+      contained within a <a>JSON-LD document</a> to be exposed within it's proper
+      graph context. By default, framing uses a <em>merged graph</em>, composed of all
+      the <a>node objects</a> across all graphs within the input. By using <code>@graph</code>
+      within a frame, the output document can include information specifically
+      from <a>named graphs</a> contained within the input document.</p>
+
+    <p>The following example uses a variation on our library theme where information
+      is split between the <a>default graph</a>, and a graph named <code>http://example.org/graphs/books</code>:</p>
+
+    <pre class="example" data-transform="updateExample"
+         title="Frame with named graphs">
+    <!--
+    {
+      "@context": {"@vocab": "http://example.org/"},
+      "@type": "Library",
+      "contains": {
+        "@id": "http://example.org/graphs/books",
+        ****"@graph": {
+          "@type": "Book"
+        }****
+      }
+    }
+    -->
+    </pre>
+
+    <pre class="example" data-transform="updateExample"
+         title="Flattened Input with named graphs">
+    <!--
+    [{
+      "@context": {"@vocab": "http://example.org/"},
+      "@id": "http://example.org/graphs/books"
+      "@graph": [{
+        "@id": "http://example.org/library/the-republic",
+        "@type": "http://example.org/Book",
+        "http://example.org/contains": {
+          "@id": "http://example.org/library/the-republic#introduction"
+        },
+        "http://example.org/creator": "Plato",
+        "http://example.org/title": "The Republic"
+      }, {
+        "@id": "http://example.org/library/the-republic#introduction",
+        "@type": "http://example.org/Chapter",
+        "http://example.org/description": "An introductory chapter on The Republic.",
+        "http://example.org/title": "The Introduction"
+      }],
+    }, {
+      "@context": {"@vocab": "http://example.org/"},
+      "@id": "http://example.org/library",
+      "@type": "http://example.org/Library",
+      "http://example.org/contains": {"@id": "http://example.org/graphs/books"},
+      "http://example.org/name": "Library"
+    }]
+    -->
+    </pre>
+
+    <pre class="example" data-transform="updateExample"
+         title="Framed output with named graphs">
+    <!--
+    {
+      "@context": {"@vocab": "http://example.org/"},
+      "@graph": [{
+        "@id": "http://example.org/library",
+        "@type": "Library",
+        "name": "Library",
+        "contains": {
+          ****"@id": "http://example.org/graphs/books",
+          "@graph": [{****
+            "@id": "http://example.org/library/the-republic",
+            "@type": "Book",
+            "creator": "Plato",
+            "title": "The Republic",
+            "contains": {
+              "@id": "http://example.org/library/the-republic#introduction",
+              "@type": "Chapter",
+              "description": "An introductory chapter on The Republic.",
+              "title": "The Introduction"
+            }
+          ****}]****
+        }
+      }]
+    }
+    -->
+    </pre>
+
   </section>
 </section>
 
@@ -733,6 +822,12 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     <li>The values of <code>@id</code> and <code>@type</code> may also be an empty <a>JSON object</a>, or an <a>array</a>
       containing only an empty <a>JSON object</a>.
       <a>Processors</a> MUST preserve this value when expanding.</li>
+    <li>Framing either operates on the merged node definitions contained in
+      the input document, or on the <a>default graph</a> depending on if the
+      input frame contains the <code>@graph</code> key at the top level.
+      Nodes with a <a>subject</a> that is also a <a>named graph</a>, where
+      the <a>frame object</a> contains <code>@graph</code>, extend framing
+      to <a>node objects</a> from the assocated <a>named graph</a>.</li>
   </ul>
 </section>
 
@@ -752,18 +847,29 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   generate a <a>JsonLdFramingError</a> with <a data-link-for="JsonLdFramingError">code</a> set to <a data-link-for="JsonLdFramingErrorCode">invalid frame</a>.
   <span class="ednote">Need more specifics as to what constitutes a valid frame.</span></p>
 
+<p>Set <em>graph map</em> to the result of performing the
+  <a href="../json-ld-api/#node-map-generation">Node Map Generation</a> algorithm on
+  <em>expanded input</em>.</p>
+
+<p>If the <code>frameDefault</code> option
+  is present with the value <code>true</code>, set <em>graph name</em> to <code>@default</code>.
+  Otherwise, create <em>merged node map</em> using the the <a href="../json-ld-api/#merge-node-maps">Merge Node Maps</a> algorithm
+  with <em>graph map</em> and add <em>merged node map</em> as the value of <code>@merged</code>
+  in <em>graph map</em> and set <em>graph name</em> to <code>@merged</code>.</p>
+
 <p>The recursive algorithm operates with a <a>framing state</a> (<em>state</em>),
   created initially using
   the <a>object embed flag</a> set to <code>true</code>,
   the <a>explicit inclusion flag</a> set to <code>false</code>,
   the <a>require all flag</a> set to <code>true</code>,
-  and the <a>omit default flag</a> set to <code>false</code>
+  the <a>omit default flag</a> set to <code>false</code>,
+  <em>graph map</em>, <em>graph name</em>,
   along with <a>map of flattened subjects</a>
-  set to the <code>@merged</code> property of the result of performing the
-  <a href="../json-ld-api/#node-map-generation">Node Map Generation</a> algorithm on
-  <em>expanded input</em>,
-  <em>subjectStack</em> set to an empty <a>array</a>,
-  <em>link</em> set to an empty <a>dictionary</a>.
+  set to the property associated with <em>graph name</em> in <em>graph map</em>,
+  <em>graph stack</em> set to an empty <a>array</a>, and
+  <em>link</em> set to an empty <a>dictionary</a>. The initial values of the
+  <a>object embed flag</a>, <a>require all flag</a>, and <a>omit default flag</a>
+  MUST be overridden by values set in options.
   Also initialize <em>results</em> as an empty <a>array</a>.</p>
 
 <p class="note"><a>Processors</a> MAY use other runtime options to set different <a>framing state</a> defaults
@@ -792,6 +898,8 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   <li>Create a list of matched subjects by filtering <em>subjects</em> against <em>frame</em>
     using the <a href="#frame-matching">Frame Matching algorithm</a>
     with <em>state</em>, <em>subjects</em>, <em>frame</em>, and <em>requireAll</em>.</li>
+  <li>Set <em>link</em> the the value of <em>link</em> in <em>state</em> associated with
+    <em>graph name</em> in <em>state</em>, creating a new empty <a>dictionary</a>, if necessary.</li>
   <li>For each <em>id</em> and associated <a>node object</a> <em>node</em>
     from the set of matched subjects, ordered by <em>id</em>:
     <p class="ednote">Can we remove sorting, or make it subject to a processing
@@ -809,11 +917,36 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         add <em>output</em> to <em>parent</em>
         and do not perform additional processing for this <em>node</em>.</li>
       <li>Otherwise, if <em>embed</em> is <code>@last</code>,
-        remove any existing embedded node from <em>parent</em>.
+        remove any existing embedded node from <em>parent</em> accociate with
+        <em>graph name</em> in <em>state</em>.
         <span class="ednote">Requires sorting of subjects. We could consider <code>@sample</code>, to embed
           just the first matched node. With sorting, we could also consider <code>@first</code>.</span></li>
       <li>If <em>embed</em> is <code>@last</code> or <code>@always</code>
         <ol class="algorithm">
+          <li>If <em>graph map</em> in <em>state</em> has an entry for <em>id</em>:
+            <ol class="algorithm">
+              <li>If <em>frame</em> does not have the key <code>@graph</code>,
+                set <em>recurse</em> to <code>true</code>, unless <em>graph name</em> in <em>state</em> is <code>@merged</code>
+                and set <em>subframe</em> to a new empty <a>dictionary</a>.</li>
+              <li>Otherwise, set <em>subframe</em> to the first entry for <code>@graph</code> in <em>frame</em>,
+                or a new empty <a>dictionary</a>, if it does not exist, and
+                set <em>recurse</em> to <code>true</code>, unless <em>graph name</em>
+                in <em>state</em> is <code>@merged</code> or <code>@default</code>.</li>
+              <li>If <em>recurse</em> is <code>true</code>:
+                <ol class="algorithm">
+                  <li>Push <em>graph name</em> from <em>state</em> onto <em>graph stack</em>
+                  in <em>state</em>.</li>
+                  <li>Set the value of <em>graph name</em> in <em>state</em> to <em>id</em>.</li>
+                  <li>Invoke the recursive algorithm using <em>state</em>,
+                    the keys from the <em>graph map</em> in <em>state</em> associated with id as <em>subjects</em>,
+                    <em>subframe</em> as <em>frame</em>,
+                    <em>output</em> as <em>parent</em>, and <code>@graph</code> as <em>active property</em>.
+                  <li>Pop the value from <em>graph stack</em> in <em>state</em> and set <em>graph name</em> in <em>state</em>
+                    back to that value.</li>
+                </ol>
+              </li>
+            </ol>
+          </li>
           <li>For each <em>property</em> and <em>objects</em> in <em>node</em>, ordered by <em>property</em>:
             <ol class="algorithm">
               <li>If <em>property</em> is a <a>keyword</a>, add <em>property</em> and <em>objects</em>
@@ -1076,6 +1209,10 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
       <li>Set <em>context</em> to the value of <code>@context</code>
         from <a data-lt="JsonLdProcessor-frame-frame">frame</a>, if it exists, or to
         a new empty <a>context</a>, otherwise.</li>
+      <li>If <a data-lt="JsonLdProcessor-frame-frame">frame</a> has a top-level
+        property which expands to <code>@graph</code> add the <code>frameDefault</code>
+        option to <a data-lt="JsonLdProcessor-frame-options">options</a> with the
+        value <code>true</code>.</li>
       <li>Set <em>framed</em> to the result of using the
         <a href="#framing-algorithm">Framing algorithm</a>, passing
         <em>expanded input</em>, <em>expanded frame</em>, <em>context</em>, and <em>options</em>.</li>

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -413,7 +413,10 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
 
       <p>The <a>object embed flag</a> determines if a referenced
         <a>node object</a> is embedded as a property value of a referencing
-        object, or kept as a <a>node reference</a>. Consider the following frame
+        object, or kept as a <a>node reference</a>.
+        The initial value for the <a>object embed flag</a> is set using the
+        <a data-link-for="JsonLdOptions">embed</a> option.
+        Consider the following frame
         based on the default <code>@last</code> value of the <a>object embed flag</a>:</p>
 
       <pre class="example" data-transform="updateExample"
@@ -472,7 +475,10 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         properties which will be included in the output document.
         The default value is <code>false</code>, which means that properties
         present in an input <a>node object</a> that are not in the associated frame will be
-        included in the output object. If <code>true</code>, only properties present in
+        included in the output object.
+        The initial value for the <a>explicit inclusion flag</a> is set using the
+        <a data-link-for="JsonLdOptions">explicit</a> option.
+        If <code>true</code>, only properties present in
         the input frame will be placed into the output.</p>
 
       <p>For example, take an expanded version of the library frame which include
@@ -530,6 +536,8 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
       <h4>Omit default flag</h4>
       <p>The <a>omit default flag</a> changes the way framing generates output when a property
         described in the frame is not present in the input document.
+        The initial value for the <a>omit default flag</a> is set using the
+        <a data-link-for="JsonLdOptions">omitDefault</a> option.
         See <a href="#default-content" class="sectionRef"></a> for a futher discussion.</p>
     </section>
 
@@ -841,7 +849,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   which  MUST be a <a>JSON-LD frame</a> in
     <a href="../json-ld-api/#dfn-expanded-form" class="externalDFN">expanded form</a>,
   a <a>context</a> (<em>context</em>),
-  and a number of options and produces <a>JSON-LD output</a>.</p>
+  and a number of <a data-lt="JsonLdProcessor-frame-options">options</a> and produces <a>JSON-LD output</a>.</p>
 
 <p>If an error is detected in the <em>expanded frame</em>, a processor MUST
   generate a <a>JsonLdFramingError</a> with <a data-link-for="JsonLdFramingError">code</a> set to <a data-link-for="JsonLdFramingErrorCode">invalid frame</a>.
@@ -851,7 +859,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   <a href="../json-ld-api/#node-map-generation">Node Map Generation</a> algorithm on
   <em>expanded input</em>.</p>
 
-<p>If the <code>frameDefault</code> option
+<p>If the <a data-link-for="JsonLdOptions">frameDefault</a> option
   is present with the value <code>true</code>, set <em>graph name</em> to <code>@default</code>.
   Otherwise, create <em>merged node map</em> using the the <a href="../json-ld-api/#merge-node-maps">Merge Node Maps</a> algorithm
   with <em>graph map</em> and add <em>merged node map</em> as the value of <code>@merged</code>
@@ -869,7 +877,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   <em>graph stack</em> set to an empty <a>array</a>, and
   <em>link</em> set to an empty <a>dictionary</a>. The initial values of the
   <a>object embed flag</a>, <a>require all flag</a>, and <a>omit default flag</a>
-  MUST be overridden by values set in options.
+  MUST be overridden by values set in <a data-lt="JsonLdProcessor-frame-options">options</a>.
   Also initialize <em>results</em> as an empty <a>array</a>.</p>
 
 <p class="note"><a>Processors</a> MAY use other runtime options to set different <a>framing state</a> defaults
@@ -1210,7 +1218,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         from <a data-lt="JsonLdProcessor-frame-frame">frame</a>, if it exists, or to
         a new empty <a>context</a>, otherwise.</li>
       <li>If <a data-lt="JsonLdProcessor-frame-frame">frame</a> has a top-level
-        property which expands to <code>@graph</code> add the <code>frameDefault</code>
+        property which expands to <code>@graph</code> set the <a data-link-for="JsonLdOptions">frameDefault</a>
         option to <a data-lt="JsonLdProcessor-frame-options">options</a> with the
         value <code>true</code>.</li>
       <li>Set <em>framed</em> to the result of using the
@@ -1269,7 +1277,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         <a>IRI</a>, or an array of <a>JSON objects</a>
         and <a>strings</a>.</p>
 
-    <p>See <a href="../json-ld-api/#dom-jsonldcontext" class="externalDFN">JsonLdOptions</a> definition in [[!JSON-LD-API]].</p>
+    <p>See <a href="../json-ld-api/#dom-jsonldcontext" class="externalDFN">JsonLdContext</a> definition in [[!JSON-LD-API]].</p>
     </section>
 
     <section>
@@ -1283,6 +1291,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         boolean explicit    = false;
         boolean omitDefault = false;
         boolean requireAll  = false;
+        boolean frameDefault  = false;
       };
 
       enum JsonLdEmbed {
@@ -1314,6 +1323,8 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
       <dt><dfn data-dfn-for="JsonLdOptions">requireAll</dfn></dt>
       <dd>Sets the value <a>require all flag</a> used in the
         <a href="#framing-algorithm">Framing Algorithm</a></dd>
+      <dt><dfn data-dfn-for="JsonLdOptions">frameDefault</dfn></dt>
+      <dd>Instead of framing a <em>merged graph</em>, frame only the <a>default graph</a>.</dd>
     </dl>
 
     <p>See <a href="../json-ld-api/#dom-jsonldoptions" class="externalDFN">JsonLdOptions</a> definition in [[!JSON-LD-API]].</p>

--- a/test-suite/tests/frame-0046-frame.jsonld
+++ b/test-suite/tests/frame-0046-frame.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@type": "Class"
+}

--- a/test-suite/tests/frame-0046-in.jsonld
+++ b/test-suite/tests/frame-0046-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@id": "urn:id-1",
+  "@type": "Class",
+  "preserve": {
+    "@graph": {
+      "@id": "urn:id-2",
+      "term": "data"
+    }
+  }
+}

--- a/test-suite/tests/frame-0046-out.jsonld
+++ b/test-suite/tests/frame-0046-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@graph": [{
+    "@id": "urn:id-1",
+    "@type": "Class",
+    "preserve": {
+      "@id": "_:b0"
+    }
+  }]
+}

--- a/test-suite/tests/frame-0047-frame.jsonld
+++ b/test-suite/tests/frame-0047-frame.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@type": "Class",
+  "@graph": {}
+}

--- a/test-suite/tests/frame-0047-in.jsonld
+++ b/test-suite/tests/frame-0047-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@id": "urn:id-1",
+  "@type": "Class",
+  "preserve": {
+    "@id": "urn:gr-1",
+    "@graph": {
+      "@id": "urn:id-2",
+      "term": "data"
+    }
+  }
+}

--- a/test-suite/tests/frame-0047-out.jsonld
+++ b/test-suite/tests/frame-0047-out.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@graph": [{
+    "@id": "urn:id-1",
+    "@type": "Class",
+    "preserve": {
+      "@id": "urn:gr-1",
+      "@graph": [{
+        "@id": "urn:id-2",
+        "term": "data"
+      }]
+    }
+  }]
+}

--- a/test-suite/tests/frame-0048-frame.jsonld
+++ b/test-suite/tests/frame-0048-frame.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@type": "Class",
+  "preserve": {
+    "@graph": {}
+  }
+}

--- a/test-suite/tests/frame-0048-in.jsonld
+++ b/test-suite/tests/frame-0048-in.jsonld
@@ -1,0 +1,19 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@id": "urn:id-1",
+  "@type": "Class",
+  "merge": {
+    "@id": "urn:id-2",
+    "@graph": {
+      "@id": "urn:id-2",
+      "term": "foo"
+    }
+  },
+  "preserve": {
+    "@id": "urn:graph-1",
+    "@graph": {
+      "@id": "urn:id-3",
+      "term": "bar"
+    }
+  }
+}

--- a/test-suite/tests/frame-0048-out.jsonld
+++ b/test-suite/tests/frame-0048-out.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@graph": [{
+    "@id": "urn:id-1",
+    "@type": "Class",
+    "merge": {
+      "@id": "urn:id-2",
+      "term": "foo"
+    },
+    "preserve": {
+      "@id": "urn:graph-1",
+      "@graph": [{
+        "@id": "urn:id-3",
+        "term": "bar"
+      }]
+    }
+  }]
+}

--- a/test-suite/tests/frame-0049-frame.jsonld
+++ b/test-suite/tests/frame-0049-frame.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@type": "Class",
+  "preserve": {
+    "deep": {
+      "@graph": {}
+    }
+  }
+}

--- a/test-suite/tests/frame-0049-in.jsonld
+++ b/test-suite/tests/frame-0049-in.jsonld
@@ -1,0 +1,20 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@id": "urn:id-1",
+  "@type": "Class",
+  "merge": {
+    "@id": "urn:id-2",
+    "@graph": {
+      "@id": "urn:id-2",
+      "term": "foo"
+    }
+  },
+  "preserve": {
+    "deep": {
+      "@graph": {
+        "@id": "urn:id-3",
+        "term": "bar"
+      }
+    }
+  }
+}

--- a/test-suite/tests/frame-0049-out.jsonld
+++ b/test-suite/tests/frame-0049-out.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {"@vocab": "urn:"},
+  "@graph": [{
+    "@id": "urn:id-1",
+    "@type": "Class",
+    "merge": {
+      "@id": "urn:id-2",
+      "term": "foo"
+    },
+    "preserve": {
+      "@id": "_:b0",
+      "deep": {
+        "@id": "_:b1",
+        "@graph": [{
+          "@id": "urn:id-3",
+          "term": "bar"
+        }]
+      }
+    }
+  }]
+}

--- a/test-suite/tests/frame-0050-frame.jsonld
+++ b/test-suite/tests/frame-0050-frame.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {"@vocab": "http://example.org/"},
+  "@type": "Library",
+  "contains": {
+    "@id": "http://example.org/graphs/books",
+    "@graph": {"@type": "Book"}
+  }
+}

--- a/test-suite/tests/frame-0050-in.jsonld
+++ b/test-suite/tests/frame-0050-in.jsonld
@@ -1,0 +1,21 @@
+{
+  "@context": {"@vocab": "http://example.org/"},
+  "@id": "http://example.org/library",
+  "@type": "Library",
+  "name": "Library",
+  "contains": {
+    "@id": "http://example.org/graphs/books",
+    "@graph": {
+      "@id": "http://example.org/library/the-republic",
+      "@type": "Book",
+      "creator": "Plato",
+      "title": "The Republic",
+      "contains": {
+        "@id": "http://example.org/library/the-republic#introduction",
+        "@type": "Chapter",
+        "description": "An introductory chapter on The Republic.",
+        "title": "The Introduction"
+      }
+    }
+  }
+}

--- a/test-suite/tests/frame-0050-out.jsonld
+++ b/test-suite/tests/frame-0050-out.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {"@vocab": "http://example.org/"},
+  "@graph": [
+    {
+      "@id": "http://example.org/library",
+      "@type": "Library",
+      "name": "Library",
+      "contains": {
+        "@id": "http://example.org/graphs/books",
+        "@graph": [
+          {
+            "@id": "http://example.org/library/the-republic",
+            "@type": "Book",
+            "creator": "Plato",
+            "title": "The Republic",
+            "contains": {
+              "@id": "http://example.org/library/the-republic#introduction",
+              "@type": "Chapter",
+              "description": "An introductory chapter on The Republic.",
+              "title": "The Introduction"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -365,5 +365,44 @@
       "input": "frame-0045-in.jsonld",
       "frame": "frame-0045-frame.jsonld",
       "expect": "frame-0045-out.jsonld"
+    }, {
+      "@id": "#t0046",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Merge graphs if no outer @graph is used",
+      "purpose": "Unless @graph exists at the top level, framing uses merged node objects.",
+      "input": "frame-0046-in.jsonld",
+      "frame": "frame-0046-frame.jsonld",
+      "expect": "frame-0046-out.jsonld"
+    }, {
+      "@id": "#t0047",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Frame default graph if outer @graph is used",
+      "purpose": "If @graph exists at the top level, framing uses the default graph.",
+      "input": "frame-0047-in.jsonld",
+      "frame": "frame-0047-frame.jsonld",
+      "expect": "frame-0047-out.jsonld"
+    }, {
+      "@id": "#t0048",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Merge one graph and preserve another",
+      "purpose": "@graph used within a property value frames embedded values from a named graph.",
+      "input": "frame-0048-in.jsonld",
+      "frame": "frame-0048-frame.jsonld",
+      "expect": "frame-0048-out.jsonld"
+    }, {
+      "@id": "#t0049",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Merge one graph and deep preserve another",
+      "purpose": "@graph used within a property value frames embedded values from a named graph.",
+      "input": "frame-0049-in.jsonld",
+      "frame": "frame-0049-frame.jsonld",
+      "expect": "frame-0049-out.jsonld"
+    }, {
+      "@id": "#t0050",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Library example with named graphs",
+      "input": "frame-0050-in.jsonld",
+      "frame": "frame-0050-frame.jsonld",
+      "expect": "frame-0050-out.jsonld"
     }]
 }


### PR DESCRIPTION
This PR closes #118, adding support for named graphs when framing, and allows framing to use either the merged graph or the default graph. It also adds an algorithm for creating the merged node set.