### PR TITLE
Add JSON-LD verification via BTC public key

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -252,13 +252,13 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
             </div>
 
             <div id="privatekey-koblitz-div" class="span6">
-              <h3>Bitcoin Private Key (ECDSA Koblitz)</h3>
+              <h3>Bitcoin (ECDSA Koblitz) Private Key for Signing</h3>
               <textarea id="privatekey-koblitz" class="compressed process span6 codemirror-input"
-                placeholder="Enter your Bitcoin (koblitz) private key here..." rows="3">L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw</textarea>
+                placeholder="Enter your Bitcoin (Koblitz) private key here..." rows="3">L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw</textarea>
 
-              <h3>Bitcoin Public Key (ECDSA Koblitz)</h3>
+              <h3>Bitcoin (ECDSA Koblitz) Public Key for Verification</h3>
               <textarea id="publickey-koblitz" class="compressed process span6 codemirror-input"
-                placeholder="Enter your Bitcoin (koblitz) public key here..." rows="3">1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER</textarea>
+                placeholder="Enter your Bitcoin (Koblitz) public key here..." rows="3">1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER</textarea>
 
               <div class="koblitz-verification"></div>
             </div>

--- a/playground/index.html
+++ b/playground/index.html
@@ -251,17 +251,26 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
               </textarea>
             </div>
 
-            <div id="privatekey-secp256k1-div" class="span6">
-              <h3>Bitcoin Private Key (secp256k1)</h3>
-              <textarea id="privatekey-secp256k1" class="compressed process span6 codemirror-input"
-                placeholder="Enter your Bitcoin (secp256k1) private key here..." rows="3">L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw</textarea>
+            <div id="privatekey-koblitz-div" class="span6">
+              <h3>Bitcoin Private Key (ECDSA Koblitz)</h3>
+              <textarea id="privatekey-koblitz" class="compressed process span6 codemirror-input"
+                placeholder="Enter your Bitcoin (koblitz) private key here..." rows="3">L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw</textarea>
+
+              <h3>Bitcoin Public Key (ECDSA Koblitz)</h3>
+              <textarea id="publickey-koblitz" class="compressed process span6 codemirror-input"
+                placeholder="Enter your Bitcoin (koblitz) public key here..." rows="3">1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER</textarea>
+
+              <div class="koblitz-verification"></div>
             </div>
+
 
           </div>
         </div>
 
         <div id="markup-errors" class="hide alert alert-error"></div>
         <div id="param-errors" class="hide alert alert-error"></div>
+        <div id="validation-errors" class="hide alert alert-error"></div>
+        <div id="validation-message" class="hide alert alert-success"></div>
         <div id="using-context-map" class="hide alert alert-note">
           <p>NOTE: A remote context that is not known to be fully working yet was detected in your input.
             If you wish, you can use an alternative context created by the JSON-LD community to
@@ -328,7 +337,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
               </a>
             </li>
             <li>
-              <a id="tab-signed-secp256k1" href="#pane-signed-secp256k1" data-toggle="tab" name="tab-signed-secp256k1">
+              <a id="tab-signed-koblitz" href="#pane-signed-koblitz" data-toggle="tab" name="tab-signed-koblitz">
                 <i class="icon-pencil"></i>
                 <span>Signed with Bitcoin</span>
               </a>
@@ -357,8 +366,8 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
             <div id="pane-signed-rsa" class="tab-pane">
               <textarea id="signed-rsa" class="codemirror-output"></textarea>
             </div>
-            <div id="pane-signed-secp256k1" class="tab-pane">
-              <textarea id="signed-secp256k1" class="codemirror-output"></textarea>
+            <div id="pane-signed-koblitz" class="tab-pane">
+              <textarea id="signed-koblitz" class="codemirror-output"></textarea>
             </div>
           </div><!-- /.tab-content -->
         </div>
@@ -406,7 +415,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
       $('#context-div').hide();
       $('#frame-div').hide();
       $('#privatekey-rsa-div').hide();
-      $('#privatekey-secp256k1-div').hide();
+      $('#privatekey-koblitz-div').hide();
       $('#markup,#context,#frame').bind('keyup', function() {
         $('.btn-group > .btn').each(function () {
           $(this).removeClass('active');

--- a/playground/playground.css
+++ b/playground/playground.css
@@ -73,3 +73,7 @@
 #markup-container, #output-container {
   margin-top: 1em;
 }
+
+#privatekey-koblitz-div .CodeMirror {
+  height: 100px;
+}

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -858,7 +858,7 @@
       var signed = null;
       var publicKeyFromPrivateKey;
       try {
-        publicKeyFromPrivateKey = new bitcoreMessage.Bitcore.PrivateKey(privateKey).toPublicKey();
+        publicKeyFromPrivateKey = new bitcoreMessage.Bitcore.PrivateKey(privateKey).toPublicKey().toAddress('livenet');
       } catch (e) {
         promise = Promise.reject(e)
       }


### PR DESCRIPTION
We have signature validation with bitcoin keys [working and live on a demo server](http://thawing-inlet-70039.herokuapp.com/playground/).  

**We should wait for the following to be merged before merging this PR:**

- [x] https://github.com/digitalbazaar/jsonld-signatures/pull/10
- [x] https://github.com/digitalbazaar/jsonld-signatures/pull/16
- [x] https://github.com/digitalbazaar/jsonld-signatures/pull/17

Once https://web-payments.org/contexts/security-v1.jsonld contains EcdsaKoblitzSignature2016 we can: 

- [x] Change https://comakery.github.io/json-ld.org/schemas/security-v1-patch.jsonld to https://w3id.org/security/v1 within this PR

Nice to have but probably not critical:

https://github.com/web-payments/web-payments.org/issues/41

cc @ChristopherA @msporny 