### PR TITLE
Add spec text for scoped contexts

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -877,7 +877,7 @@
         <li>If <em>value</em> contains the key <code>@type</code>:
           <ol class="algorithm">
             <li>Initialize <em>type</em> to the value associated with the
-              <code>@type</code> key, which MUST be a <a>string</a>. Otherwise, an
+              <code>@type</code> key, which must be a <a>string</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Set <em>type</em> to the result of using the
@@ -976,7 +976,7 @@
         <li>If <em>value</em> contains the key <code>@container</code>:
           <ol class="algorithm">
             <li>Initialize <em>container</em> to the value associated with the
-              <code>@container</code> key, which MUST be either
+              <code>@container</code> key, which must be either
               <code>@list</code>, <code>@set</code>, <code>@index</code>,
               or <code>@language</code>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid container mapping</a>
@@ -992,7 +992,7 @@
             <li>Invoke the <a href="#context-processing-algorithm">Context Processing algorithm</a>
               using the <a>active context</a> and <em>context</em> as <a>local context</a>.
               If any error is detected, an
-              <a data-link-for="JsonLdErrorCode">invalid scoped context</a> errors
+              <a data-link-for="JsonLdErrorCode">invalid scoped context</a> error
               has been detected and processing is aborted.</li>
             <li>Set the <a>local context</a> of <em>definition</em> to <em>context</em>.</li>
           </ol>
@@ -1001,7 +1001,7 @@
           does not contain the key <code>@type</code>:
           <ol class="algorithm">
             <li>Initialize <em>language</em> to the value associated with the
-              <code>@language</code> key, which MUST be either <code>null</code>
+              <code>@language</code> key, which must be either <code>null</code>
               or a <a>string</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid language mapping</a>
               error has been detected and processing is aborted.</li>
@@ -1010,6 +1010,11 @@
               of <em>definition</em> to <em>language</em>.</li>
           </ol>
         </li>
+        <li>If the value contains any key other than <code>@id</code>,
+          <code>@reverse</code>, <code>@container</code>,
+          <code>@context</code>, or <code>@type</code>, an
+          <a data-link-for="JsonLdErrorCode">invalid term definition</a> error has
+          been detected and processing is aborted.</li>
         <li>Set the <a>term definition</a> of <em>term</em> in
           <a>active context</a> to <em>definition</em> and set the value
           associated with <em>defined</em>'s key <em>term</em> to

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -620,7 +620,8 @@
       the <a>vocabulary mapping</a> and the <a>default language</a>. Each
       <a>term definition</a> consists of an <dfn data-lt="IRI mappings">IRI mapping</dfn>, a boolean
       flag <dfn data-lt="reverse properties">reverse property</dfn>, an optional <dfn data-lt="type mappings">type mapping</dfn>
-      or <dfn data-lt="language mappings">language mapping</dfn>, and an optional  <dfn data-lt="container mappings">container mapping</dfn>.
+      or <dfn data-lt="language mappings">language mapping</dfn>,
+      an optional context, and an optional <dfn data-lt="container mappings">container mapping</dfn>.
       A <a>term definition</a> can not only be used to map a <a>term</a>
       to an IRI, but also to map a <a>term</a> to a <a>keyword</a>,
       in which case it is referred to as a <dfn data-lt="keyword aliases">keyword alias</dfn>.</p>
@@ -876,7 +877,7 @@
         <li>If <em>value</em> contains the key <code>@type</code>:
           <ol class="algorithm">
             <li>Initialize <em>type</em> to the value associated with the
-              <code>@type</code> key, which must be a <a>string</a>. Otherwise, an
+              <code>@type</code> key, which MUST be a <a>string</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
               error has been detected and processing is aborted.</li>
             <li>Set <em>type</em> to the result of using the
@@ -975,7 +976,7 @@
         <li>If <em>value</em> contains the key <code>@container</code>:
           <ol class="algorithm">
             <li>Initialize <em>container</em> to the value associated with the
-              <code>@container</code> key, which must be either
+              <code>@container</code> key, which MUST be either
               <code>@list</code>, <code>@set</code>, <code>@index</code>,
               or <code>@language</code>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid container mapping</a>
@@ -984,11 +985,23 @@
               <em>container</em>.</li>
           </ol>
         </li>
+        <li>If <em>value</em> contains the key <code>@context</code>:
+          <ol class="algorithm">
+            <li>Initialize <em>context</em> to the value associated with the
+              <code>@context</code> key, which is treated as a <a>local context</a>.</li>
+            <li>Invoke the <a href="#context-processing-algorithm">Context Processing algorithm</a>
+              using the <a>active context</a> and <em>context</em> as <a>local context</a>.
+              If any error is detected, an
+              <a data-link-for="JsonLdErrorCode">invalid scoped context</a> errors
+              has been detected and processing is aborted.</li>
+            <li>Set the <a>local context</a> of <em>definition</em> to <em>context</em>.</li>
+          </ol>
+        </li>
         <li>If <em>value</em> contains the key <code>@language</code> and
           does not contain the key <code>@type</code>:
           <ol class="algorithm">
             <li>Initialize <em>language</em> to the value associated with the
-              <code>@language</code> key, which must be either <code>null</code>
+              <code>@language</code> key, which MUST be either <code>null</code>
               or a <a>string</a>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid language mapping</a>
               error has been detected and processing is aborted.</li>
@@ -1400,8 +1413,14 @@
                 <li>Continue with the next <em>key</em> from <em>element</em>.</li>
               </ol>
             </li>
-            <li>Otherwise, if <em>key</em>'s <a>container mapping</a> in
-              <a>active context</a> is <code>@language</code> and
+            <li>If <em>key</em>'s <a>term definition</a> in <a>active context</a>
+              has a <a>local context</a>, set <em>term context</em> to the result of the
+              <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+              passing <a>active context</a> and the value of the
+              <em>key</em>'s <a>local context</a> as <a>local context</a>. Otherwise,
+              set <em>term context</em> to <a>active context</a>.</li>
+            <li>If <em>key</em>'s <a>container mapping</a> in
+              <em>term context</em> is <code>@language</code> and
               <em>value</em> is a <a>JSON object</a> then <em>value</em>
               is expanded from a <a>language map</a>
               as follows:
@@ -1432,7 +1451,7 @@
               </ol>
             </li>
             <li>Otherwise, if <em>key</em>'s <a>container mapping</a> in
-              <a>active context</a> is <code>@index</code> and
+              <em>term context</em> is <code>@index</code> and
               <em>value</em> is a <a>JSON object</a> then <em>value</em>
               is expanded from an index map as follows:
               <ol class="algorithm">
@@ -1446,7 +1465,7 @@
                       <em>index value</em>.</li>
                     <li>Initialize <em>index value</em> to the result of
                       using this algorithm recursively, passing
-                      <a>active context</a>,
+                      <em>term context</em> as <a>active context</a>,
                       <em>key</em> as <a>active property</a>,
                       and <em>index value</em> as <em>element</em>.</li>
                     <li>For each <em>item</em> in <em>index value</em>:
@@ -1463,13 +1482,13 @@
               </ol>
             </li>
             <li>Otherwise, initialize <em>expanded value</em> to the result of
-              using this algorithm recursively, passing <a>active context</a>,
+              using this algorithm recursively, passing <em>term context</em> as <a>active context</a>,
               <em>key</em> for <a>active property</a>, and <em>value</em>
               for <em>element</em>.</li>
             <li>If <em>expanded value</em> is <code>null</code>, ignore <em>key</em>
               by continuing to the next <em>key</em> from <em>element</em>.</li>
             <li>If the <a>container mapping</a> associated to <em>key</em> in
-              <a>active context</a> is <code>@list</code> and
+              <em>term context</em> is <code>@list</code> and
               <em>expanded value</em> is not already a <a>list object</a>,
               convert <em>expanded value</em> to a <a>list object</a>
               by first setting it to an <a>array</a> containing only
@@ -1726,6 +1745,18 @@
         is set to <code>true</code>.</p>
 
       <ol class="algorithm">
+        <li>If the <a>term definition</a> for <a>active property</a> has a
+          <a>local context</a>:
+          <ol class="algorithm">
+            <li>Set <a>active context</a> to the result of the
+              <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+              passing <a>active context</a> and the value of the
+              <a>active property</a>'s <a>local context</a> as <a>local context</a>.</li>
+            <li>Set <a>inverse context</a> using the
+              <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
+              using <a>active context</a>.</li>
+          </ol>
+        </li>
         <li>If <em>element</em> is a <a>scalar</a>, it is already in its most
           compact form, so simply return <em>element</em>.</li>
         <li>If <em>element</em> is an <a>array</a>:
@@ -3131,7 +3162,7 @@
     <section>
       <h3>Algorithm</h3>
 
-      <p>The algorithm takes as its sole argument <em>item</em> which must be
+      <p>The algorithm takes as its sole argument <em>item</em> which MUST be
         either a <a>value object</a> or <a>node object</a>.</p>
 
       <ol class="algorithm">
@@ -3991,114 +4022,127 @@
 
       <pre class="idl" data-transform="unComment"><!--
         enum JsonLdErrorCode {
-            "loading document failed",
-            "list of lists",
-            "invalid @index value",
-            "conflicting indexes",
-            "invalid @id value",
-            "invalid local context",
-            "multiple context link headers",
-            "loading remote context failed",
-            "invalid remote context",
-            "recursive context inclusion",
-            "invalid base IRI",
-            "invalid vocab mapping",
-            "invalid default language",
-            "keyword redefinition",
-            "invalid term definition",
-            "invalid reverse property",
-            "invalid IRI mapping",
-            "cyclic IRI mapping",
-            "invalid keyword alias",
-            "invalid type mapping",
-            "invalid language mapping",
             "colliding keywords",
+            "compaction to list of lists",
+            "conflicting indexes",
+            "cyclic IRI mapping",
+            "invalid @id value",
+            "invalid @index value",
+            "invalid @reverse value",
+            "invalid base IRI",
             "invalid container mapping",
-            "invalid type value",
-            "invalid value object",
-            "invalid value object value",
+            "invalid default language",
+            "invalid IRI mapping",
+            "invalid keyword alias",
+            "invalid language map value",
+            "invalid language mapping",
             "invalid language-tagged string",
             "invalid language-tagged value",
-            "invalid typed value",
-            "invalid set or list object",
-            "invalid language map value",
-            "compaction to list of lists",
+            "invalid local context",
+            "invalid remote context",
+            "invalid reverse property",
             "invalid reverse property map",
-            "invalid @reverse value",
-            "invalid reverse property value"
+            "invalid reverse property value",
+            "invalid scoped context",
+            "invalid set or list object",
+            "invalid term definition",
+            "invalid type mapping",
+            "invalid type value",
+            "invalid typed value",
+            "invalid value object",
+            "invalid value object value",
+            "invalid vocab mapping",
+            "keyword redefinition",
+            "list of lists",
+            "loading document failed",
+            "loading remote context failed",
+            "multiple context link headers",
+            "recursive context inclusion"
         };
       --></pre>
 
       <dl data-dfn-for="JsonLdErrorCode">
-        <dt><dfn>loading document failed</dfn></dt>
-        <dd>The document could not be loaded or parsed as JSON.</dd>
-        <dt><dfn>list of lists</dfn></dt>
-        <dd>A list of lists was detected. List of lists are not supported in
-          this version of JSON-LD due to the algorithmic complexity.</dd>
-        <dt><dfn>invalid @index value</dfn></dt>
-        <dd>An <code>@index</code> member was encountered whose value was
-          not a <a>string</a>.</dd>
-        <dt><dfn>conflicting indexes</dfn></dt>
-        <dd>Multiple conflicting indexes have been found for the same node.</dd>
-        <dt><dfn>invalid @id value</dfn></dt>
-        <dd>An <code>@id</code> member was encountered whose value was not a
-          <a>string</a>.</dd>
-        <dt><dfn>invalid local context</dfn></dt>
-        <dd>In invalid <a>local context</a> was detected.</dd>
-        <dt><dfn>multiple context link headers</dfn></dt>
-        <dd>Multiple HTTP Link Headers [[!RFC5988]] using the
-          <code>http://www.w3.org/ns/json-ld#context</code> link relation
-          have been detected.</dd>
-        <dt><dfn>loading remote context failed</dfn></dt>
-        <dd>There was a problem encountered loading a remote context.</dd>
-        <dt><dfn>invalid remote context</dfn></dt>
-        <dd>No valid context document has been found for a referenced,
-         remote context.</dd>
-        <dt><dfn>recursive context inclusion</dfn></dt>
-        <dd>A cycle in remote context inclusions has been detected.</dd>
-        <dt><dfn>invalid base IRI</dfn></dt>
-        <dd>An invalid <a>base IRI</a> has been detected, i.e., it is
-          neither an <a>absolute IRI</a> nor <code>null</code>.</dd>
-        <dt><dfn>invalid vocab mapping</dfn></dt>
-        <dd>An invalid <a>vocabulary mapping</a> has been detected, i.e.,
-          it is neither an <a>absolute IRI</a> nor <code>null</code>.</dd>
-        <dt><dfn>invalid default language</dfn></dt>
-        <dd>The value of the <a>default language</a> is not a <a>string</a>
-          or <code>null</code> and thus invalid.</dd>
-        <dt><dfn>keyword redefinition</dfn></dt>
-        <dd>A <a>keyword</a> redefinition has been detected.</dd>
-        <dt><dfn>invalid term definition</dfn></dt>
-        <dd>An invalid <a>term definition</a> has been detected.</dd>
-        <dt><dfn>invalid reverse property</dfn></dt>
-        <dd>An invalid reverse property definition has been detected.</dd>
-        <dt><dfn>invalid IRI mapping</dfn></dt>
-        <dd>A <a>local context</a> contains a <a>term</a> that has
-          an invalid or missing <a>IRI mapping</a>.</dd>
-        <dt><dfn>cyclic IRI mapping</dfn></dt>
-        <dd>A cycle in <a>IRI mappings</a> has been detected.</dd>
-        <dt><dfn>invalid keyword alias</dfn></dt>
-        <dd>An invalid <a>keyword</a> alias definition has been
-          encountered.</dd>
-        <dt><dfn>invalid type mapping</dfn></dt>
-        <dd>An <code>@type</code> member in a <a>term definition</a>
-          was encountered whose value could not be expanded to an
-          <a>absolute IRI</a>.</dd>
-        <dt><dfn>invalid language mapping</dfn></dt>
-        <dd>An <code>@language</code> member in a <a>term definition</a>
-          was encountered whose value was neither a <a>string</a> nor
-          <code>null</code> and thus invalid.</dd>
         <dt><dfn>colliding keywords</dfn></dt>
         <dd>Two properties which expand to the same keyword have been detected.
           This might occur if a <a>keyword</a> and an alias thereof
           are used at the same time.</dd>
+        <dt><dfn>compaction to list of lists</dfn></dt>
+        <dd>The compacted document contains a list of lists as multiple
+          lists have been compacted to the same term.</dd>
+        <dt><dfn>conflicting indexes</dfn></dt>
+        <dd>Multiple conflicting indexes have been found for the same node.</dd>
+        <dt><dfn>cyclic IRI mapping</dfn></dt>
+        <dd>A cycle in <a>IRI mappings</a> has been detected.</dd>
+        <dt><dfn>invalid @id value</dfn></dt>
+        <dd>An <code>@id</code> member was encountered whose value was not a
+          <a>string</a>.</dd>
+        <dt><dfn>invalid @index value</dfn></dt>
+        <dd>An <code>@index</code> member was encountered whose value was
+          not a <a>string</a>.</dd>
+        <dt><dfn>invalid @reverse value</dfn></dt>
+        <dd>An invalid value for an <code>@reverse</code> member has been detected,
+          i.e., the value was not a <a>JSON object</a>.</dd>
+        <dt><dfn>invalid base IRI</dfn></dt>
+        <dd>An invalid <a>base IRI</a> has been detected, i.e., it is
+          neither an <a>absolute IRI</a> nor <code>null</code>.</dd>
         <dt><dfn>invalid container mapping</dfn></dt>
         <dd>An <code>@container</code> member was encountered whose value was
           not one of the following <a>strings</a>:
           <code>@list</code>, <code>@set</code>, or <code>@index</code>.</dd>
+        <dt><dfn>invalid default language</dfn></dt>
+        <dd>The value of the <a>default language</a> is not a <a>string</a>
+          or <code>null</code> and thus invalid.</dd>
+        <dt><dfn>invalid IRI mapping</dfn></dt>
+        <dd>A <a>local context</a> contains a <a>term</a> that has
+          an invalid or missing <a>IRI mapping</a>.</dd>
+        <dt><dfn>invalid keyword alias</dfn></dt>
+        <dd>An invalid <a>keyword</a> alias definition has been
+          encountered.</dd>
+        <dt><dfn>invalid language map value</dfn></dt>
+        <dd>An invalid value in a <a>language map</a>
+          has been detected. It has to be a <a>string</a> or an <a>array</a> of
+          <a>strings</a>.</dd>
+        <dt><dfn>invalid language mapping</dfn></dt>
+        <dd>An <code>@language</code> member in a <a>term definition</a>
+          was encountered whose value was neither a <a>string</a> nor
+          <code>null</code> and thus invalid.</dd>
+        <dt><dfn>invalid language-tagged string</dfn></dt>
+        <dd>A <a>language-tagged string</a> with an invalid language
+          value was detected.</dd>
+        <dt><dfn>invalid language-tagged value</dfn></dt>
+        <dd>A <a>number</a>, <code>true</code>, or <code>false</code> with an
+          associated language tag was detected.</dd>
+        <dt><dfn>invalid local context</dfn></dt>
+        <dd>In invalid <a>local context</a> was detected.</dd>
+        <dt><dfn>invalid remote context</dfn></dt>
+        <dd>No valid context document has been found for a referenced,
+         remote context.</dd>
+        <dt><dfn>invalid reverse property</dfn></dt>
+        <dd>An invalid reverse property definition has been detected.</dd>
+        <dt><dfn>invalid reverse property map</dfn></dt>
+        <dd>An invalid reverse property map has been detected. No
+          <a>keywords</a> apart from <code>@context</code>
+          are allowed in reverse property maps.</dd>
+        <dt><dfn>invalid reverse property value</dfn></dt>
+        <dd>An invalid value for a reverse property has been detected. The value of an inverse
+          property must be a <a>node object</a>.</dd>
+        <dt><dfn>invalid scoped context</dfn></dt>
+        <dd>The <a>local context</a> defined within a <a>term definition</a> is invalid.</dd>
+        <dt><dfn>invalid set or list object</dfn></dt>
+        <dd>A <a>set object</a> or <a>list object</a> with
+          disallowed members has been detected.</dd>
+        <dt><dfn>invalid term definition</dfn></dt>
+        <dd>An invalid <a>term definition</a> has been detected.</dd>
+        <dt><dfn>invalid type mapping</dfn></dt>
+        <dd>An <code>@type</code> member in a <a>term definition</a>
+          was encountered whose value could not be expanded to an
+          <a>absolute IRI</a>.</dd>
         <dt><dfn>invalid type value</dfn></dt>
         <dd>An invalid value for an <code>@type</code> member has been detected,
           i.e., the value was neither a <a>string</a> nor an <a>array</a>
           of <a>strings</a>.</dd>
+        <dt><dfn>invalid typed value</dfn></dt>
+        <dd>A <a>typed value</a> with an invalid type was detected.</dd>
         <dt><dfn>invalid value object</dfn></dt>
         <dd>A <a>value object</a> with disallowed members has been
           detected.</dd>
@@ -4106,41 +4150,42 @@
         <dd>An invalid value for the <code>@value</code> member of a
           <a>value object</a> has been detected, i.e., it is neither
           a <a>scalar</a> nor <code>null</code>.</dd>
-        <dt><dfn>invalid language-tagged string</dfn></dt>
-        <dd>A <a>language-tagged string</a> with an invalid language
-          value was detected.</dd>
-        <dt><dfn>invalid language-tagged value</dfn></dt>
-        <dd>A <a>number</a>, <code>true</code>, or <code>false</code> with an
-          associated language tag was detected.</dd>
-        <dt><dfn>invalid typed value</dfn></dt>
-        <dd>A <a>typed value</a> with an invalid type was detected.</dd>
-        <dt><dfn>invalid set or list object</dfn></dt>
-        <dd>A <a>set object</a> or <a>list object</a> with
-          disallowed members has been detected.</dd>
-        <dt><dfn>invalid language map value</dfn></dt>
-        <dd>An invalid value in a <a>language map</a>
-          has been detected. It has to be a <a>string</a> or an <a>array</a> of
-          <a>strings</a>.</dd>
-        <dt><dfn>compaction to list of lists</dfn></dt>
-        <dd>The compacted document contains a list of lists as multiple
-          lists have been compacted to the same term.</dd>
-        <dt><dfn>invalid reverse property map</dfn></dt>
-        <dd>An invalid reverse property map has been detected. No
-          <a>keywords</a> apart from <code>@context</code>
-          are allowed in reverse property maps.</dd>
-        <dt><dfn>invalid @reverse value</dfn></dt>
-        <dd>An invalid value for an <code>@reverse</code> member has been detected,
-          i.e., the value was not a <a>JSON object</a>.</dd>
-        <dt><dfn>invalid reverse property value</dfn></dt>
-        <dd>An invalid value for a reverse property has been detected. The value of an inverse
-          property must be a <a>node object</a>.</dd>
+        <dt><dfn>invalid vocab mapping</dfn></dt>
+        <dd>An invalid <a>vocabulary mapping</a> has been detected, i.e.,
+          it is neither an <a>absolute IRI</a> nor <code>null</code>.</dd>
+        <dt><dfn>keyword redefinition</dfn></dt>
+        <dd>A <a>keyword</a> redefinition has been detected.</dd>
+        <dt><dfn>list of lists</dfn></dt>
+        <dd>A list of lists was detected. List of lists are not supported in
+          this version of JSON-LD due to the algorithmic complexity.</dd>
+        <dt><dfn>loading document failed</dfn></dt>
+        <dd>The document could not be loaded or parsed as JSON.</dd>
+        <dt><dfn>loading remote context failed</dfn></dt>
+        <dd>There was a problem encountered loading a remote context.</dd>
+        <dt><dfn>multiple context link headers</dfn></dt>
+        <dd>Multiple HTTP Link Headers [[!RFC5988]] using the
+          <code>http://www.w3.org/ns/json-ld#context</code> link relation
+          have been detected.</dd>
+        <dt><dfn>recursive context inclusion</dfn></dt>
+        <dd>A cycle in remote context inclusions has been detected.</dd>
       </dl>
     </section>
   </section> <!-- end of Error Handling -->
 </section> <!-- end of The Application Programming Interfaces -->
 
 <section class="appendix informative">
-  <h4>Open Issues</h4>
+  <h2>Changes since 1.0 Recommendation of 16 January 2014</h2>
+  <ul>
+    <li>An <a>expanded term definition</a> can now have an
+      <code>@context</code> property, which defines a context used for values of
+      a <a>property</a> identified with such a <a>term</a>. This context is used
+      in both the <a href="#expansion-algorithm">Expansion Algorithm</a> and
+      <a href="#compaction-algorithm">Compaction Algorithm</a>.</li>
+  </ul>
+</section>
+
+<section class="appendix informative">
+  <h2>Open Issues</h2>
   <p>The following is a list of open issues being worked on for the next release.</p>
   <p class="issue" data-number="110"></p>
   <p class="issue" data-number="140"></p>

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -2115,6 +2115,87 @@ specified. The full <a>IRI</a> for
   </pre>
 </section>
 
+<section class="informative">
+  <h2>Scoped Contexts</h2>
+
+  <p>An <a>expanded term definition</a> can include a <code>@context</code>
+    property, which defines a <a>context</a> for <a data-lt="JSON-LD
+    value">values</a> of properties defined using that <a>term</a>. This allows
+    values to use <a>term definitions</a>, <a>base IRI</a>,
+    <a>vocabulary mapping</a> or <a>default language</a> which is different from the
+    <a>node object</a> they are contained in, in exactly the same was as if the
+    <a>context</a> were specified within the value itself.</p>
+  
+  <pre class="example" data-transform="updateExample"
+       title="Defining an @context within a term definition">
+  <!--
+  {
+    "@context":
+    {
+      "name": "http://schema.org/name",
+      "interest": {
+        "@id":"http://xmlns.com/foaf/0.1/interest",
+        ****"@context": {"@vocab": "http://xmlns.com/foaf/0.1/"}****
+      }
+    },
+    "name": "Manu Sporny",
+    "interest": ****{
+      "@id": "https://www.w3.org/TR/json-ld/",
+      "name": "JSON-LD",
+      "topic": "Linking Data"
+    }****
+  }
+  -->
+  </pre>
+
+  <p>In this case, the social profile is defined using the schema.org vocabulary, but interest is imported from FOAF, and is used to define a node describing one of Manu's interests where those properties now come from the FOAF vocabulary.</p>
+
+  <p>Expanding this document, uses a combination of terms defined in the outer context, and those defined specifically for that term.</p>
+
+  <pre class="example" data-transform="updateExample"
+       title="Expanded document using a scoped context">
+  <!--
+  [{
+    "http://schema.org/name": [{"@value": "Manu Sporny"}],
+    "http://xmlns.com/foaf/0.1/interest": [{
+      "@id": "https://www.w3.org/TR/json-ld/",
+      "http://schema.org/name": [{"@value": "JSON-LD"}],
+      ****"http://xmlns.com/foaf/0.1/topic": [{"@value": "Linking Data"}]****
+    }]
+  }]
+  -->
+  </pre>
+
+  <p>The <code>@reverse</code> <a>keyword</a> can also be used in
+    <a>expanded term definitions</a>
+    to create reverse properties as shown in the following example:</p>
+
+
+  <pre class="example" data-transform="updateExample"
+       title="Using @reverse to define reverse properties">
+  <!--
+  {
+    "@context": {
+      "name": "http://example.com/vocab#name",
+      ****"children": { "@reverse": "http://example.com/vocab#parent" }****
+    },
+    "@id": "#homer",
+    "name": "Homer",
+    ****"children"****: [
+      {
+        "@id": "#bart",
+        "name": "Bart"
+      },
+      {
+        "@id": "#lisa",
+        "name": "Lisa"
+      }
+    ]
+  }
+  -->
+  </pre>
+</section>
+
 
 <section class="informative">
   <h2>Named Graphs</h2>
@@ -3126,7 +3207,7 @@ specified. The full <a>IRI</a> for
 
   <p>An <a>expanded term definition</a> MUST be a <a>JSON object</a>
     composed of zero or more keys from <code>@id</code>, <code>@reverse</code>,
-    <code>@type</code>, <code>@language</code> or <code>@container</code>. An
+    <code>@type</code>, <code>@language</code>, <code>@context</code> or <code>@container</code>. An
     <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
 
   <p>If an <a>expanded term definition</a> has an <code>@reverse</code> member,
@@ -3160,6 +3241,9 @@ specified. The full <a>IRI</a> for
     If the value is <code>@index</code>, when the <a>term</a> is used outside of
     the <code>@context</code>, the associated value MUST be an
     <a>index map</a>.</p>
+
+  <p>If an <a>expanded term definition</a> has an <code>@context</code> member,
+    it MUST be a valid <code>context definition</code>.</p>
 
   <p><a>Terms</a> MUST NOT be used in a circular manner. That is,
     the definition of a term cannot depend on the definition of another term if that other
@@ -3345,6 +3429,15 @@ specified. The full <a>IRI</a> for
       for all triples having a common subject, and a single <a>property</a>
       for those triples also having a common predicate.</p>
   </section>
+</section>
+
+<section class="appendix informative">
+  <h2>Changes since 1.0 Recommendation of 16 January 2014</h2>
+  <ul>
+    <li>An <a>expanded term definition</a> can now have an
+      <code>@context</code> property, which defines a <a>context</a> used for values of
+      a <a>property</a> identified with such a <a>term</a>.</li>
+  </ul>
 </section>
 
 <section class="appendix informative">

--- a/test-suite/tests/compact-c001-context.jsonld
+++ b/test-suite/tests/compact-c001-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"bar": "http://example.org/bar"}}
+  }
+}

--- a/test-suite/tests/compact-c001-in.jsonld
+++ b/test-suite/tests/compact-c001-in.jsonld
@@ -1,0 +1,3 @@
+[{
+  "http://example/foo": [{"http://example.org/bar": [{"@value": "baz"}]}]
+}]

--- a/test-suite/tests/compact-c001-out.jsonld
+++ b/test-suite/tests/compact-c001-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"bar": "http://example.org/bar"}}
+  },
+  "foo": {
+    "bar": "baz"
+  }
+}

--- a/test-suite/tests/compact-c002-context.jsonld
+++ b/test-suite/tests/compact-c002-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"bar": {"@type": "@id"}}},
+    "bar": {"@type": "http://www.w3.org/2001/XMLSchema#string"}
+  }
+}

--- a/test-suite/tests/compact-c002-in.jsonld
+++ b/test-suite/tests/compact-c002-in.jsonld
@@ -1,0 +1,5 @@
+[
+  {
+    "http://example/foo": [{"http://example/bar": [{"@id": "http://example/baz"}]}]
+  }
+]

--- a/test-suite/tests/compact-c002-out.jsonld
+++ b/test-suite/tests/compact-c002-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"bar": {"@type": "@id"}}},
+    "bar": {"@type": "http://www.w3.org/2001/XMLSchema#string"}
+  },
+  "foo": {
+    "bar": "http://example/baz"
+  }
+}

--- a/test-suite/tests/compact-c003-context.jsonld
+++ b/test-suite/tests/compact-c003-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"Bar": {"@id": "bar"}}}
+  }
+}

--- a/test-suite/tests/compact-c003-in.jsonld
+++ b/test-suite/tests/compact-c003-in.jsonld
@@ -1,0 +1,9 @@
+[
+  {
+    "http://example/foo": [{
+      "http://example/bar": [
+        {"@value": "baz"}
+      ]}
+    ]
+  }
+]

--- a/test-suite/tests/compact-c003-out.jsonld
+++ b/test-suite/tests/compact-c003-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"Bar": {"@id": "bar"}}}
+  },
+  "foo": {
+    "Bar": "baz"
+  }
+}

--- a/test-suite/tests/compact-c004-context.jsonld
+++ b/test-suite/tests/compact-c004-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"baz": {"@type": "@id"}}}
+  }
+}

--- a/test-suite/tests/compact-c004-in.jsonld
+++ b/test-suite/tests/compact-c004-in.jsonld
@@ -1,0 +1,9 @@
+[
+  {
+    "http://example/foo": [{
+      "http://example/bar": [{
+        "http://example/baz": [{"@id": "buzz"}]
+      }]
+    }]
+  }
+]

--- a/test-suite/tests/compact-c004-out.jsonld
+++ b/test-suite/tests/compact-c004-out.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"baz": {"@type": "@id"}}}
+  },
+  "foo": {
+    "bar": {
+      "baz": "buzz"
+    }
+  }
+}

--- a/test-suite/tests/compact-c005-context.jsonld
+++ b/test-suite/tests/compact-c005-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "b": {"@context": {"c": "http://example.org/c"}}
+  }
+}

--- a/test-suite/tests/compact-c005-in.jsonld
+++ b/test-suite/tests/compact-c005-in.jsonld
@@ -1,0 +1,10 @@
+[{
+  "http://example/a": [{
+    "http://example.com/c": [{"@value": "C in example.com"}],
+    "http://example/b": [{
+      "http://example.com/a": [{"@value": "A in example.com"}],
+      "http://example.org/c": [{"@value": "C in example.org"}]
+    }]
+  }],
+  "http://example/c": [{"@value": "C in example"}]
+}]

--- a/test-suite/tests/compact-c005-out.jsonld
+++ b/test-suite/tests/compact-c005-out.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "b": {"@context": {"c": "http://example.org/c"}}
+  },
+  "a": {
+    "b": {
+      "c": "C in example.org",
+      "http://example.com/a": "A in example.com"
+    },
+    "http://example.com/c": "C in example.com"
+  },
+  "c": "C in example"
+}

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -585,6 +585,46 @@
       "input": "compact-0072-in.jsonld",
       "context": "compact-0072-context.jsonld",
       "expect": "compact-0072-out.jsonld"
+    }, {
+      "@id": "#tc001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "adding new term",
+      "purpose": "Compaction using a scoped context uses term scope for selecting proper term",
+      "input": "compact-c001-in.jsonld",
+      "context": "compact-c001-context.jsonld",
+      "expect": "compact-c001-out.jsonld"
+    }, {
+      "@id": "#tc002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "overriding a term",
+      "purpose": "Compaction using a scoped context uses term scope for selecting proper term",
+      "input": "compact-c002-in.jsonld",
+      "context": "compact-c002-context.jsonld",
+      "expect": "compact-c002-out.jsonld"
+    }, {
+      "@id": "#tc003",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "property and value with different terms mapping to the same expanded property",
+      "purpose": "Compaction using a scoped context uses term scope for selecting proper term",
+      "input": "compact-c003-in.jsonld",
+      "context": "compact-c003-context.jsonld",
+      "expect": "compact-c003-out.jsonld"
+    }, {
+      "@id": "#tc004",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "deep @context affects nested nodes",
+      "purpose": "Compaction using a scoped context uses term scope for selecting proper term",
+      "input": "compact-c004-in.jsonld",
+      "context": "compact-c004-context.jsonld",
+      "expect": "compact-c004-out.jsonld"
+    }, {
+      "@id": "#tc005",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "scoped context layers on intemediate contexts",
+      "purpose": "Compaction using a scoped context uses term scope for selecting proper term",
+      "input": "compact-c005-in.jsonld",
+      "context": "compact-c005-context.jsonld",
+      "expect": "compact-c005-out.jsonld"
     }
   ]
 }

--- a/test-suite/tests/error-c001-in.jsonld
+++ b/test-suite/tests/error-c001-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "term": {"@id": "http://example/", "@index": true}
+  },
+  "@id": "http://example/test#example"
+}

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -308,6 +308,13 @@
       "purpose": "Verifies that an exception is raised in Flattening when conflicting indexes are found",
       "input": "error-0043-in.jsonld",
       "expect": "conflicting indexes"
+    }, {
+      "@id": "#t1001",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
+      "name": "Invalid keyword in term definition",
+      "purpose": "Verifies that an exception is raised on expansion when a invalid term definition is found",
+      "input": "error-c001-in.jsonld",
+      "expect": "invalid term definition"
     }
   ]
 }

--- a/test-suite/tests/expand-c001-in.jsonld
+++ b/test-suite/tests/expand-c001-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"bar": "http://example.org/bar"}}
+  },
+  "foo": {
+    "bar": "baz"
+  }
+}

--- a/test-suite/tests/expand-c001-out.jsonld
+++ b/test-suite/tests/expand-c001-out.jsonld
@@ -1,0 +1,5 @@
+[
+  {
+    "http://example/foo": [{"http://example.org/bar": [{"@value": "baz"}]}]
+  }
+]

--- a/test-suite/tests/expand-c002-in.jsonld
+++ b/test-suite/tests/expand-c002-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"bar": {"@type": "@id"}}},
+    "bar": {"@type": "http://www.w3.org/2001/XMLSchema#string"}
+  },
+  "foo": {
+    "bar": "http://example/baz"
+  }
+}

--- a/test-suite/tests/expand-c002-out.jsonld
+++ b/test-suite/tests/expand-c002-out.jsonld
@@ -1,0 +1,5 @@
+[
+  {
+    "http://example/foo": [{"http://example/bar": [{"@id": "http://example/baz"}]}]
+  }
+]

--- a/test-suite/tests/expand-c003-in.jsonld
+++ b/test-suite/tests/expand-c003-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"Bar": {"@id": "bar"}}}
+  },
+  "foo": {
+    "Bar": "baz"
+  }
+}

--- a/test-suite/tests/expand-c003-out.jsonld
+++ b/test-suite/tests/expand-c003-out.jsonld
@@ -1,0 +1,9 @@
+[
+  {
+    "http://example/foo": [{
+      "http://example/bar": [
+        {"@value": "baz"}
+      ]}
+    ]
+  }
+]

--- a/test-suite/tests/expand-c004-in.jsonld
+++ b/test-suite/tests/expand-c004-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "foo": {"@context": {"baz": {"@type": "@vocab"}}}
+  },
+  "foo": {
+    "bar": {
+      "baz": "buzz"
+    }
+  }
+}

--- a/test-suite/tests/expand-c004-out.jsonld
+++ b/test-suite/tests/expand-c004-out.jsonld
@@ -1,0 +1,9 @@
+[
+  {
+    "http://example/foo": [{
+      "http://example/bar": [{
+        "http://example/baz": [{"@id": "http://example/buzz"}]
+      }]
+    }]
+  }
+]

--- a/test-suite/tests/expand-c005-in.jsonld
+++ b/test-suite/tests/expand-c005-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "b": {"@context": {"c": "http://example.org/c"}}
+  },
+  "a": {
+    "@context": {"@vocab": "http://example.com/"},
+    "b": {
+      "a": "A in example.com",
+      "c": "C in example.org"
+    },
+    "c": "C in example.com"
+  },
+  "c": "C in example"
+}

--- a/test-suite/tests/expand-c005-out.jsonld
+++ b/test-suite/tests/expand-c005-out.jsonld
@@ -1,0 +1,10 @@
+[{
+  "http://example/a": [{
+    "http://example.com/c": [{"@value": "C in example.com"}],
+    "http://example/b": [{
+      "http://example.com/a": [{"@value": "A in example.com"}],
+      "http://example.org/c": [{"@value": "C in example.org"}]
+    }]
+  }],
+  "http://example/c": [{"@value": "C in example"}]
+}]

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -558,6 +558,41 @@
       "purpose": "Use of multiple reverse properties",
       "input": "expand-0078-in.jsonld",
       "expect": "expand-0078-out.jsonld"
+    }, {
+      "@id": "#tc001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "adding new term",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input": "expand-c001-in.jsonld",
+      "expect": "expand-c001-out.jsonld"
+    }, {
+      "@id": "#tc002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "overriding a term",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input": "expand-c002-in.jsonld",
+      "expect": "expand-c002-out.jsonld"
+    }, {
+      "@id": "#tc003",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "property and value with different terms mapping to the same expanded property",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input": "expand-c003-in.jsonld",
+      "expect": "expand-c003-out.jsonld"
+    }, {
+      "@id": "#tc004",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "deep @context affects nested nodes",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input": "expand-c004-in.jsonld",
+      "expect": "expand-c004-out.jsonld"
+    }, {
+      "@id": "#tc005",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "scoped context layers on intemediate contexts",
+      "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
+      "input": "expand-c005-in.jsonld",
+      "expect": "expand-c005-out.jsonld"
     }
   ]
 }


### PR DESCRIPTION
to syntax and API documents along with compaction and expansion tests.

Fixes #247. Fixes #262. Fixes #369.