### PR TITLE
Issue 430 containers

### DIFF
--- a/spec/latest/common/terms.html
+++ b/spec/latest/common/terms.html
@@ -110,7 +110,14 @@
       <a>node object</a> or a <a>value object</a> in the input.</dd>
     <dt><dfn data-lt="graph names">graph name</dfn></dt><dd>
       The <a>IRI</a> identifying a <a>named graph</a>.</dd>
-    <dt><dfn data-lt="index maps">index map</dfn></dt><dd>
+    <dt class="changed"><dfn data-lt="id maps">id map</dfn></dt><dd class="changed">
+      An <a>id map</a> is a <a>JSON object</a> value of a <a>term</a> defined with
+      <code>@container</code> set to <code>@id</code>, who's keys are
+      interpreted as <a>IRIs</a> representing the <code>@id</code>
+      of the associated <a>node object</a>; value MUST be a <a>node object</a>.
+      If the value contains a property expanding to <code>@id</code>, it's value MUST
+      be equivalent to the referencing key.</dd>
+     <dt><dfn data-lt="index maps">index map</dfn></dt><dd>
       An <a>index map</a> is a <a>JSON object</a> value of a <a>term</a> defined with
       <code>@container</code> set to <code>@index</code>, who's values MUST be any of the following types:
         <a>string</a>,

--- a/spec/latest/common/terms.html
+++ b/spec/latest/common/terms.html
@@ -251,6 +251,14 @@
       a <a>JSON object</a> as a <a>property</a>, type, or elsewhere that a string is interpreted as a vocabulary item.
       Its value is either a string, expanding to an absolute IRI, or an <a>expanded term definition</a>.
     </dd>
+    <dt class="changed"><dfn data-lt="type maps">type map</dfn></dt><dd class="changed">
+      An <a>type map</a> is a <a>JSON object</a> value of a <a>term</a> defined with
+      <code>@container</code> set to <code>@type</code>, who's keys are
+      interpreted as <a>IRIs</a> representing the <code>@type</code>
+      of the associated <a>node object</a>;
+      value MUST be a <a>node object</a>, or <a>array</a> of node objects.
+      If the value contains a property expanding to <code>@type</code>, it's values
+      are merged with the map value when expanding.</dd>
     <dt><dfn>typed literal</dfn></dt><dd>
       A <a>typed literal</a> is a <a>literal</a> with an associated <a>IRI</a>
       which indicates the literal's datatype. See <cite><a

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -987,6 +987,7 @@
             <li>Initialize <em>container</em> to the value associated with the
               <code>@container</code> key, which must be either
               <code>@list</code>, <code>@set</code>, <code>@index</code>,
+              <span class="changed"><code>@id</code>, <code>@type</code></span>
               or <code>@language</code>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid container mapping</a>
               has been detected and processing is aborted.</li>
@@ -1470,9 +1471,10 @@
               </ol>
             </li>
             <li>Otherwise, if <em>key</em>'s <a>container mapping</a> in
-              <em class="changed">term context</em> is <code>@index</code> and
+              <em class="changed">term context</em> is <code>@index</code>,
+              <span class="changed"><code>@type</code>, or <code>@id</code></span> and
               <em>value</em> is a <a>JSON object</a> then <em>value</em>
-              is expanded from an index map as follows:
+              is expanded from an map as follows:
               <ol class="algorithm">
                 <li>Initialize <em>expanded value</em> to an empty
                   <a>array</a>.</li>
@@ -1488,10 +1490,22 @@
                       <em>key</em> as <a>active property</a>,
                       and <em>index value</em> as <em>element</em>.</li>
                     <li>For each <em>item</em> in <em>index value</em>:
-                      <ol class="algorithm">
-                        <li>If <em>item</em> does not have the key
+                      <ol class="algorithm changed">
+                        <li>If <a>container mapping</a> is <code>@index</code>
+                          and <em>item</em> does not have the key
                           <code>@index</code>, add the key-value pair
                           (<code>@index</code>-<em>index</em>) to
+                          <em>item</em>.</li>
+                        <li>Otherwise, if <a>container mapping</a> is <code>@id</code>
+                          and <em>item</em> does not have the key
+                          <code>@id</code>, add the key-value pair
+                          (<code>@id</code>-<em>index</em>) to
+                          <em>item</em>.</li>
+                        <li>Otherwise, if <a>container mapping</a> is <code>@type</code>
+                          set <em>types</em> to the concatenation of <em>index
+                          value</em> with any existing values of
+                          <code>@type</code> in <em>item</em> and add the
+                          key-value pair (<code>@type</code>-<em>types</em>) to
                           <em>item</em>.</li>
                         <li>Append <em>item</em> to <em>expanded value</em>.</li>
                       </ol>
@@ -1994,20 +2008,39 @@
                   </ol>
                 </li>
                 <li>
-                  If <em>container</em> is <code>@language</code> or
-                  <code>@index</code>:
+                  If <em>container</em> is <code>@language</code>,
+                  <code>@index</code>, <span class="changed"><code>@id</code>,
+                    or <code>@type</code></span>:
                   <ol class="algorithm">
                     <li>If <em>item active property</em> is not a key in
                       <em>result</em>, initialize it to an empty <a>JSON object</a>.
                       Initialize <em>map object</em> to the value of <em>item active property</em>
                       in <em>result</em>.</li>
+                    <li>Set <em>compacted container</em> to the result of calling the 
+                      <a href="#iri-compaction">IRI Compaction algorithm</a>
+                      passing <a>active context</a>,
+                      <em>container</em> as <em>iri</em>, and <code>true</code>
+                      for <em>vocab</em>.</li>
                     <li>If <em>container</em> is <code>@language</code> and
                       <em>compacted item</em> contains the key
                       <code>@value</code>, then set <em>compacted item</em>
                       to the value associated with its <code>@value</code> key.</li>
-                    <li>Initialize <em>map key</em> to the value associated with
+                    <li>If <em>container</em> is <code>@index</code>,
+                      set <em>map key</em> to the value associated with
                       with the key that equals <em>container</em> in
                       <em>expanded item</em>.</li>
+                    <li class="changed">If <em>container</em> is <code>@id</code>, set
+                      <em>map key</em> to the value associated with the key that equals
+                      <em>compacted container</em> in <em>compacted item</em>
+                      and remove that key-value pair from <em>compacted item</em>.</li>
+                    <li class="changed">If <em>container</em> is <code>@type</code>,
+                      set <em>map key</em> to the first value associated with
+                      the key that equals <em>container</em> in <em>expanded
+                      item</em>. If there are remaining values in <em>compacted
+                      item</em> for <em>compacted container</em>, set the value
+                      of <em>compacted container</em> in <em>compacted
+                      value</em> to those remaining values. Otherwise, remove
+                      that key-value pair from <em>compacted item</em>.</li>
                     <li>If <em>map key</em> is not a key in <em>map object</em>,
                       then set this key's value in <em>map object</em>
                       to <em>compacted item</em>. Otherwise, if the value
@@ -2284,9 +2317,10 @@
               variables will keep track of the preferred
               <a>type mapping</a> or <a>language mapping</a> for
               a <a>term</a>, based on what is compatible with <em>value</em>.</li>
-            <li>If <em>value</em> is a <a>JSON object</a> that contains the
-              key <code>@index</code>, then append the value <code>@index</code>
-              to <em>containers</em>.</li>
+            <li>If <em>value</em> is a <a>JSON object</a>,
+              <span class="changed">then for the keywords <code>@index</code>,
+              <code>@id</code>, and <code>@type</code>, if <em>value</em>
+              contains that <a>keyword</a>, append it to <em>containers</em>.</span></li>
             <li>If <em>reverse</em> is <code>true</code>, set <em>type/language</em>
               to <code>@type</code>, <em>type/language value</em> to
               <code>@reverse</code>, and append <code>@set</code> to <em>containers</em>.</li>
@@ -4208,6 +4242,8 @@
     <li>A new <a href="#merge-node-maps" class="sectionRef"></a> is required
       for framing, to create a single graph from the <a data-lt="default graph">default</a>
       and <a>named graphs</a>.</li>
+    <li><code>@container</code> values within an <a>expanded term definition</a> may now
+      include <code>@id</code> and <code>@type</code>, corresponding to <a>id maps</a> and <a>type maps</a>.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -2586,10 +2586,10 @@ specified. The full <a>IRI</a> for
 <section class="informative changed">
   <h2>Node Identifier Indexing</h2>
 
-  <p>In addition to index maps, JSON-LD introduces the notion of <a>id maps</a>
+  <p>In addition to <a>index maps</a>, JSON-LD introduces the notion of <a>id maps</a>
     for structuring data. The id indexing feature allows an author to
     structure data using a simple key-value map where the keys map
-    to <a>IRIs</a>. This enables direct access to associated node objects
+    to <a>IRIs</a>. This enables direct access to associated <a>node objects</a>
     instead of having to scan an array in search of a specific item.
     In JSON-LD such data can be specified by associating the
     <code>@id</code> <a>keyword</a> with a
@@ -2627,14 +2627,61 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p>In the example above, the <strong>post</strong> <a>term</a> has
-    been marked as an <a>id map</a>. The <strong>http://example.com/posts/1/en</strong> and
-    <strong>http://example.com/posts/1/de</strong> keys will be interpreted
+  <p>In the example above, the <code>post</code> <a>term</a> has
+    been marked as an <a>id map</a>. The <code>http://example.com/posts/1/en</code> and
+    <code>http://example.com/posts/1/de</code> keys will be interpreted
     as the <code>@id</code> property of the <a>node object</a> value.</p>
 
   <p>The interpretation of the data above is exactly the same
     as that in <a class="sectionRef" href="#data-indexing"></a>
-    using a JSON-LD processor:</p>
+    using a JSON-LD processor.</p>
+</section>
+
+<section class="informative changed">
+  <h2>Node Type Indexing</h2>
+
+  <p>In addition to <a data-lt="id map">id</a> and <a>index maps</a>, JSON-LD introduces the notion of <a>type maps</a>
+    for structuring data. The type indexing feature allows an author to
+    structure data using a simple key-value map where the keys map
+    to <a>IRIs</a>. This enables data to be structured based on the <code>@type</code>
+    of specific <a>node objects</a>.
+    In JSON-LD such data can be specified by associating the
+    <code>@type</code> <a>keyword</a> with a
+    <code>@container</code> declaration in the context:</p>
+
+  <pre class="example" data-transform="updateExample"
+       title="Indexing data in JSON-LD by node identifiers">
+  <!--
+  {
+    "@context":
+    {
+       "schema": "http://schema.org/",
+       "name": "schema:name",
+       "affiliation": {
+         "@id": "schema:affiliation",
+         ****"@container": "@type"****
+       }
+    },
+    "name": "Manu Sporny",
+    "affiliation": {
+      ****"schema:Corporpation"****: {
+        "@id": "http://digitalbazaar.com/",
+        "name": "Digital Bazaar"
+      },
+      ****"schema:ProfessionalService"****: {
+        "@id": "https://spec-ops.io",
+        "name": "Spec-Ops"
+      }
+      
+    }
+  }
+  -->
+  </pre>
+
+  <p>In the example above, the <code>affiliation</code> <a>term</a> has
+    been marked as an <a>type map</a>. The <code>schema:Corporpation</code> and
+    <code>schema:ProfessionalService</code> keys will be interpreted
+    as the <code>@type</code> property of the <a>node object</a> value.</p>
 </section>
 
 <section class="informative">
@@ -3250,7 +3297,21 @@ specified. The full <a>IRI</a> for
       and the values MUST be <a>node objects</a>.</p>
 
     <p>If the value contains a property expanding to <code>@id</code>, it's value MUST
-      be equivalent to the referencing key. Otherwise, the key is used as
+      be equivalent to the referencing key. Otherwise, the property from the value is used as
+      the <code>@id</code> of the <a>node object</a> value when expanding.</p>
+  </section>
+
+  <section class="changed">
+    <h2>Type Maps</h2>
+
+    <p>An <a>type map</a> is used to associate an <a>IRI</a> with a value that allows easy
+      programatic access. An <a>id map</a> may be used as a term value within a <a>node object</a> if the <a>term</a>
+      is defined with <code>@container</code> set to <code>@id</code>. The keys of an <a>id map</a> MUST be <a>IRIs</a>
+      (<a>relative IRI</a>, <a>compact IRI</a> (including <a>blank node identifiers</a>), or <a>absolute IRI</a>)
+      and the values MUST be <a>node objects</a>.</p>
+
+    <p>If the value contains a property expanding to <code>@id</code>, it's value MUST
+      be equivalent to the referencing key. Otherwise, the property from the value is used as
       the <code>@id</code> of the <a>node object</a> value when expanding.</p>
   </section>
 
@@ -3519,17 +3580,16 @@ specified. The full <a>IRI</a> for
     <li>An <a>expanded term definition</a> can now have an
       <code>@context</code> property, which defines a <a>context</a> used for values of
       a <a>property</a> identified with such a <a>term</a>.</li>
+    <li><code>@container</code> values within an <a>expanded term definition</a> may now
+      include <code>@id</code> and <code>@type</code>, corresponding to <a>id maps</a> and <a>type maps</a>.</li>
   </ul>
 </section>
 
 <section class="appendix informative">
   <h4>Open Issues</h4>
   <p>The following is a list of open issues being worked on for the next release.</p>
-  <p class="issue" data-number="12"></p>
   <p class="issue" data-number="195"></p>
   <p class="issue" data-number="246"></p>
-  <p class="issue" data-number="247"></p>
-  <p class="issue" data-number="262"></p>
   <p class="issue" data-number="269"></p>
   <p class="issue" data-number="271"></p>
   <p class="issue" data-number="272"></p>

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -2583,6 +2583,60 @@ specified. The full <a>IRI</a> for
   </table>
 </section>
 
+<section class="informative changed">
+  <h2>Node Identifier Indexing</h2>
+
+  <p>In addition to index maps, JSON-LD introduces the notion of <a>id maps</a>
+    for structuring data. The id indexing feature allows an author to
+    structure data using a simple key-value map where the keys map
+    to <a>IRIs</a>. This enables direct access to associated node objects
+    instead of having to scan an array in search of a specific item.
+    In JSON-LD such data can be specified by associating the
+    <code>@id</code> <a>keyword</a> with a
+    <code>@container</code> declaration in the context:</p>
+
+  <pre class="example" data-transform="updateExample"
+       title="Indexing data in JSON-LD by node identifiers">
+  <!--
+  {
+    "@context":
+    {
+       "schema": "http://schema.org/",
+       "name": "schema:name",
+       "body": "schema:articleBody",
+       "words": "schema:wordCount",
+       "post": {
+         "@id": "schema:blogPost",
+         ****"@container": "@id"****
+       }
+    },
+    "@id": "http://example.com/",
+    "@type": "schema:Blog",
+    "name": "World Financial News",
+    ****"post": {
+       "http://example.com/posts/1/en": {
+         "body": "World commodities were up today with heavy trading of crude oil...",
+         "words": 1539
+       },
+       "http://example.com/posts/1/de": {
+         "body": "Die Werte an Warenbörsen stiegen im Sog eines starken Handels von Rohöl...",
+         "words": 1204
+       }****
+    }
+  }
+  -->
+  </pre>
+
+  <p>In the example above, the <strong>post</strong> <a>term</a> has
+    been marked as an <a>id map</a>. The <strong>http://example.com/posts/1/en</strong> and
+    <strong>http://example.com/posts/1/de</strong> keys will be interpreted
+    as the <code>@id</code> property of the <a>node object</a> value.</p>
+
+  <p>The interpretation of the data above is exactly the same
+    as that in <a class="sectionRef" href="#data-indexing"></a>
+    using a JSON-LD processor:</p>
+</section>
+
 <section class="informative">
   <h3>Expanded Document Form</h3>
 
@@ -3184,6 +3238,20 @@ specified. The full <a>IRI</a> for
     </ul>
 
     <p>See <a class="sectionRef" href="#data-indexing"></a> for further information on this topic.</p>
+  </section>
+
+  <section class="changed">
+    <h2>Id Maps</h2>
+
+    <p>An <a>id map</a> is used to associate an <a>IRI</a> with a value that allows easy
+      programatic access. An <a>id map</a> may be used as a term value within a <a>node object</a> if the <a>term</a>
+      is defined with <code>@container</code> set to <code>@id</code>. The keys of an <a>id map</a> MUST be <a>IRIs</a>
+      (<a>relative IRI</a>, <a>compact IRI</a> (including <a>blank node identifiers</a>), or <a>absolute IRI</a>)
+      and the values MUST be <a>node objects</a>.</p>
+
+    <p>If the value contains a property expanding to <code>@id</code>, it's value MUST
+      be equivalent to the referencing key. Otherwise, the key is used as
+      the <code>@id</code> of the <a>node object</a> value when expanding.</p>
   </section>
 
 <section class="normative">

--- a/test-suite/README.md
+++ b/test-suite/README.md
@@ -23,6 +23,7 @@ Tests are defined into _compact_, _expand_, _flatten_, _frame_, _normalize_, and
   contained within the _sparql_ document using a SPARQL endpoint. The end result is a
   yes/no on whether the expected triples were extracted by the JSON-LD processor.
 
+Unless `processingMode` is set explicitly in a test entry, `processingMode` is compatible with both `json-ld-1.0` and `json-ld-1.1`. Otherwise, a JSON-LD 1.0 processor should not run tests marked `json-ld-1.1` and a JSON-LD 1.1 processor should not run tests marked `json-ld-1.0`.
 
 Contributing
 ------------

--- a/test-suite/index.html
+++ b/test-suite/index.html
@@ -166,6 +166,11 @@
           <p>To run the tests, create a test runner which will run through each test manifest
             and execute the tests defined within the manifest using the rules associated with
             each <code>@type</code> defined for the test case as defined in <a href="vocab">the test vocabulary</a>.</p>
+          <p>Unless <code>processingMode</code> is set explicitly in a test entry,
+            <code>processingMode</code> is compatible with both <code>json-ld-1.0</code> and
+            <code>json-ld-1.1</code>. Otherwise, a JSON-LD 1.0 processor should not run
+            tests marked <code>json-ld-1.1</code> and a JSON-LD 1.1 processor should not run
+            tests marked <code>json-ld-1.0</code>. </p>
           <p>Note that property values are typed, and those which are typed as <code>@id</code> must
             be treated as IRIs relative to the manifest test base. In particular, this means that
             <em>input</em>, </em>context</em>, <em>frame</em>, and <em>expandContext</em> are to be

--- a/test-suite/tests/compact-m001-context.jsonld
+++ b/test-suite/tests/compact-m001-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id"}
+  }
+}

--- a/test-suite/tests/compact-m001-in.jsonld
+++ b/test-suite/tests/compact-m001-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example/idmap": [
+    {"http://example/label": [{"@value": "Object with @id _:bar"}], "@id": "_:bar"},
+    {"http://example/label": [{"@value": "Object with @id <foo>"}], "@id": "http://example.org/foo"}
+  ]
+}]

--- a/test-suite/tests/compact-m001-out.jsonld
+++ b/test-suite/tests/compact-m001-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id"}
+  },
+  "idmap": {
+    "http://example.org/foo": {"label": "Object with @id <foo>"},
+    "_:bar": {"label": "Object with @id _:bar"}
+  }
+}

--- a/test-suite/tests/compact-m002-context.jsonld
+++ b/test-suite/tests/compact-m002-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id"}
+  }
+}

--- a/test-suite/tests/compact-m002-in.jsonld
+++ b/test-suite/tests/compact-m002-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example/idmap": [
+    {"@id": "_:foo", "http://example/label": [{"@value": "Object with @id _:bar"}]},
+    {"@id": "http://example.org/bar", "http://example/label": [{"@value": "Object with @id <foo>"}]}
+  ]
+}]

--- a/test-suite/tests/compact-m002-out.jsonld
+++ b/test-suite/tests/compact-m002-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id"}
+  },
+  "idmap": {
+    "_:foo": {"label": "Object with @id _:bar"},
+    "http://example.org/bar": {"label": "Object with @id <foo>"}
+  }
+}

--- a/test-suite/tests/compact-m003-context.jsonld
+++ b/test-suite/tests/compact-m003-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  }
+}

--- a/test-suite/tests/compact-m003-in.jsonld
+++ b/test-suite/tests/compact-m003-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example/typemap": [
+    {"http://example/label": [{"@value": "Object with @type _:bar"}], "@type": ["_:bar"]},
+    {"http://example/label": [{"@value": "Object with @type <foo>"}], "@type": ["http://example.org/foo"]}
+  ]
+}]

--- a/test-suite/tests/compact-m003-out.jsonld
+++ b/test-suite/tests/compact-m003-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  },
+  "typemap": {
+    "http://example.org/foo": {"label": "Object with @type <foo>"},
+    "_:bar": {"label": "Object with @type _:bar"}
+  }
+}

--- a/test-suite/tests/compact-m004-context.jsonld
+++ b/test-suite/tests/compact-m004-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  }
+}

--- a/test-suite/tests/compact-m004-in.jsonld
+++ b/test-suite/tests/compact-m004-in.jsonld
@@ -1,0 +1,12 @@
+[{
+  "http://example/typemap": [
+    {
+      "@type": ["_:bar", "_:foo"],
+      "http://example/label": [{"@value": "Object with @type _:bar"}]
+    },
+    {
+      "@type": ["http://example.org/foo", "http://example.org/bar"],
+      "http://example/label": [{"@value": "Object with @type <foo>"}]
+    }
+  ]
+}]

--- a/test-suite/tests/compact-m004-out.jsonld
+++ b/test-suite/tests/compact-m004-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  },
+  "typemap": {
+    "http://example.org/foo": {"@type": "http://example.org/bar", "label": "Object with @type <foo>"},
+    "_:bar": {"@type": "_:foo", "label": "Object with @type _:bar"}
+  }
+}

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -625,6 +625,38 @@
       "input": "compact-c005-in.jsonld",
       "context": "compact-c005-context.jsonld",
       "expect": "compact-c005-out.jsonld"
+    }, {
+      "@id": "#tm001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Indexes to object not having an @id",
+      "purpose": "Compaction using @container: @id",
+      "input": "compact-m001-in.jsonld",
+      "context": "compact-m001-context.jsonld",
+      "expect": "compact-m001-out.jsonld"
+    }, {
+      "@id": "#tm002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Indexes to object already having an @id",
+      "purpose": "Compaction using @container: @id",
+      "input": "compact-m002-in.jsonld",
+      "context": "compact-m002-context.jsonld",
+      "expect": "compact-m002-out.jsonld"
+    }, {
+      "@id": "#tm003",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Indexes to object not having an @type",
+      "purpose": "Compaction using @container: @type",
+      "input": "compact-m003-in.jsonld",
+      "context": "compact-m003-context.jsonld",
+      "expect": "compact-m003-out.jsonld"
+    }, {
+      "@id": "#tm004",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Indexes to object already having an @type",
+      "purpose": "Compaction using @container: @type",
+      "input": "compact-m004-in.jsonld",
+      "context": "compact-m004-context.jsonld",
+      "expect": "compact-m004-out.jsonld"
     }
   ]
 }

--- a/test-suite/tests/error-m021-in.jsonld
+++ b/test-suite/tests/error-m021-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "term": {"@id": "http://example/term", "@container": "@context"}
+  },
+  "@id": "http://example/test#example"
+}

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -152,7 +152,10 @@
       "name": "Invalid container mapping",
       "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
       "input": "error-0021-in.jsonld",
-      "expect": "invalid container mapping"
+      "expect": "invalid container mapping",
+      "option": {
+        "processingMode": "json-ld-1.0"
+      }
     }, {
       "@id": "#t0022",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -309,12 +312,22 @@
       "input": "error-0043-in.jsonld",
       "expect": "conflicting indexes"
     }, {
-      "@id": "#t1001",
+      "@id": "#tc001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
       "name": "Invalid keyword in term definition",
       "purpose": "Verifies that an exception is raised on expansion when a invalid term definition is found",
       "input": "error-c001-in.jsonld",
       "expect": "invalid term definition"
+    }, {
+      "@id": "#tm021",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
+      "name": "Invalid container mapping",
+      "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
+      "input": "error-m021-in.jsonld",
+      "expect": "invalid container mapping",
+      "option": {
+        "processingMode": "json-ld-1.1"
+      }
     }
   ]
 }

--- a/test-suite/tests/expand-m001-in.jsonld
+++ b/test-suite/tests/expand-m001-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id"}
+  },
+  "idmap": {
+    "http://example.org/foo": {"label": "Object with @id <foo>"},
+    "_:bar": {"label": "Object with @id _:bar"}
+  }
+}

--- a/test-suite/tests/expand-m001-out.jsonld
+++ b/test-suite/tests/expand-m001-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example/idmap": [
+    {"http://example/label": [{"@value": "Object with @id _:bar"}], "@id": "_:bar"},
+    {"http://example/label": [{"@value": "Object with @id <foo>"}], "@id": "http://example.org/foo"}
+  ]
+}]

--- a/test-suite/tests/expand-m002-in.jsonld
+++ b/test-suite/tests/expand-m002-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id"}
+  },
+  "idmap": {
+    "http://example.org/foo": {"@id": "http://example.org/bar", "label": "Object with @id <foo>"},
+    "_:bar": {"@id": "_:foo", "label": "Object with @id _:bar"}
+  }
+}

--- a/test-suite/tests/expand-m002-out.jsonld
+++ b/test-suite/tests/expand-m002-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example/idmap": [
+    {"@id": "_:foo", "http://example/label": [{"@value": "Object with @id _:bar"}]},
+    {"@id": "http://example.org/bar", "http://example/label": [{"@value": "Object with @id <foo>"}]}
+  ]
+}]

--- a/test-suite/tests/expand-m003-in.jsonld
+++ b/test-suite/tests/expand-m003-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  },
+  "typemap": {
+    "http://example.org/foo": {"label": "Object with @type <foo>"},
+    "_:bar": {"label": "Object with @type _:bar"}
+  }
+}

--- a/test-suite/tests/expand-m003-out.jsonld
+++ b/test-suite/tests/expand-m003-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example/typemap": [
+    {"http://example/label": [{"@value": "Object with @type _:bar"}], "@type": ["_:bar"]},
+    {"http://example/label": [{"@value": "Object with @type <foo>"}], "@type": ["http://example.org/foo"]}
+  ]
+}]

--- a/test-suite/tests/expand-m004-in.jsonld
+++ b/test-suite/tests/expand-m004-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  },
+  "typemap": {
+    "http://example.org/foo": {"@type": "http://example.org/bar", "label": "Object with @type <foo>"},
+    "_:bar": {"@type": "_:foo", "label": "Object with @type _:bar"}
+  }
+}

--- a/test-suite/tests/expand-m004-out.jsonld
+++ b/test-suite/tests/expand-m004-out.jsonld
@@ -1,0 +1,12 @@
+[{
+  "http://example/typemap": [
+    {
+      "@type": ["_:bar", "_:foo"],
+      "http://example/label": [{"@value": "Object with @type _:bar"}]
+    },
+    {
+      "@type": ["http://example.org/foo", "http://example.org/bar"],
+      "http://example/label": [{"@value": "Object with @type <foo>"}]
+    }
+  ]
+}]

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -593,6 +593,34 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c005-in.jsonld",
       "expect": "expand-c005-out.jsonld"
+    }, {
+      "@id": "#tm001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Adds @id to object not having an @id",
+      "purpose": "Expansion using @container: @id",
+      "input": "expand-m001-in.jsonld",
+      "expect": "expand-m001-out.jsonld"
+    }, {
+      "@id": "#tm002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Retains @id in object already having an @id",
+      "purpose": "Expansion using @container: @id",
+      "input": "expand-m002-in.jsonld",
+      "expect": "expand-m002-out.jsonld"
+    }, {
+      "@id": "#tm003",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Adds @type to object not having an @type",
+      "purpose": "Expansion using @container: @type",
+      "input": "expand-m003-in.jsonld",
+      "expect": "expand-m003-out.jsonld"
+    }, {
+      "@id": "#tm004",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Prepends @type in object already having an @type",
+      "purpose": "Expansion using @container: @type",
+      "input": "expand-m004-in.jsonld",
+      "expect": "expand-m004-out.jsonld"
     }
   ]
 }

--- a/test-suite/vocab.html
+++ b/test-suite/vocab.html
@@ -143,10 +143,10 @@
             <dd about='jld:NegativeSyntaxTest' property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.</p></dd>
             <dt about='jld:NormalizeTest' property='rdfs:label' typeof='rdfs:Class'>Normalization Evaluation Test</dt>
             <dd about='jld:NormalizeTest' property='rdfs:comment'><p>A <code>NormalizeTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/rdf-graph-normalization/#normalization-algorithm">Normalization</a> algorithmwith the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing an JSON-LD file and optional options from <code>:option</code>. The expected results for a PositiveEvaluationTest are N-Quads serialized in lexographical order and MUST be compared using string comparison.</p></dd>
-            <dt about='jld:NegativeEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>Positive Evaluation Test</dt>
-            <dd about='jld:NegativeEvaluationTest' property='rdfs:comment'><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) results in the error identified by the literal value of <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p></dd>
             <dt about='jld:PositiveEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>Positive Evaluation Test</dt>
             <dd about='jld:PositiveEvaluationTest' property='rdfs:comment'><p>A Positive Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) exactly matches the output file specified as <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p></dd>
+            <dt about='jld:NegativeEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>Positive Evaluation Test</dt>
+            <dd about='jld:NegativeEvaluationTest' property='rdfs:comment'><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) results in the error identified by the literal value of <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p></dd>
             <dt about='jld:PositiveSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>Positive Syntax Test</dt>
             <dd about='jld:PositiveSyntaxTest' property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.</p></dd>
             <dt about='jld:Option' property='rdfs:label' typeof='rdfs:Class'>Processor Options</dt>
@@ -301,7 +301,7 @@
                 <strong>
                   domain:
                 </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
+                <code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
               </div>
               <div>
                 <strong>

--- a/test-suite/vocab.jsonld
+++ b/test-suite/vocab.jsonld
@@ -183,7 +183,7 @@
       "@id": "jld:processingMode",
       "@type": "rdf:Property",
       "rdfs:comment": "If set to \"json-ld-1.1\", the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "processing mode",
       "rdfs:range": "xsd:string"
     },

--- a/test-suite/vocab.ttl
+++ b/test-suite/vocab.ttl
@@ -224,7 +224,7 @@
     Consequently, different implementations may implement different optimizations.
     Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.
   """ ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:string .
 
 :produceGeneralizedRdf a rdf:Property ;


### PR DESCRIPTION
This PR adds support for id-maps and type-maps.
Fixes #430.

Formatted HTML versions are available for [JSON-LD](http://gkellogg.github.io/json-ld.org/spec/latest/json-ld/), and [JSON-LD-API](http://gkellogg.github.io/json-ld.org/spec/latest/json-ld-api/) on my personal fork.

Note that I've added some simple change highlighting to make it easier to see changes since 1.0.

For the Syntax doc this includes _Node Identifier Indexing_ and _Node Type_ Indexing sections in addition to the grammar. For the API document, it includes minor changes to _Create Term Definition_, _IRI Compaction_, _Expansion Algorithm_, and _Compaction Algorithm_.

There are also 9 new tests, and one error test marked `json-ld-1.0` only.