### PR TITLE
This adds a `@nest` member to term definitions used for _transparent properties_

### DIFF
--- a/spec/latest/common/terms.html
+++ b/spec/latest/common/terms.html
@@ -173,6 +173,10 @@
       specified via the <code>@context</code> <a>keyword</a>.</dd>
     <dt><dfn data-lt="named graphs">named graph</dfn></dt><dd>
       A <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>
+    <dt><dfn data-lt="nested properties">nested property</dfn></dt><dd>
+      A <a>nested property</a> is a <a>property</a> which is contained within an object referenced by
+      a semantically meaningless <em>nesting property</em>.
+    </dd>
       (the <a>graph name</a>) and a <a>graph</a>.</dd>
     <dt><dfn data-lt="nodes">node</dfn></dt><dd>
       Every <a>node</a> is an <a>IRI</a>, a <a>blank node</a>,

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -4102,6 +4102,7 @@
             "cyclic IRI mapping",
             "invalid @id value",
             "invalid @index value",
+            "invalid @nest value",
             "invalid @reverse value",
             "invalid base IRI",
             "invalid container mapping",
@@ -4112,7 +4113,6 @@
             "invalid language mapping",
             "invalid language-tagged string",
             "invalid language-tagged value",
-            "invalid @nest value",
             "invalid local context",
             "invalid remote context",
             "invalid reverse property",
@@ -4154,6 +4154,8 @@
         <dt><dfn>invalid @index value</dfn></dt>
         <dd>An <code>@index</code> member was encountered whose value was
           not a <a>string</a>.</dd>
+        <dt class="changed"><dfn>invalid @nest value</dfn></dt>
+        <dd class="changed">An invalid value for <code>@nest</code> has been found.</dd>
         <dt><dfn>invalid @reverse value</dfn></dt>
         <dd>An invalid value for an <code>@reverse</code> member has been detected,
           i.e., the value was not a <a>JSON object</a>.</dd>
@@ -4189,8 +4191,6 @@
           associated language tag was detected.</dd>
         <dt><dfn>invalid local context</dfn></dt>
         <dd>In invalid <a>local context</a> was detected.</dd>
-        <dt class="changed"><dfn>invalid @nest value</dfn></dt>
-        <dd class="changed">An invalid value for <code>@nest</code> has been found.</dd>
         <dt><dfn>invalid remote context</dfn></dt>
         <dd>No valid context document has been found for a referenced,
          remote context.</dd>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -903,7 +903,7 @@
         </li>
         <li>If <em>value</em> contains the key <code>@reverse</code>:
           <ol class="algorithm">
-            <li>If <em>value</em> contains an <code>@id</code>, member, an
+            <li>If <em>value</em> contains <code>@id</code> or <code>@nest</code>, members, an
               <a data-link-for="JsonLdErrorCode">invalid reverse property</a>
               error has been detected and processing is aborted.</li>
             <li>If the value associated with the <code>@reverse</code> key
@@ -1019,9 +1019,18 @@
               of <em>definition</em> to <em>language</em>.</li>
           </ol>
         </li>
+        <li class="changed">If <em>value</em> contains the key <code>@nest</code>:
+          <ol class="algorithm">
+            <li>Initialize <em>nest</em> to the value associated with the
+              <code>@nest</code> key, which must be a <a>string</a> and
+              must not be a keyword other than <code>@nest</code>. Otherwise, an
+              <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
+              error has been detected and processing is aborted.</li>
+          </ol>
+        </li>
         <li>If the value contains any key other than <code>@id</code>,
           <code>@reverse</code>, <code>@container</code>,
-          <code>@context</code>, or <code>@type</code>, an
+          <code>@context</code>, <code class="changed">@nest</code>, or <code>@type</code>, an
           <a data-link-for="JsonLdErrorCode">invalid term definition</a> error has
           been detected and processing is aborted.</li>
         <li>Set the <a>term definition</a> of <em>term</em> in
@@ -1269,7 +1278,7 @@
           passing <a>active context</a> and the value of the
           <code>@context</code> key as <a>local context</a>.</li>
         <li>Initialize an empty <a>JSON object</a>, <em>result</em>.</li>
-        <li>For each <em>key</em> and <em>value</em> in <em>element</em>,
+        <li id="alg-expand-each-key-value">For each <em>key</em> and <em>value</em> in <em>element</em>,
           ordered lexicographically by <em>key</em>:
           <ol class="algorithm">
             <li>If <em>key</em> is <code>@context</code>, continue to
@@ -1417,6 +1426,10 @@
                     <li>Continue with the next <em>key</em> from <em>element</em>.</li>
                   </ol>
                 </li>
+                <li class="changed">If <em>expanded property</em> is <code>@nest</code>,
+                  add <em>key</em> to <em>nests</em>, initializing it to an empty <a>array</a>,
+                  if necessary.
+                  Continue with the next <em>key</em> from <em>element</em>.</li>
                 <li class="changed">When the <code>frame expansion</code> flag is set,
                   if <em>expanded property</em> is any other
                   framing keyword (<code>@explicit</code>, <code>@default</code>,
@@ -1543,6 +1556,22 @@
                   <a>array</a>.</li>
                 <li>Append <em>expanded value</em> to value of the <em>expanded property</em>
                   member of <em>result</em>.</li>
+              </ol>
+            </li>
+            <li class="changed">For each key <em>nesting-key</em> in <em>nests</em>
+              <ol class="algorithm">
+                <li>Set <em>nested values</em> to the value of <em>nesting-key</em>
+                  in <em>element</em>, ensuring that it is an <a>array</a>.</li>
+                <li>For each <em>nested value</em> in <em>nested values</em>:
+                  <ol class="algorithm">
+                    <li>If <em>nested value</em> is not a <a>JSON object</a>, or any key within
+                      <em>nested value</em> expands to <code>@value</code>, an
+                      <a data-link-for="JsonLdErrorCode">invalid @nest value</a> error
+                      has been detected and processing is aborted.</li>
+                    <li>Recursively repeat <a href="#alg-expand-each-key-value">step 7</a>
+                      using <em>nested value</em> for <em>element</em>.</li>
+                  </ol>
+                </li>
               </ol>
             </li>
           </ol>
@@ -1928,7 +1957,22 @@
                   <em>expanded value</em> for <em>value</em>,
                   <code>true</code> for <em>vocab</em>, and
                   <em>inside reverse</em>.</li>
-                <li>If <em>result</em> does not have the key that equals
+                <li class="changed">If the <a>term definition</a> for <em>item active property</em>
+                  in the <em>active context</em> has a <code>@nest</code>
+                  member, that value (<em>nest term</em>) must be
+                  <code>@nest</code>, or a <a>term definition</a> in the
+                  <em>active context</em> that expands to <code>@nest</code>,
+                  otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
+                  value</a> error has been detected, and processing is aborted.
+                  If <em>result</em> does not have the key that equals <em>nest
+                  term</em>, initialize it to an empty JSON object (<em>nest
+                  object</em>). If <em>nest object</em> does not have the key
+                  that equals <em>item active property</em>, set this key's
+                  value in <em>nest object</em> to an empty
+                  <a>array</a>.Otherwise, if the key's value is not an
+                  <a>array</a>, then set it to one containing only the
+                  value.</li>
+                <li>Otherwise, if <em>result</em> does not have the key that equals
                   <em>item active property</em>, set this key's value in
                   <em>result</em> to an empty <a>array</a>. Otherwise, if
                   the key's value is not an <a>array</a>, then set it
@@ -1948,6 +1992,16 @@
                   <em>expanded item</em> for <em>value</em>,
                   <code>true</code> for <em>vocab</em>, and
                   <em>inside reverse</em>.</li>
+                <li class="changed">If the <a>term definition</a> for <em>item active property</em>
+                  in the <em>active context</em> has a <code>@nest</code>
+                  member, that value (<em>nest term</em>) must be
+                  <code>@nest</code>, or a <a>term definition</a> in the
+                  <em>active context</em> that expands to <code>@nest</code>,
+                  otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
+                  value</a> error has been detected, and processing is aborted.
+                  Set <em>nest result</em> to the value of <em>nest term</em> in <em>result</em>,
+                  initializing it to a new <a>JSON object</a>, if necessary; otherwise
+                  set <em>nest result</em> to <em>result</em>.</li>
                 <li>Initialize <em>container</em> to <code>null</code>. If there
                   is a <a>container mapping</a> for
                   <em>item active property</em> in <a>active context</a>,
@@ -1985,7 +2039,7 @@
                       </ol>
                     </li>
                     <li>Otherwise, <em>item active property</em> must not be a key
-                      in <em>result</em> because there cannot be two
+                      in <em class="changed">nest result</em> because there cannot be two
                       <a>list objects</a> associated
                       with an <a>active property</a> that has a
                       <a>container mapping</a>; a
@@ -1998,9 +2052,9 @@
                   <code>@index</code>:
                   <ol class="algorithm">
                     <li>If <em>item active property</em> is not a key in
-                      <em>result</em>, initialize it to an empty <a>JSON object</a>.
+                      <em class="changed">nest result</em>, initialize it to an empty <a>JSON object</a>.
                       Initialize <em>map object</em> to the value of <em>item active property</em>
-                      in <em>result</em>.</li>
+                      in <em class="changed">nest result</em>.</li>
                     <li>If <em>container</em> is <code>@language</code> and
                       <em>compacted item</em> contains the key
                       <code>@value</code>, then set <em>compacted item</em>
@@ -2030,9 +2084,9 @@
                     <li>If <em>item active property</em> is not a key in
                       <em>result</em> then add the key-value pair,
                       (<em>item active property</em>-<em>compacted item</em>),
-                      to <em>result</em>.</li>
+                      to <em class="changed">nest result</em>.</li>
                     <li>Otherwise, if the value associated with the key that
-                      equals <em>item active property</em> in <em>result</em>
+                      equals <em>item active property</em> in <em class="changed">nest result</em>
                       is not an <a>array</a>, set it to a new
                       <a>array</a> containing only the value. Then
                       append <em>compacted item</em> to the value if
@@ -4058,6 +4112,7 @@
             "invalid language mapping",
             "invalid language-tagged string",
             "invalid language-tagged value",
+            "invalid @nest value",
             "invalid local context",
             "invalid remote context",
             "invalid reverse property",
@@ -4134,6 +4189,8 @@
           associated language tag was detected.</dd>
         <dt><dfn>invalid local context</dfn></dt>
         <dd>In invalid <a>local context</a> was detected.</dd>
+        <dt class="changed"><dfn>invalid @nest value</dfn></dt>
+        <dd class="changed">An invalid value for <code>@nest</code> has been found.</dd>
         <dt><dfn>invalid remote context</dfn></dt>
         <dd>No valid context document has been found for a referenced,
          remote context.</dd>
@@ -4208,6 +4265,12 @@
     <li>A new <a href="#merge-node-maps" class="sectionRef"></a> is required
       for framing, to create a single graph from the <a data-lt="default graph">default</a>
       and <a>named graphs</a>.</li>
+    <li>An <a>expanded term definition</a> can now have an
+      <code>@nest</code> property, which identifies a term expanding to
+      <code>@nest</code> which is used for containing properties using the same
+      <code>@nest</code> mapping. When expanding, the values of a property
+      expanding to <code>@nest</code> are treated as if they were contained
+      within the enclosing <a>node object</a> directly.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -395,6 +395,8 @@
         <a>IRI</a>. This keyword is described in <a class="sectionRef" href="#default-vocabulary"></a>.</dd>
       <dt><code>@graph</code></dt><dd>Used to express a <a>graph</a>.
         This keyword is described in <a class="sectionRef" href="#named-graphs"></a>.</dd>
+      <dt class="changed"><code>@nest</code></dt><dd class="changed">Collects a set of <a>nested properties</a> within
+        a <a>node object</a>.</dd>
       <dt><code>:</code></dt>
       <dd>The separator for JSON keys and values that use
         <a>compact IRIs</a>.</dd>
@@ -2583,6 +2585,85 @@ specified. The full <a>IRI</a> for
   </table>
 </section>
 
+<section class="informative changed">
+  <h2>Nested Properties</h2>
+
+  <p>Many JSON APIs separate properties from their entities using an
+    intermediate object; in JSON-LD these are called <a>nested properties</a>.
+    For example, a set of possible labels may be grouped
+    under a common property:</p>
+  <pre class="example" data-transform="updateExample"
+       title="Nested properties">
+  <!--
+  {
+    "@context": {
+      "skos": "http://www.w3.org/2004/02/skos/core#",
+      ****"labels": "@nest"****,
+      "main_label": {"@id": "skos:prefLabel"},
+      "other_label": {"@id": "skos:altLabel"},
+      "homepage": {"@id": "http://schema.org/description", "@type": "@id"}
+    },
+    "@id": "http://example.org/myresource",
+    "homepage": "http://example.org",
+    "labels": {
+       "main_label": "This is the main label for my resource",
+       "other_label": "This is the other label"
+    }
+  }
+  -->
+  </pre>
+
+  <p>By defining <em>labels</em> using the <a>keyword</a> <code>@nest</code>,
+    a <a>JSON-LD processor</a> will ignore the nesting created by using the
+    <em>labels</em> property and process the contents as if it were declared
+    directly within containing object. In this case, the <em>labels</em>
+    property is semantically meaningless. Defining it as equivalent to
+    <code>@nest</code> causes it to be ignored when expanding, making it
+    equivalent to the following:</p>
+
+  <pre class="example" data-transform="updateExample"
+       title="Nested properties folded into containing object">
+  <!--
+  {
+    "@context": {
+      "skos": "http://www.w3.org/2004/02/skos/core#",
+      "main_label": {"@id": "skos:prefLabel"},
+      "other_label": {"@id": "skos:altLabel"},
+      "homepage": {"@id": "http://schema.org/description", "@type": "@id"}
+    },
+    "@id": "http://example.org/myresource",
+    "homepage": "http://example.org",
+    ****"main_label": "This is the main label for my resource",
+    "other_label": "This is the other label"****
+  }
+  -->
+  </pre>
+
+  <p>Similarly, node definitions may contain a <code>@nest</code> property to
+    reference a term aliased to <code>@nest</code> which causes such
+    values to be nested under that aliased term.</p>
+  <pre class="example" data-transform="updateExample"
+       title="Defining property nesting">
+  <!--
+ {
+   "@context": {
+     "skos": "http://www.w3.org/2004/02/skos/core#",
+     ****"labels": "@nest"****,
+     "main_label": {"@id": "skos:prefLabel", ****"@nest": "labels"****},
+     "other_label": {"@id": "skos:altLabel", ****"@nest": "labels"****},
+     "homepage": {"@id": "http://schema.org/description", "@type": "@id"}
+   },
+   "@id": "http://example.org/myresource",
+   "homepage": "http://example.org",
+   "labels": {
+      "main_label": "This is the main label for my resource",
+      "other_label": "This is the other label"
+   }
+ }
+  -->
+  </pre>
+</section>
+
 <section class="informative">
   <h3>Expanded Document Form</h3>
 
@@ -2989,6 +3070,7 @@ specified. The full <a>IRI</a> for
       <li><code>@context</code>,</li>
       <li><code>@id</code>,</li>
       <li><code>@graph</code>,</li>
+      <li class="changed"><code>@nest</code>,</li>
       <li><code>@type</code>,</li>
       <li><code>@reverse</code>, or</li>
       <li><code>@index</code></li>
@@ -3043,6 +3125,12 @@ specified. The full <a>IRI</a> for
       its value MUST be a <a>string</a>. See
       <a class="sectionRef" href="#data-indexing"></a> for further discussion
       on <code>@index</code> values.</p>
+
+    <p class="changed">If the <a>node object</a> contains the <code>@nest</code> key,
+      its value MUST be an <a>JSON object</a> or an <a>array</a> of <a>JSON objects</a>
+      which MUST NOT include a <a>value object</a>. See
+      <a class="sectionRef" href="#property-nesting"></a> for further discussion
+      on <code>@nest</code> values.</p>
 
     <p>Keys in a <a>node object</a> that are not
       <a>keyword</a> MAY expand to an <a>absolute IRI</a>
@@ -3186,6 +3274,19 @@ specified. The full <a>IRI</a> for
     <p>See <a class="sectionRef" href="#data-indexing"></a> for further information on this topic.</p>
   </section>
 
+  <section class="changed">
+    <h2>Property Nesting</h2>
+
+    <p>A <a>nested property</a> is used to gather <a>properties</a> of a <a>node object</a> in a separate
+      <a>JSON object</a>, or <a>array</a> of <a>JSON objects</a> which are not
+      <a>value objects</a>. It is semantically transparent and is removed
+      during the process of expansion. Property nesting is recursive, and
+      collections of nested properties may contain further nesting.</p>
+
+    <p>Semantically, nesting is treated as if the properties and values were declared directly
+      within the containing <a>node object</a>.</p>
+  </section>
+
 <section class="normative">
   <h2>Context Definitions</h2>
 
@@ -3225,7 +3326,7 @@ specified. The full <a>IRI</a> for
     <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
 
   <p>If an <a>expanded term definition</a> has an <code>@reverse</code> member,
-    it MUST NOT have an <code>@id</code> member at the same time. If an
+    it MUST NOT have <code>@id</code> or <code>@nest</code> members at the same time. If an
     <code>@container</code> member exists, its value MUST be <a>null</a>,
     <code>@set</code>, or <code>@index</code>.</p>
 
@@ -3262,6 +3363,10 @@ specified. The full <a>IRI</a> for
   <p><a>Terms</a> MUST NOT be used in a circular manner. That is,
     the definition of a term cannot depend on the definition of another term if that other
     term also depends on the first term.</p>
+
+  <p>If the <a>expanded term definition</a> contains the <code>@nest</code>
+    <a>keyword</a>, its value MUST be either <code>@nest</code>, or a term
+    which expands to <code>@nest</code>.</p>
 
   <p>See <a class="sectionRef" href="#the-context"></a> for further discussion on contexts.</p>
 </section>
@@ -3451,17 +3556,20 @@ specified. The full <a>IRI</a> for
     <li>An <a>expanded term definition</a> can now have an
       <code>@context</code> property, which defines a <a>context</a> used for values of
       a <a>property</a> identified with such a <a>term</a>.</li>
+    <li>An <a>expanded term definition</a> can now have an
+      <code>@nest</code> property, which identifies a term expanding to
+      <code>@nest</code> which is used for containing properties using the same
+      <code>@nest</code> mapping. When expanding, the values of a property
+      expanding to <code>@nest</code> are treated as if they were contained
+      within the enclosing <a>node object</a> directly.</li>
   </ul>
 </section>
 
 <section class="appendix informative">
   <h4>Open Issues</h4>
   <p>The following is a list of open issues being worked on for the next release.</p>
-  <p class="issue" data-number="12"></p>
   <p class="issue" data-number="195"></p>
   <p class="issue" data-number="246"></p>
-  <p class="issue" data-number="247"></p>
-  <p class="issue" data-number="262"></p>
   <p class="issue" data-number="269"></p>
   <p class="issue" data-number="271"></p>
   <p class="issue" data-number="272"></p>

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -630,6 +630,96 @@
       "context": "compact-c005-context.jsonld",
       "expect": "compact-c005-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Indexes to @nest for property with @nest",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n001-in.jsonld",
+      "context": "compact-n001-context.jsonld",
+      "expect": "compact-n001-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Indexes to @nest for all properties with @nest",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n002-in.jsonld",
+      "context": "compact-n002-context.jsonld",
+      "expect": "compact-n002-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn003",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Nests using alias of @nest",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n003-in.jsonld",
+      "context": "compact-n003-context.jsonld",
+      "expect": "compact-n003-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn004",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Arrays of nested values",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n004-in.jsonld",
+      "context": "compact-n004-context.jsonld",
+      "expect": "compact-n004-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn005",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Nested @container: @list",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n005-in.jsonld",
+      "context": "compact-n005-context.jsonld",
+      "expect": "compact-n005-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn006",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Nested @container: @index",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n006-in.jsonld",
+      "context": "compact-n006-context.jsonld",
+      "expect": "compact-n006-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn007",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Nested @container: @language",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n007-in.jsonld",
+      "context": "compact-n007-context.jsonld",
+      "expect": "compact-n007-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn008",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Nested @container: @type",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n008-in.jsonld",
+      "context": "compact-n008-context.jsonld",
+      "expect": "compact-n008-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn009",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Nested @container: @id",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n009-in.jsonld",
+      "context": "compact-n009-context.jsonld",
+      "expect": "compact-n009-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn010",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Multiple nest aliases",
+      "purpose": "Compaction using @nest",
+      "input": "compact-n010-in.jsonld",
+      "context": "compact-n010-context.jsonld",
+      "expect": "compact-n010-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
     }
   ]
 }

--- a/test-suite/tests/compact-n001-context.jsonld
+++ b/test-suite/tests/compact-n001-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "p2": {"@nest": "@nest"}
+  }
+}

--- a/test-suite/tests/compact-n001-in.jsonld
+++ b/test-suite/tests/compact-n001-in.jsonld
@@ -1,0 +1,4 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [{"@value": "v2"}]
+}]

--- a/test-suite/tests/compact-n001-out.jsonld
+++ b/test-suite/tests/compact-n001-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "p2": {"@nest": "@nest"}
+  },
+  "p1": "v1",
+  "@nest": {
+    "p2": "v2"
+  }
+}

--- a/test-suite/tests/compact-n002-context.jsonld
+++ b/test-suite/tests/compact-n002-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "p1": {"@nest": "@nest"},
+    "p2": {"@nest": "@nest"}
+  }
+}

--- a/test-suite/tests/compact-n002-in.jsonld
+++ b/test-suite/tests/compact-n002-in.jsonld
@@ -1,0 +1,4 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [{"@value": "v2"}]
+}]

--- a/test-suite/tests/compact-n002-out.jsonld
+++ b/test-suite/tests/compact-n002-out.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "p1": {"@nest": "@nest"},
+    "p2": {"@nest": "@nest"}
+  },
+  "@nest": {
+    "p1": "v1",
+    "p2": "v2"
+  }
+}

--- a/test-suite/tests/compact-n003-context.jsonld
+++ b/test-suite/tests/compact-n003-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest": "@nest",
+    "p2": {"@nest": "nest"}
+  }
+}

--- a/test-suite/tests/compact-n003-in.jsonld
+++ b/test-suite/tests/compact-n003-in.jsonld
@@ -1,0 +1,4 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [{"@value": "v2"}]
+}]

--- a/test-suite/tests/compact-n003-out.jsonld
+++ b/test-suite/tests/compact-n003-out.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest": "@nest",
+    "p2": {"@nest": "nest"}
+  },
+  "p1": "v1",
+  "nest": {
+    "p2": "v2"
+  }
+}

--- a/test-suite/tests/compact-n004-context.jsonld
+++ b/test-suite/tests/compact-n004-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "p2": {"@nest": "@nest"}
+  }
+}

--- a/test-suite/tests/compact-n004-in.jsonld
+++ b/test-suite/tests/compact-n004-in.jsonld
@@ -1,0 +1,4 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [{"@value": "v2"}, {"@value": "v3"}]
+}]

--- a/test-suite/tests/compact-n004-out.jsonld
+++ b/test-suite/tests/compact-n004-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "p2": {"@nest": "@nest"}
+  },
+  "p1": "v1",
+  "@nest": {
+    "p2": ["v2", "v3"]
+  }
+}

--- a/test-suite/tests/compact-n005-context.jsonld
+++ b/test-suite/tests/compact-n005-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "list": {"@container": "@list", "@nest": "nestedlist"},
+    "nestedlist": "@nest"
+  }
+}

--- a/test-suite/tests/compact-n005-in.jsonld
+++ b/test-suite/tests/compact-n005-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/list": [{"@list": [
+    {"@value": "a"},
+    {"@value": "b"}
+  ]}]
+}]

--- a/test-suite/tests/compact-n005-out.jsonld
+++ b/test-suite/tests/compact-n005-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "list": {"@container": "@list", "@nest": "nestedlist"},
+    "nestedlist": "@nest"
+  },
+  "nestedlist": {
+    "list": ["a", "b"]
+  }
+}

--- a/test-suite/tests/compact-n006-context.jsonld
+++ b/test-suite/tests/compact-n006-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "index": {"@container": "@index", "@nest": "nestedindex"},
+    "nestedindex": "@nest"
+  }
+}

--- a/test-suite/tests/compact-n006-in.jsonld
+++ b/test-suite/tests/compact-n006-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/index": [
+    {"@value": "a", "@index": "A"},
+    {"@value": "b", "@index": "B"}
+  ]
+}]

--- a/test-suite/tests/compact-n006-out.jsonld
+++ b/test-suite/tests/compact-n006-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "index": {"@container": "@index", "@nest": "nestedindex"},
+    "nestedindex": "@nest"
+  },
+  "nestedindex": {
+    "index": {
+      "A": "a",
+      "B": "b"
+    }
+  }
+}

--- a/test-suite/tests/compact-n007-context.jsonld
+++ b/test-suite/tests/compact-n007-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "container": {"@container": "@language", "@nest": "nestedlanguage"},
+    "nestedlanguage": "@nest"
+  }
+}

--- a/test-suite/tests/compact-n007-in.jsonld
+++ b/test-suite/tests/compact-n007-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example.org/container": [
+    {"@value": "Die Königin", "@language": "de"},
+    {"@value": "The Queen", "@language": "en"}
+  ]
+}]

--- a/test-suite/tests/compact-n007-out.jsonld
+++ b/test-suite/tests/compact-n007-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "container": {"@container": "@language", "@nest": "nestedlanguage"},
+    "nestedlanguage": "@nest"
+  },
+  "nestedlanguage": {
+    "container": {
+      "en": "The Queen",
+      "de": "Die Königin"
+    }
+  }
+}

--- a/test-suite/tests/compact-n008-context.jsonld
+++ b/test-suite/tests/compact-n008-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type", "@nest": "nestedtypemap"},
+    "nestedtypemap": "@nest"
+  }
+}

--- a/test-suite/tests/compact-n008-in.jsonld
+++ b/test-suite/tests/compact-n008-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example/typemap": [
+    {"http://example/label": [{"@value": "Object with @type _:bar"}], "@type": ["_:bar"]},
+    {"http://example/label": [{"@value": "Object with @type <foo>"}], "@type": ["http://example.org/foo"]}
+  ]
+}]

--- a/test-suite/tests/compact-n008-out.jsonld
+++ b/test-suite/tests/compact-n008-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type", "@nest": "nestedtypemap"},
+    "nestedtypemap": "@nest"
+  },
+  "nestedtypemap": {
+    "typemap": {
+      "_:bar": {"label": "Object with @type _:bar"},
+      "http://example.org/foo": {"label": "Object with @type <foo>"}
+    }
+  }
+}

--- a/test-suite/tests/compact-n009-context.jsonld
+++ b/test-suite/tests/compact-n009-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id", "@nest": "nestedidmap"},
+    "nestedidmap": "@nest"
+  }
+}

--- a/test-suite/tests/compact-n009-in.jsonld
+++ b/test-suite/tests/compact-n009-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "http://example/idmap": [
+    {"http://example/label": [{"@value": "Object with @id _:bar"}], "@id": "_:bar"},
+    {"http://example/label": [{"@value": "Object with @id <foo>"}], "@id": "http://example.org/foo"}
+  ]
+}]

--- a/test-suite/tests/compact-n009-out.jsonld
+++ b/test-suite/tests/compact-n009-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id", "@nest": "nestedidmap"},
+    "nestedidmap": "@nest"
+  },
+  "nestedidmap": {
+    "idmap": {
+      "http://example.org/foo": {"label": "Object with @id <foo>"},
+      "_:bar": {"label": "Object with @id _:bar"}
+    }
+  }
+}

--- a/test-suite/tests/compact-n010-context.jsonld
+++ b/test-suite/tests/compact-n010-context.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "foonest": "@nest",
+    "barnest": "@nest",
+    "foo": {"@nest": "foonest"},
+    "bar": {"@nest": "barnest"}
+  }
+}

--- a/test-suite/tests/compact-n010-in.jsonld
+++ b/test-suite/tests/compact-n010-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "http://example.org/foo": "bar",
+  "http://example.org/bar": "foo"
+}

--- a/test-suite/tests/compact-n010-out.jsonld
+++ b/test-suite/tests/compact-n010-out.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "foonest": "@nest",
+    "barnest": "@nest",
+    "foo": {"@nest": "foonest"},
+    "bar": {"@nest": "barnest"}
+  },
+  "barnest": {"bar": "foo"},
+  "foonest": {"foo": "bar"}
+}

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -309,12 +309,70 @@
       "input": "error-0043-in.jsonld",
       "expect": "conflicting indexes"
     }, {
-      "@id": "#t1001",
+      "@id": "#tc001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
       "name": "Invalid keyword in term definition",
       "purpose": "Verifies that an exception is raised on expansion when a invalid term definition is found",
       "input": "error-c001-in.jsonld",
-      "expect": "invalid term definition"
+      "expect": "invalid term definition",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn001",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
+      "name": "@nest MUST NOT have a string value",
+      "purpose": "container: @nest",
+      "input": "error-n001-in.jsonld",
+      "expect": "invalid @nest value",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn002",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
+      "name": "@nest MUST NOT have a boolen value",
+      "purpose": "Transparent Nesting",
+      "input": "error-n002-in.jsonld",
+      "expect": "invalid @nest value",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn003",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
+      "name": "@nest MUST NOT have a numeric value",
+      "purpose": "Transparent Nesting",
+      "input": "error-n003-in.jsonld",
+      "expect": "invalid @nest value",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn004",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
+      "name": "@nest MUST NOT have a value object value",
+      "purpose": "Transparent Nesting",
+      "input": "error-n004-in.jsonld",
+      "expect": "invalid @nest value",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn005",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
+      "name": "does not allow a keyword other than @nest for the value of @nest",
+      "purpose": "Transparent Nesting",
+      "input": "error-n005-in.jsonld",
+      "expect": "invalid @nest value",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn006",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
+      "name": "does not allow @nest with @reverse",
+      "purpose": "Transparent Nesting",
+      "input": "error-n006-in.jsonld",
+      "expect": "invalid reverse property",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn007",
+      "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
+      "name": "Nest term not defined",
+      "purpose": "Transparent Nesting",
+      "input": "error-n007-in.jsonld",
+      "context": "error-n007-context.jsonld",
+      "expect": "invalid @nest value",
+      "option": {"processingMode": "json-ld-1.1"}
     }
   ]
 }

--- a/test-suite/tests/error-n001-in.jsonld
+++ b/test-suite/tests/error-n001-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": {"@vocab": "http://example.org/"},
+  "@nest": "This should generate an error"
+}

--- a/test-suite/tests/error-n002-in.jsonld
+++ b/test-suite/tests/error-n002-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": {"@vocab": "http://example.org/"},
+  "@nest": true
+}

--- a/test-suite/tests/error-n003-in.jsonld
+++ b/test-suite/tests/error-n003-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": {"@vocab": "http://example.org/"},
+  "@nest": 1
+}

--- a/test-suite/tests/error-n004-in.jsonld
+++ b/test-suite/tests/error-n004-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@context": {"@vocab": "http://example.org/"},
+  "@nest": {"@value": "This should generate an error"}
+}

--- a/test-suite/tests/error-n005-in.jsonld
+++ b/test-suite/tests/error-n005-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "term": {"@id": "http://example/term", "@nest": "@id"}
+  }
+}

--- a/test-suite/tests/error-n006-in.jsonld
+++ b/test-suite/tests/error-n006-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "term": {"@reverse": "http://example/term", "@nest": "@nest"}
+  }
+}

--- a/test-suite/tests/error-n007-context.jsonld
+++ b/test-suite/tests/error-n007-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "term": {"@id": "http://example/foo", "@nest": "unknown"}
+  }
+}

--- a/test-suite/tests/error-n007-in.jsonld
+++ b/test-suite/tests/error-n007-in.jsonld
@@ -1,0 +1,3 @@
+{
+  "http://example/foo": "bar"
+}

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -598,6 +598,62 @@
       "input": "expand-c005-in.jsonld",
       "expect": "expand-c005-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
+   }, {
+      "@id": "#tn001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expands input using @nest",
+      "purpose": "Expansion using @nest",
+      "input": "expand-n001-in.jsonld",
+      "expect": "expand-n001-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expands input using @nest",
+      "purpose": "Expansion using @nest",
+      "input": "expand-n002-in.jsonld",
+      "expect": "expand-n002-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn003",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expands input using @nest",
+      "purpose": "Expansion using @nest",
+      "input": "expand-n003-in.jsonld",
+      "expect": "expand-n003-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn004",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expands input using @nest",
+      "purpose": "Expansion using @nest",
+      "input": "expand-n004-in.jsonld",
+      "expect": "expand-n004-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn005",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expands input using @nest",
+      "purpose": "Expansion using @nest",
+      "input": "expand-n005-in.jsonld",
+      "expect": "expand-n005-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn006",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expands input using @nest",
+      "purpose": "Expansion using @nest",
+      "input": "expand-n006-in.jsonld",
+      "expect": "expand-n006-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tn007",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Expands input using @nest",
+      "purpose": "Expansion using @nest",
+      "input": "expand-n007-in.jsonld",
+      "expect": "expand-n007-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
     }
   ]
 }

--- a/test-suite/tests/expand-n001-in.jsonld
+++ b/test-suite/tests/expand-n001-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {"@vocab": "http://example.org/"},
+  "p1": "v1",
+  "@nest": {
+    "p2": "v2"
+  }
+}

--- a/test-suite/tests/expand-n001-out.jsonld
+++ b/test-suite/tests/expand-n001-out.jsonld
@@ -1,0 +1,4 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [{"@value": "v2"}]
+}]

--- a/test-suite/tests/expand-n002-in.jsonld
+++ b/test-suite/tests/expand-n002-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest": "@nest"
+  },
+  "p1": "v1",
+  "nest": {
+    "p2": "v2"
+  }
+}

--- a/test-suite/tests/expand-n002-out.jsonld
+++ b/test-suite/tests/expand-n002-out.jsonld
@@ -1,0 +1,4 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [{"@value": "v2"}]
+}]

--- a/test-suite/tests/expand-n003-in.jsonld
+++ b/test-suite/tests/expand-n003-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest": "@nest"
+  },
+  "p1": "v1",
+  "nest": {
+    "p2": "v3"
+  },
+  "p2": "v2"
+}

--- a/test-suite/tests/expand-n003-out.jsonld
+++ b/test-suite/tests/expand-n003-out.jsonld
@@ -1,0 +1,7 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [
+    {"@value": "v2"},
+    {"@value": "v3"}
+  ]
+}]

--- a/test-suite/tests/expand-n004-in.jsonld
+++ b/test-suite/tests/expand-n004-in.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest1": "@nest",
+    "nest2": "@nest"
+  },
+  "p1": "v1",
+  "nest2": {
+    "p2": "v4"
+  },
+  "p2": "v2",
+  "nest1": {
+    "p2": "v3"
+  }
+}

--- a/test-suite/tests/expand-n004-out.jsonld
+++ b/test-suite/tests/expand-n004-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [
+    {"@value": "v2"},
+    {"@value": "v3"},
+    {"@value": "v4"}
+  ]
+}]

--- a/test-suite/tests/expand-n005-in.jsonld
+++ b/test-suite/tests/expand-n005-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/"
+  },
+  "p1": "v1",
+  "@nest": {
+    "p2": "v3",
+    "@nest": {
+      "p2": "v4"
+    }
+  },
+  "p2": "v2"
+}

--- a/test-suite/tests/expand-n005-out.jsonld
+++ b/test-suite/tests/expand-n005-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [
+    {"@value": "v2"},
+    {"@value": "v3"},
+    {"@value": "v4"}
+  ]
+}]

--- a/test-suite/tests/expand-n006-in.jsonld
+++ b/test-suite/tests/expand-n006-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest": "@nest"
+  },
+  "p1": "v1",
+  "nest": {
+    "p2": ["v4", "v5"]
+  },
+  "p2": ["v2", "v3"]
+}

--- a/test-suite/tests/expand-n006-out.jsonld
+++ b/test-suite/tests/expand-n006-out.jsonld
@@ -1,0 +1,9 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [
+    {"@value": "v2"},
+    {"@value": "v3"},
+    {"@value": "v4"},
+    {"@value": "v5"}
+  ]
+}]

--- a/test-suite/tests/expand-n007-in.jsonld
+++ b/test-suite/tests/expand-n007-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "nest": "@nest"
+  },
+  "p1": "v1",
+  "nest": [{
+    "p2": "v4"
+  }, {
+    "p2": "v5"
+  }],
+  "p2": ["v2", "v3"]
+}

--- a/test-suite/tests/expand-n007-out.jsonld
+++ b/test-suite/tests/expand-n007-out.jsonld
@@ -1,0 +1,9 @@
+[{
+  "http://example.org/p1": [{"@value": "v1"}],
+  "http://example.org/p2": [
+    {"@value": "v2"},
+    {"@value": "v3"},
+    {"@value": "v4"},
+    {"@value": "v5"}
+  ]
+}]


### PR DESCRIPTION
This introduces the `@nest` keyword, used for folding contained properties to the enclosing node object, and allows for `@nest` in a term definition, to introduce such nesting when compacting.

Fixes #246. This also is an alternative to PR #451 and is (mostly) independent of #449).

In contrast to #451, having a parallel `@nest` term definition property allows this to be used in conjunction with `@container` (but not for `@reverse` compaction).

There are several new expand, compact and error tests for this feature.

Formatted HTML versions are available for [JSON-LD](http://gkellogg.github.io/json-ld.org/spec/latest/json-ld/), and [JSON-LD-API](http://gkellogg.github.io/json-ld.org/spec/latest/json-ld-api/) on my personal fork.