### PR TITLE
Issue 415 scope on type

### DIFF
--- a/spec/latest/common/terms.html
+++ b/spec/latest/common/terms.html
@@ -2,7 +2,7 @@
 <section>
   <h1>General Terminology</h1>
   <p>This document uses the following terms as defined in JSON [[!RFC7159]]. Refer
-    to the <a data-cite="rfc7159#section-2">JSON Grammar section</a> in [[!RFC7159]] for formal definitions.</p>
+    to the <a data-cite="RFC7159#section-2">JSON Grammar section</a> in [[!RFC7159]] for formal definitions.</p>
 
   <dl class="termlist">
     <dt><dfn data-lt="arrays">array</dfn></dt><dd>
@@ -15,14 +15,14 @@
       unless specifically defined (see
       <a data-cite="JSON-LD#sets-and-lists" class="externalDFN">Sets and Lists</a> in
       the JSON-LD specification [[JSON-LD]]).</dd>
-    <dt><dfn data-cite="ecmascript-6.0#sec-terms-and-definitions-object" data-lt="JSON objects">JSON object</dfn></dt><dd>
+    <dt><dfn data-cite="ECMASCRIPT-6.0#sec-terms-and-definitions-object" data-lt="JSON objects">JSON object</dfn></dt><dd>
       In the JSON serialization, an object structure is represented as a pair of curly brackets surrounding zero or
       more key-value pairs. A key is a <a>string</a>. A single colon comes after
       each key, separating the key from the value. A single comma separates a value
       from a following key. In JSON-LD the keys in an object MUST be unique.
       In the <em>abstract representation</em> a <a>JSON object</a> is equivalent to a
       <a data-cite="WebIDL#dfn-dictionary" class="externalDFN"><dfn data-lt="dictionaries">dictionary</dfn></a> (see [[WebIDL]]).</dd>
-    <dt><dfn data-cite="ecmascript-6.0#sec-null-value">null</dfn></dt><dd>
+    <dt><dfn data-cite="ECMASCRIPT-6.0#sec-null-value">null</dfn></dt><dd>
       The use of the <a>null</a> value within JSON-LD is used to
       ignore or reset values. A key-value pair in the <code>@context</code> where
       the value, or the <code>@id</code> of the value, is <a>null</a>
@@ -32,7 +32,7 @@
       <code>@value</code>, <code>@list</code>, or <code>@set</code> is set to
       <a>null</a> in expanded form, then the entire <a>JSON
       object</a> is ignored.</dd>
-    <dt><dfn data-cite="ecmascript-6.0#sec-number-object" data-lt="numbers|JSON number|JSON numbers">number</dfn></dt><dd>
+    <dt><dfn data-cite="ECMASCRIPT-6.0#sec-number-object" data-lt="numbers|JSON number|JSON numbers">number</dfn></dt><dd>
       In the JSON serialization, a number is similar to that used in most programming languages, except
       that the octal and hexadecimal formats are not used and that leading
       zeros are not allowed.
@@ -43,7 +43,7 @@
     <dt><dfn>scalar</dfn></dt><dd>
       A scalar is either a JSON <a>string</a>, <a>number</a>, <a>true</a>,
       or <a>false</a>.</dd>
-    <dt><dfn data-cite="ecmascript-6.0#sec-string-object" data-lt="strings">string</dfn></dt><dd>
+    <dt><dfn data-cite="ECMASCRIPT-6.0#sec-string-object" data-lt="strings">string</dfn></dt><dd>
       A string is a sequence of zero or more Unicode (UTF-8) characters,
       wrapped in double quotes, using backslash escapes (if necessary). A
       character is represented as a single character string.</dd>
@@ -55,21 +55,21 @@
   <p>Furthermore, the following terminology is used throughout this document:</p>
 
   <dl class="termlist">
-    <dt><dfn data-cite="rfc3987#section-1.3" data-lt="absolute IRIs">absolute IRI</dfn></dt><dd>
+    <dt><dfn data-cite="RFC3987#section-1.3" data-lt="absolute IRIs">absolute IRI</dfn></dt><dd>
       An <a>absolute IRI</a> is defined in [[!RFC3987]] containing a <em>scheme</em> along with a <em>path</em> and
       optional <em>query</em> and fragment segments.</dd>
     <dt><dfn data-lt="base IRIs">base IRI</dfn></dt><dd>
       The <a>base IRI</a> is an <a>absolute IRI</a> established in the <a>context</a>,
       or is based on the <a>JSON-LD document</a> location. The <a>base IRI</a> is used to turn
       <a>relative IRIs</a> into <a>absolute IRIs</a>.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-blank-node" data-lt="blank nodes">blank node</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node" data-lt="blank nodes">blank node</dfn></dt><dd>
       A <a>node</a> in a <a>graph</a> that is neither an
       <a>IRI</a>, nor a <a>JSON-LD value</a>, nor a <a>list</a>.
       A <a>node</a> does not contain a de-referenceable
       identifier because it is either ephemeral in nature or does not contain information that needs to be
       linked to from outside of the linked data graph. A blank node is assigned an identifier starting with
       the prefix <code>_:</code>.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-blank-node-identifier" data-lt="blank node identifiers">blank node identifier</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" data-lt="blank node identifiers">blank node identifier</dfn></dt><dd>
       A blank node identifier is a string that can be used as an identifier for a
       <a>blank node</a> within the scope of a JSON-LD document. Blank node identifiers
       begin with <code>_:</code>.</dd>
@@ -80,10 +80,10 @@
     <dt><dfn data-lt="contexts">context</dfn></dt><dd>
       A a set of rules for interpreting a <a>JSON-LD document</a> as specified in
       <cite><a data-cite="JSON-LD#the-context">The Context</a> of the [[JSON-LD]] specification.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-datatype-iri">datatype IRI</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-datatype-iri">datatype IRI</dfn></dt><dd>
       A <a>datatype IRI</a>
       as specified by [[RDF11-CONCEPTS]].</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-default-graph">default graph</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-default-graph">default graph</dfn></dt><dd>
       The default graph is the only graph in a JSON-LD document which has no <a>graph name</a>.
       When executing an algorithm, the graph where data should be placed
       if a <a>named graph</a> is not specified.</dd>
@@ -108,7 +108,7 @@
       A frame object is a a <a>dictionary</a> element withing a <a>frame</a>
       which represents a specific portion of the <a>frame</a> matching either a
       <a>node object</a> or a <a>value object</a> in the input.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-graph-name" data-lt="graph names">graph name</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-graph-name" data-lt="graph names">graph name</dfn></dt><dd>
       The <a>IRI</a> identifying a <a>named graph</a>.</dd>
     <dt class="changed"><dfn data-lt="id maps">id map</dfn></dt><dd class="changed">
       An <a>id map</a> is a <a>JSON object</a> value of a <a>term</a> defined with
@@ -131,7 +131,7 @@
         <a>set object</a>, or
         an <a>array</a> of zero or more of the above possibilities.
       </dd>
-    <dt><dfn data-cite="rfc3987#section-1.3" data-lt="IRIs|Internationalized Resource Identifier"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
+    <dt><dfn data-cite="RFC3987#section-1.3" data-lt="IRIs|Internationalized Resource Identifier"><abbr title="Internationalized Resource Identifier">IRI</abbr></dfn></dt><dd>
       An Internationalized Resource Identifier as described in [[!RFC3987]].</dd>
     <dt><dfn data-lt="JSON-LD documents">JSON-LD document</dfn></dt><dd>
       A <a>JSON-LD document</a> is a serialization of a collection of
@@ -152,25 +152,25 @@
         <a>string</a>, or
         an <a>array</a> of zero or more of the above possibilities.
       </dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-language-tagged-string" data-lt="language-tagged strings">language-tagged string</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-language-tagged-string" data-lt="language-tagged strings">language-tagged string</dfn></dt><dd>
       A <a>language-tagged string</a> consists of a string and a non-empty language
-      tag as defined by [[!BCP47]]. The <dfn data-cite="rdf11-concepts#dfn-language-tag">language tag</dfn> MUST be well-formed according to
-      <a data-cite="bcp47#section-2.2.9">section 2.2.9 Classes of Conformance</a>
+      tag as defined by [[!BCP47]]. The <dfn data-cite="RDF11-CONCEPTS#dfn-language-tag">language tag</dfn> MUST be well-formed according to
+      <a data-cite="BCP47#section-2.2.9">section 2.2.9 Classes of Conformance</a>
       of [[!BCP47]], and is normalized to lowercase.</dd>
     <dt><dfn>Linked Data</dfn></dt><dd>
       A set of documents, each containing a representation of a <a>linked data graph</a>.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-rdf-graph" data-lt="graph|graphs">linked data graph</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-graph" data-lt="graph|graphs">linked data graph</dfn></dt><dd>
       A labeled directed graph, i.e., a set of <a>nodes</a>
       connected by <a>edges</a>,
       as specified in the <a data-cite="JSON-LD#data-model">Data Model</a>
       section of the JSON-LD specification [[!JSON-LD]].
       A <a>linked data graph</a> is a generalized representation of a
-      <a data-cite="rdf11-concepts#dfn-rdf-graph">RDF graph</a>
+      <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graph</a>
       as defined in [[!RDF-CONCEPTS]].</dd>
     <dt><dfn data-lt="lists">list</dfn></dt><dd>
       A <a>list</a> is an ordered sequence of <a>IRIs</a>,
       <a>blank nodes</a>, and <a>JSON-LD values</a>.
-      See <dfn data-cite="rdf-schema#ch_collectionvocab" data-lt="collection">RDF collection</dfn>
+      See <dfn data-cite="RDF-SCHEMA#ch_collectionvocab" data-lt="collection">RDF collection</dfn>
       in [[RDF-SCHEMA]].</dd>
     <dt><dfn data-lt="list objects">list object</dfn></dt><dd>
       A <a>list object</a> is a <a>JSON object</a> that has an <code>@list</code>
@@ -180,13 +180,13 @@
     <dt><dfn data-lt="local contexts">local context</dfn></dt><dd>
       A <a>context</a> that is specified within a <a>JSON object</a>,
       specified via the <code>@context</code> <a>keyword</a>.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-named-graph" data-lt="named graphs">named graph</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-named-graph" data-lt="named graphs">named graph</dfn></dt><dd>
       A <a>linked data graph</a> that is identified by an <a>IRI</a> or <a>blank node</a>
     <dt><dfn data-lt="nested properties">nested property</dfn></dt><dd>
       A <a>nested property</a> is a <a>property</a> which is contained within an object referenced by
       a semantically meaningless <em>nesting property</em>.
     </dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-node" data-lt="nodes">node</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-node" data-lt="nodes">node</dfn></dt><dd>
       Every <a>node</a> is an <a>IRI</a>, a <a>blank node</a>,
       a <a>JSON-LD value</a>, or a <a>list</a>.
       A piece of information that is represented in a <a>linked data graph</a>.</dd>
@@ -205,34 +205,34 @@
     <dt><dfn data-lt="node references">node reference</dfn></dt><dd>
       A <a>node object</a> used to reference a node having only the
       <code>@id</code> key.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-object" data-lt="objects">object</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-object" data-lt="objects">object</dfn></dt><dd>
       A <a>node</a> in a <a>linked data graph</a> with at least one incoming edge.
-      See <dfn data-cite="rdf11-concepts#dfn-object">RDF object</dfn>in [[RDF11-CONCEPTS]].</dd>
+      See <dfn data-cite="RDF11-CONCEPTS#dfn-object">RDF object</dfn>in [[RDF11-CONCEPTS]].</dd>
       <dt><dfn data-lt="prefixes">prefix</dfn></dt><dd>
       A <a>prefix</a> is a <a>term</a> that expands to a vocabulary <a>base IRI</a>. It
       is typically used along with a <em>suffix</em> to form a <a>compact IRI</a> to create an IRI
       within a vocabulary.</dd>
     <dt><dfn data-lt="properties">property</dfn></dt><dd>
       The <a>IRI</a> label of an edge in a <a>linked data graph</a>.
-      See <dfn data-cite="rdf11-concepts#dfn-predicate" data-lt="predicate|predicates|RDF predicates">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
+      See <dfn data-cite="RDF11-CONCEPTS#dfn-predicate" data-lt="predicate|predicates|RDF predicates">RDF predicate</dfn> in [[RDF11-CONCEPTS]].</dd>
       <dt><dfn data-lt="quads">quad</dfn></dt><dd>
       A piece of information that contains four items; a <a>subject</a>, a <a>property</a>,
       an <a>object</a>, and a <a>graph name</a>.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-rdf-dataset" data-lt="dataset">RDF dataset</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-dataset" data-lt="dataset">RDF dataset</dfn></dt><dd>
       A <a>dataset</a> as specified by [[RDF11-CONCEPTS]] representing a collection of
-      <a data-cite="rdf11-concepts#dfn-rdf-graph">RDF graphs</a>.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-resource" data-lt="resource">RDF resource</dfn></dt><dd>
+      <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graphs</a>.</dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-resource" data-lt="resource">RDF resource</dfn></dt><dd>
       A <a>resource</a> as specified by [[RDF11-CONCEPTS]].</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-rdf-triple" data-lt="triple|triples|RDF triples">RDF triple</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-rdf-triple" data-lt="triple|triples|RDF triples">RDF triple</dfn></dt><dd>
       A <a>triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
     <dt><dfn data-lt="relative IRIs">relative IRI</dfn></dt><dd>
       A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>.</dd>
     <dt><dfn>set object</dfn></dt><dd>
       A <a>set object</a> is a <a>JSON object</a> that has an <code>@set</code>
       member.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-subject" data-lt="subjects">subject</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-subject" data-lt="subjects">subject</dfn></dt><dd>
       A <a>node</a> in a <a>linked data graph</a> with at least one outgoing edge, related to an <a>object</a> node through a <a>property</a>.
-      See <dfn data-cite="rdf11-concepts#dfn-subject">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
+      See <dfn data-cite="RDF11-CONCEPTS#dfn-subject">RDF subject</dfn> in [[RDF11-CONCEPTS]].</dd>
       <dt><dfn data-lt="terms">term</dfn></dt><dd>
       A <a>term</a> is a short word defined in a <a>context</a> that MAY be expanded to an <a>IRI</a>
     </dd>
@@ -249,10 +249,10 @@
       value MUST be a <a>node object</a>, or <a>array</a> of node objects.
       If the value contains a property expanding to <code>@type</code>, it's values
       are merged with the map value when expanding.</dd>
-    <dt><dfn data-cite="rdf11-concepts#dfn-typed-literal">typed literal</dfn></dt><dd>
+    <dt><dfn data-cite="RDF11-CONCEPTS#dfn-typed-literal">typed literal</dfn></dt><dd>
       A <a>typed literal</a> is a <a>literal</a> with an associated <a>IRI</a>
       which indicates the literal's datatype.
-      See <dfn data-cite="rdf11-concepts#dfn-literal" data-lt="RDF literals">RDF literal</dfn> in [[!RDF-CONCEPTS]].</dd>
+      See <dfn data-cite="RDF11-CONCEPTS#dfn-literal" data-lt="RDF literals">RDF literal</dfn> in [[!RDF-CONCEPTS]].</dd>
     <dt><dfn data-lt="typed values">typed value</dfn></dt><dd>
       A <a>typed value</a> consists of a value, which is a <a>string</a>, and a type,
       which is an <a>IRI</a>.</dd>
@@ -322,7 +322,7 @@
       as a stack with elements from the previous <a>processor state</a>
       copied into a new <a>processor state</a> when entering a new
       <a>JSON object</a>.</dd>
-    <dt><dfn data-cite="ecmascript-6.0#sec-promise-objects" data-lt="promises">promise</dfn></dt><dd>
+    <dt><dfn data-cite="ECMASCRIPT-6.0#sec-promise-objects" data-lt="promises">promise</dfn></dt><dd>
       A <em>promise</em> is an object that represents the eventual result of a single asynchronous operation.
       Promises are defined in [[ECMASCRIPT-6.0]].</dd>
     <dt><dfn>require all flag</dfn></dt><dd>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1278,6 +1278,22 @@
           <a href="#context-processing-algorithm">Context Processing algorithm</a>,
           passing <a>active context</a> and the value of the
           <code>@context</code> key as <a>local context</a>.</li>
+        <li class="changed">For each <em>key</em>/<em>value</em> pair in <em>element</em>
+          ordered lexicographically by <em>key</em> where <em>key</em> expands
+          to <code>@type</code> using the
+          <a href="#iri-expansion">IRI Expansion algorithm</a>,
+          passing <a>active context</a>, <em>key</em> for
+          <em>value</em>, and <code>true</code> for <em>vocab</em>:
+          <ol class="algorithm">
+            <li>For each <em>term</em> which is a value of <em>value</em>,
+              if <em>term</em>'s <a>term definition</a> in <a>active context</a>
+              has a <a>local context</a>, set <a>active context</a> to the result
+              to the result of the
+              <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+              passing <a>active context</a> and the value of the
+              <em>term</em>'s <a>local context</a> as <a>local context</a>.</li>
+          </ol>
+        </li>
         <li>Initialize an empty <a>JSON object</a>, <em>result</em>.</li>
         <li id="alg-expand-each-key-value">For each <em>key</em> and <em>value</em> in <em>element</em>,
           ordered lexicographically by <em>key</em>:
@@ -1494,12 +1510,21 @@
                 <li>For each key-value pair <em>index</em>-<em>index value</em>
                   in <em>value</em>, ordered lexicographically by <em>index</em>:
                   <ol class="algorithm">
+                    <li class="changed">If <a>container mapping</a> is <code>@type</code>,
+                      and <em>index</em>'s <a>term definition</a> in
+                      <em>term context</em> has a <a>local context</a>, set
+                      <em>map context</em> to the result of the <a
+                      href="#context-processing-algorithm">Context Processing
+                      algorithm</a>, passing <em>term context</em> as <a>active context</a> and the
+                      value of the <em>index</em>'s <a>local context</a> as
+                      <a>local context</a>. Otherwise, set <em>map context</em>
+                      to <em>term context</em>.</li>
                     <li>If <em>index value</em> is not an <a>array</a>
                       set it to an <a>array</a> containing only
                       <em>index value</em>.</li>
                     <li>Initialize <em>index value</em> to the result of
                       using this algorithm recursively, passing
-                      <em class="changed">term context</em> as <a>active context</a>,
+                      <em class="changed">map context</em> as <a>active context</a>,
                       <em>key</em> as <a>active property</a>,
                       and <em>index value</em> as <em>element</em>.</li>
                     <li>For each <em>item</em> in <em>index value</em>:
@@ -1883,12 +1908,28 @@
                       <li>Initialize <em>compacted value</em> to an empty
                         <a>array</a>.</li>
                       <li>For each item <em>expanded type</em> in
-                        <em>expanded value</em>, append the result of
-                        of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-                        passing <a>active context</a>, <a>inverse context</a>,
-                        <em>expanded type</em> for <em>iri</em>, and
-                        <code>true</code> for <em>vocab</em>,
-                        to <em>compacted value</em>.</li>
+                        <em>expanded value</em>:
+                        <ol class="algorithm">
+                          <li>Set <em>term</em> to the result of
+                            of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+                            passing <a>active context</a>, <a>inverse context</a>,
+                            <em>expanded type</em> for <em>iri</em>, and
+                            <code>true</code> for <em>vocab</em>.</li>
+                          <li class="changed">If the <a>term definition</a> for <em>term</em> has a
+                            <a>local context</a>:
+                            <ol class="algorithm">
+                              <li>Set <a>active context</a> to the result of the
+                                <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+                                passing <a>active context</a> and the value of <em>term</em>'s
+                                <a>local context</a> as <a>local context</a>.</li>
+                              <li>Set <a>inverse context</a> using the
+                                <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
+                                using <a>active context</a>.</li>
+                            </ol>
+                          </li>
+                          <li>Append <em>term</em>, to <em>compacted value</em>.</li>
+                        </ol>
+                      </li>
                       <li>If <em>compacted value</em> contains only one
                         item (it has a length of <code>1</code>), then
                         set <em>compacted value</em> to its only item.</li>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1512,13 +1512,23 @@
                         <li>Otherwise, if <a>container mapping</a> is <code>@id</code>
                           and <em>item</em> does not have the key
                           <code>@id</code>, add the key-value pair
-                          (<code>@id</code>-<em>index</em>) to
-                          <em>item</em>.</li>
+                          (<code>@id</code>-<em>expanded index</em>) to
+                          <em>item</em>, where <em>expanded index</em> is set to the result of
+                          using the
+                          <a href="#iri-expansion">IRI Expansion algorithm</a>,
+                          passing <a>active context</a>, <em>index</em>, and <code>true</code>
+                          for <em>document relative</em>.</li>
                         <li>Otherwise, if <a>container mapping</a> is <code>@type</code>
-                          set <em>types</em> to the concatenation of <em>index
-                          value</em> with any existing values of
-                          <code>@type</code> in <em>item</em> and add the
-                          key-value pair (<code>@type</code>-<em>types</em>) to
+                          set <em>types</em> to the concatenation of
+                          <em>expanded index</em> with any existing values of
+                          <code>@type</code> in <em>item</em>, where
+                          <em>expanded index</em> is set to the result of using
+                          the <a href="#iri-expansion">IRI Expansion
+                          algorithm</a>, passing <a>active context</a>,
+                          <em>index</em>, <code>true</code> for <em>vocab</em>,
+                          and <code>true</code> for <em>document relative</em>
+                          and add the key-value pair
+                          (<code>@type</code>-<em>types</em>) to
                           <em>item</em>.</li>
                         <li>Append <em>item</em> to <em>expanded value</em>.</li>
                       </ol>
@@ -2082,22 +2092,24 @@
                       <em>compacted item</em> contains the key
                       <code>@value</code>, then set <em>compacted item</em>
                       to the value associated with its <code>@value</code> key.</li>
-                    <li>If <em>container</em> is <code>@index</code>,
-                      set <em>map key</em> to the value associated with
-                      with the key that equals <em>container</em> in
-                      <em>expanded item</em>.</li>
                     <li class="changed">If <em>container</em> is <code>@id</code>, set
-                      <em>map key</em> to the value associated with the key that equals
-                      <em>compacted container</em> in <em>compacted item</em>
-                      and remove that key-value pair from <em>compacted item</em>.</li>
+                      <em>map key</em> to the result of calling the <a
+                      href="#iri-compaction">IRI Compaction algorithm</a>
+                      passing <a>active context</a> and the value associated with
+                      the key that equals <em>compacted container</em> in
+                      <em>compacted item</em> as <em>iri</em>.</li>
                     <li class="changed">If <em>container</em> is <code>@type</code>,
-                      set <em>map key</em> to the first value associated with
-                      the key that equals <em>container</em> in <em>expanded
-                      item</em>. If there are remaining values in <em>compacted
-                      item</em> for <em>compacted container</em>, set the value
-                      of <em>compacted container</em> in <em>compacted
-                      value</em> to those remaining values. Otherwise, remove
-                      that key-value pair from <em>compacted item</em>.</li>
+                      set <em>map key</em> to the result of calling the <a
+                      href="#iri-compaction">IRI Compaction algorithm</a>
+                      passing <a>active context</a>, the the first value
+                      associated with the key that equals <em>compacted
+                      container</em> in <em>compacted item</em> as
+                      <em>iri</em>, and <code>true</code> for <em>vocab</em>.
+                      If there are remaining values in <em>compacted item</em>
+                      for <em>compacted container</em>, set the value of
+                      <em>compacted container</em> in <em>compacted value</em>
+                      to those remaining values. Otherwise, remove that
+                      key-value pair from <em>compacted item</em>.</li>
                     <li>If <em>map key</em> is not a key in <em>map object</em>,
                       then set this key's value in <em>map object</em>
                       to <em>compacted item</em>. Otherwise, if the value

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -177,7 +177,7 @@
   </ul>
 
   <p>To understand the basics in this specification you must first be familiar with
-    <a data-cite="rfc7159">JSON</a>, which is detailed in [[!RFC7159]]. You must also understand the
+    <a data-cite="RFC7159">JSON</a>, which is detailed in [[!RFC7159]]. You must also understand the
     <a data-cite="JSON-LD">JSON-LD syntax</a> defined in [[!JSON-LD]], which is the base syntax used by all
     of the algorithms in this document. To understand the API and how it is
     intended to operate in a programming environment, it is useful to have working
@@ -717,16 +717,16 @@
               <ol class="algorithm">
                 <li>Set <em>context</em> to the result of resolving <em>value</em> against
                   the base IRI which is established as specified in
-                  <a data-cite="rfc3986#section-5.1">section 5.1 Establishing a Base URI</a>
+                  <a data-cite="RFC3986#section-5.1">section 5.1 Establishing a Base URI</a>
                   of [[!RFC3986]]. Only the basic algorithm in
-                  <a data-cite="rfc3986#section-5.2">section 5.2</a>
+                  <a data-cite="RFC3986#section-5.2">section 5.2</a>
                   of [[!RFC3986]] is used; neither
-                  <a data-cite="rfc3986#section-6.2.2">Syntax-Based Normalization</a> nor
-                  <a data-cite="rfc3986#section-6.2.3">Scheme-Based Normalization</a>
+                  <a data-cite="RFC3986#section-6.2.2">Syntax-Based Normalization</a> nor
+                  <a data-cite="RFC3986#section-6.2.3">Scheme-Based Normalization</a>
                   are performed. Characters additionally allowed in IRI
                   references are treated in the same way that unreserved
                   characters are treated in URI references, per
-                  <a data-cite="rfc3987#section-6.5">section 6.5</a>
+                  <a data-cite="RFC3987#section-6.5">section 6.5</a>
                   of [[!RFC3987]].</li>
                 <li>If <em>context</em> is in the <em>remote contexts</em> array, a
                   <a data-link-for="JsonLdErrorCode">recursive context inclusion</a>
@@ -1152,13 +1152,13 @@
         <li>Otherwise, if <em>document relative</em> is <code>true</code>,
           set <em>value</em> to the result of resolving <em>value</em> against
           the <a>base IRI</a>. Only the basic algorithm in
-          <a data-cite="rfc3986#section-5.2">section 5.2</a>
+          <a data-cite="RFC3986#section-5.2">section 5.2</a>
           of [[!RFC3986]] is used; neither
-          <a data-cite="rfc3986#section-6.2.2">Syntax-Based Normalization</a> nor
-          <a data-cite="rfc3986#section-6.2.3">Scheme-Based Normalization</a>
+          <a data-cite="RFC3986#section-6.2.2">Syntax-Based Normalization</a> nor
+          <a data-cite="RFC3986#section-6.2.3">Scheme-Based Normalization</a>
           are performed. Characters additionally allowed in IRI references are treated
           in the same way that unreserved characters are treated in URI references, per
-          <a data-cite="rfc3987#section-6.5">section 6.5</a>
+          <a data-cite="RFC3987#section-6.5">section 6.5</a>
           of [[!RFC3987]].</li>
         <li>Return <em>value</em> as is.</li>
       </ol>
@@ -3352,7 +3352,7 @@
           part (the result of a modulo&#8209;1 operation) or <em>value</em> is a <a>number</a>
           and <em>datatype</em> equals <code>xsd:double</code>, convert <em>value</em> to a
           <a>string</a> in <a>canonical lexical form</a> of
-          an <a data-cite="xmlschema11-2#dt-double"><code>xsd:double</code></a> as defined in [[!XMLSCHEMA11-2]]
+          an <a data-cite="XMLSCHEMA11-2#dt-double"><code>xsd:double</code></a> as defined in [[!XMLSCHEMA11-2]]
           and described in
           <a class="sectionRef" href="#data-round-tripping"></a>.
           If <em>datatype</em> is <code>null</code>, set it to
@@ -3362,7 +3362,7 @@
           is a <a>number</a> and <em>datatype</em>
           equals <code>xsd:integer</code>, convert <em>value</em> to a
           <a>string</a> in <a>canonical lexical form</a> of
-          an <a data-cite="xmlschema11-2#dt-integer"><code>xsd:integer</code></a> as defined in [[!XMLSCHEMA11-2]]
+          an <a data-cite="XMLSCHEMA11-2#dt-integer"><code>xsd:integer</code></a> as defined in [[!XMLSCHEMA11-2]]
           and described in
           <a class="sectionRef" href="#data-round-tripping"></a>.
           If <em>datatype</em> is <code>null</code>, set it to
@@ -3439,7 +3439,7 @@
       <a>named graphs</a> into a JSON-LD document.</p>
 
     <p>In the RDF abstract syntax, <a>RDF literals</a> have a
-      <a data-cite="rdf11-concepts#dfn-lexical-form"><dfn>lexical form</dfn></a>, as defined
+      <a data-cite="RDF11-CONCEPTS#dfn-lexical-form"><dfn>lexical form</dfn></a>, as defined
       in [[RDF11-CONCEPTS]]. The form of these literals is used when creating <a>JSON-LD values</a> based on these literals.</p>
 
     <section class="informative">
@@ -3850,7 +3850,7 @@
 
   <p>The JSON-LD API uses <a>Promises</a> to represent
     the result of the various asynchronous operations.
-    <a data-cite="ecmascript-6.0#sec-promise-objects">Promises</a> are defined in [[ECMASCRIPT-6.0]].
+    <a data-cite="ECMASCRIPT-6.0#sec-promise-objects">Promises</a> are defined in [[ECMASCRIPT-6.0]].
     General use within specifications can be found in [[promises-guide]].</p>
 
   <section class="informative">

--- a/spec/latest/json-ld-connect/index.html
+++ b/spec/latest/json-ld-connect/index.html
@@ -194,7 +194,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     <dd>An unordered labeled directed graph, where <tref title="node">nodes</tref> are
       <tref title="IRI">IRIs</tref> or <tref title="Blank Node">Blank Nodes</tref>, or other values.
       A <tref>JSON-LD graph</tref> is a generalized representation of a
-      <cite><a href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-graph">RDF graph</a></cite>
+      <cite><a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph">RDF graph</a></cite>
       as defined in [[!RDF-CONCEPTS]].</dd>
     <dt><tdef>named graph</tdef></dt>
     <dd>A <tref>JSON-LD graph</tref> that is identified by an <tref>IRI</tref>.</dd>

--- a/spec/latest/json-ld-connect/index.html
+++ b/spec/latest/json-ld-connect/index.html
@@ -194,7 +194,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     <dd>An unordered labeled directed graph, where <tref title="node">nodes</tref> are
       <tref title="IRI">IRIs</tref> or <tref title="Blank Node">Blank Nodes</tref>, or other values.
       A <tref>JSON-LD graph</tref> is a generalized representation of a
-      <cite><a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph">RDF graph</a></cite>
+      <cite><a href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-graph">RDF graph</a></cite>
       as defined in [[!RDF-CONCEPTS]].</dd>
     <dt><tdef>named graph</tdef></dt>
     <dd>A <tref>JSON-LD graph</tref> that is identified by an <tref>IRI</tref>.</dd>

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -199,7 +199,7 @@ Data in JSON. The document is primarily intended for the following audiences:
 
 <p>
 To understand the basics in this specification you must first be familiar with
-<a data-cite="rfc7159">JSON</a>, which is detailed in [[!RFC7159]]. You must also understand the
+<a data-cite="RFC7159">JSON</a>, which is detailed in [[!RFC7159]]. You must also understand the
 JSON-LD Syntax [[!JSON-LD]], which is the base syntax used by all of the
 algorithms in this document,
 and the JSON-LD API [[!JSON-LD-API]]. To understand the API and how it is

--- a/spec/latest/json-ld-rdf/index.html
+++ b/spec/latest/json-ld-rdf/index.html
@@ -184,7 +184,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     <dd>An unordered labeled directed graph, where <tref title="node">nodes</tref> are
       <tref title="IRI">IRIs</tref> or <tref title="blank node">blank nodes</tref>, or other values.
       A <tref>JSON-LD graph</tref> is a generalized representation of a
-      <cite><a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph">RDF graph</a></cite>
+      <cite><a href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-graph">RDF graph</a></cite>
       as defined in [[!RDF-CONCEPTS]].</dd>
     <dt><tdef>named graph</tdef></dt>
     <dd>A <tref>JSON-LD graph</tref> that is identified by an <tref>IRI</tref>.</dd>
@@ -403,7 +403,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     <section>
       <h3>Quad</h3>
       <p>The <a>Quad</a> interface represents an RDF Quad. An RDF Quad is an
-        <cite><a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple">RDF triple</a></cite>
+        <cite><a href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-triple">RDF triple</a></cite>
         [[!RDF-CONCEPTS]] with an optional fourth element, the graph name, being a
         <ldtref>Node</ldtref>.
       </p>
@@ -499,7 +499,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         <code>xsd:integer</code>).</p>
 
       <p> See[[!RDF-CONCEPTS]] definition for
-      <cite><a href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal">literal</a></cite>.</p>
+      <cite><a href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-literal">literal</a></cite>.</p>
 
       <dl title="[NoInterfaceObject] interface Literal : Node" class="idl">
         <dt>readonly attribute DOMString value</dt>

--- a/spec/latest/json-ld-rdf/index.html
+++ b/spec/latest/json-ld-rdf/index.html
@@ -184,7 +184,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     <dd>An unordered labeled directed graph, where <tref title="node">nodes</tref> are
       <tref title="IRI">IRIs</tref> or <tref title="blank node">blank nodes</tref>, or other values.
       A <tref>JSON-LD graph</tref> is a generalized representation of a
-      <cite><a href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-graph">RDF graph</a></cite>
+      <cite><a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph">RDF graph</a></cite>
       as defined in [[!RDF-CONCEPTS]].</dd>
     <dt><tdef>named graph</tdef></dt>
     <dd>A <tref>JSON-LD graph</tref> that is identified by an <tref>IRI</tref>.</dd>
@@ -403,7 +403,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     <section>
       <h3>Quad</h3>
       <p>The <a>Quad</a> interface represents an RDF Quad. An RDF Quad is an
-        <cite><a href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-triple">RDF triple</a></cite>
+        <cite><a href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple">RDF triple</a></cite>
         [[!RDF-CONCEPTS]] with an optional fourth element, the graph name, being a
         <ldtref>Node</ldtref>.
       </p>
@@ -499,7 +499,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         <code>xsd:integer</code>).</p>
 
       <p> See[[!RDF-CONCEPTS]] definition for
-      <cite><a href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-literal">literal</a></cite>.</p>
+      <cite><a href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal">literal</a></cite>.</p>
 
       <dl title="[NoInterfaceObject] interface Literal : Node" class="idl">
         <dt>readonly attribute DOMString value</dt>

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -2150,7 +2150,7 @@ specified. The full <a>IRI</a> for
     {
       "name": "http://schema.org/name",
       "interest": {
-        "@id":"http://xmlns.com/foaf/0.1/interest",
+        "@id": "http://xmlns.com/foaf/0.1/interest",
         ****"@context": {"@vocab": "http://xmlns.com/foaf/0.1/"}****
       }
     },
@@ -2185,7 +2185,6 @@ specified. The full <a>IRI</a> for
   <p>The <code>@reverse</code> <a>keyword</a> can also be used in
     <a>expanded term definitions</a>
     to create reverse properties as shown in the following example:</p>
-
 
   <pre class="example" data-transform="updateExample"
        title="Using @reverse to define reverse properties">

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -220,7 +220,7 @@
       providing a standard library interface for common JSON-LD operations.</p>
 
     <p>To understand the basics in this specification you must first be familiar with
-      <a data-cite="rfc7159">JSON</a>, which is detailed in [[!RFC7159]].</p>
+      <a data-cite="RFC7159">JSON</a>, which is detailed in [[!RFC7159]].</p>
 
     <p>This document almost exclusively uses the term IRI
     (<a data-cite="ld-glossary#internationalized-resource-identifier">Internationalized Resource Indicator</a>)
@@ -450,7 +450,7 @@
     tokens such as "name", "homepage", etc.</p>
 
   <p>Linked Data, and the Web in general, uses <a>IRIs</a>
-    (<a data-cite="rfc3987#section-2">Internationalized Resource Identifiers</a> as described in [[!RFC3987]]) for unambiguous
+    (<a data-cite="RFC3987#section-2">Internationalized Resource Identifiers</a> as described in [[!RFC3987]]) for unambiguous
     identification. The idea is to use <a>IRIs</a>
     to assign unambiguous identifiers to data that may be of use to other developers.
     It is useful for <a>terms</a>,
@@ -571,7 +571,7 @@
       is ignored when the document is used as an external JSON-LD context document.</p>
 
     <p>JSON documents can be interpreted as JSON-LD without having to be modified by
-      referencing a <a>context</a> via an <a data-cite="rfc5988#section-5">HTTP Link Header</a>
+      referencing a <a>context</a> via an <a data-cite="RFC5988#section-5">HTTP Link Header</a>
       as described in <a class="sectionRef" href="#interpreting-json-as-json-ld"></a>. It is also
       possible to apply a custom context using the JSON-LD API [[JSON-LD-API]].</p>
 
@@ -613,12 +613,12 @@
 <section class="informative">
   <h2>IRIs</h2>
 
-  <p><a>IRIs</a> (<a data-cite="rfc3987#section-2">Internationalized Resource Identifiers</a>
+  <p><a>IRIs</a> (<a data-cite="RFC3987#section-2">Internationalized Resource Identifiers</a>
     [[!RFC3987]]) are fundamental to Linked Data as that is how most
     <a>nodes</a> and <a>properties</a>
     are identified. In JSON-LD, IRIs may be represented as an
     <a>absolute IRI</a> or a <a>relative IRI</a>. An
-    <a data-cite="rfc3987#section-1.3">absolute IRI</a> is defined in [[!RFC3987]] as containing a
+    <a data-cite="RFC3987#section-1.3">absolute IRI</a> is defined in [[!RFC3987]] as containing a
     <em>scheme</em> along with <em>path</em> and optional <em>query</em> and
     <em>fragment</em> segments. A <a>relative IRI</a> is an IRI
     that is relative to some other <a>absolute IRI</a>.
@@ -863,7 +863,7 @@
 
   <p>JSON-LD allows <a>IRI</a>s to be specified in a relative form which is
     resolved against the document base according
-    <a data-cite="rfc3986#section-5.1">section 5.1 Establishing a Base URI</a>
+    <a data-cite="RFC3986#section-5.1">section 5.1 Establishing a Base URI</a>
     of [[RFC3986]]. The <a>base IRI</a> may be explicitly set with a <a>context</a>
     using the <code>@base</code> keyword.</p>
 
@@ -1491,7 +1491,7 @@ the data type to be specified with each piece of data.</p>
   <h2>Interpreting JSON as JSON-LD</h2>
 
   <p>Ordinary JSON documents can be interpreted as JSON-LD by referencing a JSON-LD
-    <a>context</a> document in an <a data-cite="rfc5988#section-5">HTTP Link Header</a>. Doing so allows JSON to
+    <a>context</a> document in an <a data-cite="RFC5988#section-5">HTTP Link Header</a>. Doing so allows JSON to
     be unambiguously machine-readable without requiring developers to drastically
     change their documents and provides an upgrade path for existing infrastructure
     without breaking existing clients that rely on the <code>application/json</code>
@@ -1500,7 +1500,7 @@ the data type to be specified with each piece of data.</p>
 
   <p>In order to use an external context with an ordinary JSON document, an author
     MUST specify an <a>IRI</a> to a valid <a>JSON-LD document</a> in
-    an <a data-cite="rfc5988#section-5">HTTP Link Header</a> [[!RFC5988]] using the <code>http://www.w3.org/ns/json-ld#context</code>
+    an <a data-cite="RFC5988#section-5">HTTP Link Header</a> [[!RFC5988]] using the <code>http://www.w3.org/ns/json-ld#context</code>
     link relation. The referenced document MUST have a top-level <a>JSON object</a>.
     The <code>@context</code> subtree within that object is added to the top-level
     <a>JSON object</a> of the referencing document. If an <a>array</a>
@@ -1510,7 +1510,7 @@ the data type to be specified with each piece of data.</p>
     of the <code>@context</code> subtree in the referenced document MUST be
     discarded. Effectively this means that the <a>active context</a> is
     initialized with the referenced external <a>context</a>. A response MUST NOT
-    contain more than one <a data-cite="rfc5988#section-5">HTTP Link Header</a> [[!RFC5988]] using the
+    contain more than one <a data-cite="RFC5988#section-5">HTTP Link Header</a> [[!RFC5988]] using the
     <code>http://www.w3.org/ns/json-ld#context</code> link relation.</p>
 
   <p>The following example demonstrates the use of an external context with an
@@ -1542,7 +1542,7 @@ the data type to be specified with each piece of data.</p>
     served with the <code>application/ld+json</code>
     media type MUST have all context information, including references to external
     contexts, within the body of the document. Contexts linked via a
-    <code>http://www.w3.org/ns/json-ld#context</code> <a data-cite="rfc5988#section-5">HTTP Link Header</a> MUST be
+    <code>http://www.w3.org/ns/json-ld#context</code> <a data-cite="RFC5988#section-5">HTTP Link Header</a> MUST be
     ignored for such documents.</p>
 </section>
 
@@ -1571,7 +1571,7 @@ the data type to be specified with each piece of data.</p>
 
   <p>The example above would associate the <code>ja</code> language
     code with the two <a>strings</a> <em>花澄</em> and <em>科学者</em>.
-    <a data-cite="bcp47#section-2">Languages codes</a> are defined in [[!BCP47]]. The <a>default language</a> applies to all
+    <a data-cite="BCP47#section-2">Languages codes</a> are defined in [[!BCP47]]. The <a>default language</a> applies to all
     <a>string</a> values that are not <a href="#type-coercion">type coerced</a>.</p>
 
   <p>To clear the <a>default language</a> for a subtree, <code>@language</code> can
@@ -3045,7 +3045,7 @@ specified. The full <a>IRI</a> for
   <p>JSON-LD is a serialization format for Linked Data based on JSON.
     It is therefore important to distinguish between the syntax, which is
     defined by JSON in [[!RFC7159]], and the <dfn>data model</dfn> which is
-    an extension of the <a data-cite="rdf11-concepts#data-model">RDF data model</a> [[!RDF11-CONCEPTS]]. The precise
+    an extension of the <a data-cite="RDF11-CONCEPTS#data-model">RDF data model</a> [[!RDF11-CONCEPTS]]. The precise
     details of how JSON-LD relates to the RDF data model are given in
     <a class="sectionRef" href="#relationship-to-rdf"></a>.</p>
 
@@ -3099,14 +3099,14 @@ specified. The full <a>IRI</a> for
     <li>A <a>typed value</a> consists of a value, which is a string, and a type, which is an
       <a>IRI</a>.</li>
     <li>A <a>language-tagged string</a>
-      consists of a string and a non-empty <a data-cite="bcp47#section-2">language tag</a> as defined by [[BCP47]].
+      consists of a string and a non-empty <a data-cite="BCP47#section-2">language tag</a> as defined by [[BCP47]].
       The language tag MUST be well-formed according to section
-      <a data-cite="bcp47#section-2.2.9">2.2.9 Classes of Conformance</a>
+      <a data-cite="BCP47#section-2.2.9">2.2.9 Classes of Conformance</a>
       of [[BCP47]].</li>
     <li>A <a>list</a> is a sequence of zero or more <a>IRIs</a>,
       <a>blank nodes</a>, and <a>JSON-LD values</a>.
       <a>Lists</a> are interpreted as
-      <dfn data-cite="rdf11-mt#rdf-collections">RDF list structures</dfn> [[RDF11-MT]].</li>
+      <dfn data-cite="RDF11-MT#rdf-collections">RDF list structures</dfn> [[RDF11-MT]].</li>
   </ul>
 
   <p><a>JSON-LD documents</a> MAY contain data
@@ -3126,7 +3126,7 @@ specified. The full <a>IRI</a> for
   <p>This appendix restates the syntactic conventions described in the
     previous sections more formally.</p>
 
-  <p>A <a>JSON-LD document</a> MUST be valid <a data-cite="rfc7159#section-2">JSON text</a> as described
+  <p>A <a>JSON-LD document</a> MUST be valid <a data-cite="RFC7159#section-2">JSON text</a> as described
     in [[!RFC7159]].</p>
 
   <p>A <a>JSON-LD document</a> MUST be a single <a>node object</a>
@@ -3305,7 +3305,7 @@ specified. The full <a>IRI</a> for
       an <a>absolute IRI</a>, a <a>relative IRI</a>, or <a>null</a>.</p>
 
     <p>The value associated with the <code>@language</code> key MUST have the
-      <a data-cite="bcp47#section-2.1.1">lexical form</a> described in [[!BCP47]], or be <a>null</a>.</p>
+      <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[!BCP47]], or be <a>null</a>.</p>
 
     <p>The value associated with the <code>@index</code> key MUST be a
       <a>string</a>.</p>
@@ -3457,7 +3457,7 @@ specified. The full <a>IRI</a> for
     and <code>@vocab</code>.</p>
 
   <p>If the <a>context definition</a> has an <code>@language</code> key,
-    its value MUST have the <a data-cite="bcp47#section-2.1.1">lexical form</a> described in [[!BCP47]] or be <a>null</a>.</p>
+    its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[!BCP47]] or be <a>null</a>.</p>
 
   <p>If the <a>context definition</a> has an <code>@base</code> key,
     its value MUST be an <a>absolute IRI</a>, a <a>relative IRI</a>,
@@ -3503,7 +3503,7 @@ specified. The full <a>IRI</a> for
     <a>keyword</a> <code>@id</code> or <code>@vocab</code>.</p>
 
   <p>If the <a>expanded term definition</a> contains the <code>@language</code> <a>keyword</a>,
-    its value MUST have the <a data-cite="bcp47#section-2.1.1">lexical form</a> described in [[!BCP47]] or be <a>null</a>.</p>
+    its value MUST have the <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[!BCP47]] or be <a>null</a>.</p>
 
   <p>If the <a>expanded term definition</a> contains the <code>@container</code>
     <a>keyword</a>, its value MUST be either <code>@list</code>, <code>@set</code>,
@@ -3534,12 +3534,12 @@ specified. The full <a>IRI</a> for
   <h2>Relationship to RDF</h2>
 
   <p>JSON-LD is a
-    <dfn data-cite="rdf11-concepts#dfn-concrete-rdf-syntax">concrete RDF syntax</dfn>
+    <dfn data-cite="RDF11-CONCEPTS#dfn-concrete-rdf-syntax">concrete RDF syntax</dfn>
     as described in [[RDF11-CONCEPTS]]. Hence, a JSON-LD document is both an
     RDF document <em>and</em> a JSON document and correspondingly represents an
     instance of an RDF data model. However, JSON-LD also extends the RDF data
     model to optionally allow JSON-LD to serialize
-    <dfn data-cite="rdf11-concepts#dfn-generalized-rdf-dataset" data-lt="generalized rdf dataset">generalized RDF Datasets</dfn>.
+    <dfn data-cite="RDF11-CONCEPTS#dfn-generalized-rdf-dataset" data-lt="generalized rdf dataset">generalized RDF Datasets</dfn>.
     The JSON-LD extensions to the RDF data model are:</p>
 
   <ul>
@@ -3587,7 +3587,7 @@ specified. The full <a>IRI</a> for
       <a>blank nodes</a> used as
       <a>properties</a> to <a>IRIs</a>,
       by minting new "Skolem IRIs" as per
-      <a data-cite="rdf11-concepts#section-skolemization">Replacing Blank Nodes with IRIs</a>
+      <a data-cite="RDF11-CONCEPTS#section-skolemization">Replacing Blank Nodes with IRIs</a>
       of [[RDF11-CONCEPTS]].</li>
   </ul>
 
@@ -3597,7 +3597,7 @@ specified. The full <a>IRI</a> for
 
   <p>Even though JSON-LD serializes
     <a>generalized RDF Datasets</a>, it can
-    also be used as a <dfn data-cite="rdf11-concepts#dfn-rdf-source">RDF graph source</dfn>.
+    also be used as a <dfn data-cite="RDF11-CONCEPTS#dfn-rdf-source">RDF graph source</dfn>.
     In that case, a consumer MUST only use the default graph and ignore all named graphs.
     This allows servers to expose data in languages such as Turtle and JSON-LD
     using content negotiation.</p>
@@ -4129,7 +4129,7 @@ specified. The full <a>IRI</a> for
           <p>When processing the "profile" media type parameter, it is important to
             note that its value contains one or more URIs and not IRIs. In some cases
             it might therefore be necessary to convert between IRIs and URIs as specified in
-            <a data-cite="rfc3986#section-5.1">section 3 Relationship between IRIs and URIs</a>
+            <a data-cite="RFC3986#section-5.1">section 3 Relationship between IRIs and URIs</a>
             of [[RFC3987]].</p>
         </dd>
       </dl>
@@ -4197,7 +4197,7 @@ specified. The full <a>IRI</a> for
 
   <p>Fragment identifiers used with <a href="#application-ld-json">application/ld+json</a>
     are treated as in RDF syntaxes, as per
-    <a data-cite="rdf11-concepts#section-fragID">RDF 1.1 Concepts and Abstract Syntax</a>
+    <a data-cite="RDF11-CONCEPTS#section-fragID">RDF 1.1 Concepts and Abstract Syntax</a>
     [[RDF11-CONCEPTS]].</p>
 </section>
 

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -2209,6 +2209,35 @@ specified. The full <a>IRI</a> for
   }
   -->
   </pre>
+
+  <p>Scoping can also be performed using a term used as a value of <code>@type</code>:</p>
+  
+  <pre class="example" data-transform="updateExample"
+       title="Defining an @context within a term definition used on @type">
+  <!--
+  {
+    "@context":
+    {
+      "name": "http://schema.org/name",
+      "interest": "http://xmlns.com/foaf/0.1/interest",
+      ****"Document"****: {
+        "@id": "http://xmlns.com/foaf/0.1/Document",
+        ****"@context": {"@vocab": "http://xmlns.com/foaf/0.1/"}****
+      }
+    },
+    "@type": "Person",
+    "name": "Manu Sporny",
+    "interest": {
+      "@id": "https://www.w3.org/TR/json-ld/",
+      ****"@type": "Document"****,
+      "name": "JSON-LD",
+      "topic": "Linking Data"
+    }
+  }
+  -->
+  </pre>
+
+  <p>Scoping on <code>@type</code> is useful when common properties are used to relate things of different types, where the vocabularies in use within different entities calls for different context scoping. For example, `hasPart`/`partOf` may be common terms used in a document, but mean different things depending on the context.</p>
 </section>
 
 

--- a/spec/latest/rdf-dataset-normalization/index.html
+++ b/spec/latest/rdf-dataset-normalization/index.html
@@ -208,35 +208,35 @@
       <dd>An <tref>IRI</tref> (Internationalized Resource Identifier) is a string that conforms to the syntax
         defined in [[RFC3987]].</dd>
       <dt><tdef>RDF subject</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-subject">subject</tref>
+      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-subject">subject</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF predicate</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-predicate">predicate</tref>
+      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-predicate">predicate</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF object</tdef></dt>
-      <dd>An <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-object">object</tref>
+      <dd>An <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-object">object</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF triple</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple">triple</tref>
+      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-triple">triple</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF graph</tdef></dt>
-      <dd>An <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph">RDF graph</tref>
+      <dd>An <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-graph">RDF graph</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF graph name</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset">graph name</tref>
+      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-dataset">graph name</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF quad</tdef></dt>
       <dd>The pairing of an <tref>RDF triple</tref> with an <tref>RDF graph name</tref>.</dd>
       <dt><tdef>RDF dataset</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset">dataset</tref>
+      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-dataset">dataset</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF blank node</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#section-blank-nodes">blank node</tref>
+      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#section-blank-nodes">blank node</tref>
         as specified by [[RDF11-CONCEPTS]]. In short, it is a node in a graph that is
         neither an <tref>IRI</tref>, nor a
-        <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal">literal</tref>.</dd>
+        <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-literal">literal</tref>.</dd>
       <dt><tdef>RDF blank node identifier</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">blank node identifier</tref>
+      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-blank-node-identifier">blank node identifier</tref>
         as specified by [[RDF11-CONCEPTS]]. In short, it is a string that begins
         with <code>_:</code> that is used as an identifier for an
         <tref>RDF blank node</tref>. <tref>RDF blank node identifier</tref>s

--- a/spec/latest/rdf-dataset-normalization/index.html
+++ b/spec/latest/rdf-dataset-normalization/index.html
@@ -208,35 +208,35 @@
       <dd>An <tref>IRI</tref> (Internationalized Resource Identifier) is a string that conforms to the syntax
         defined in [[RFC3987]].</dd>
       <dt><tdef>RDF subject</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-subject">subject</tref>
+      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-subject">subject</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF predicate</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-predicate">predicate</tref>
+      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-predicate">predicate</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF object</tdef></dt>
-      <dd>An <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-object">object</tref>
+      <dd>An <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-object">object</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF triple</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-triple">triple</tref>
+      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-triple">triple</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF graph</tdef></dt>
-      <dd>An <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-graph">RDF graph</tref>
+      <dd>An <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-graph">RDF graph</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF graph name</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-dataset">graph name</tref>
+      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset">graph name</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF quad</tdef></dt>
       <dd>The pairing of an <tref>RDF triple</tref> with an <tref>RDF graph name</tref>.</dd>
       <dt><tdef>RDF dataset</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-rdf-dataset">dataset</tref>
+      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-rdf-dataset">dataset</tref>
         as specified by [[RDF11-CONCEPTS]].</dd>
       <dt><tdef>RDF blank node</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#section-blank-nodes">blank node</tref>
+      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#section-blank-nodes">blank node</tref>
         as specified by [[RDF11-CONCEPTS]]. In short, it is a node in a graph that is
         neither an <tref>IRI</tref>, nor a
-        <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-literal">literal</tref>.</dd>
+        <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-literal">literal</tref>.</dd>
       <dt><tdef>RDF blank node identifier</tdef></dt>
-      <dd>A <tref href="http://www.w3.org/TR/RDF11-CONCEPTS/#dfn-blank-node-identifier">blank node identifier</tref>
+      <dd>A <tref href="http://www.w3.org/TR/rdf11-concepts/#dfn-blank-node-identifier">blank node identifier</tref>
         as specified by [[RDF11-CONCEPTS]]. In short, it is a string that begins
         with <code>_:</code> that is used as an identifier for an
         <tref>RDF blank node</tref>. <tref>RDF blank node identifier</tref>s

--- a/test-suite/tests/compact-m005-context.jsonld
+++ b/test-suite/tests/compact-m005-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "ex": "http://example.org/",
+    "idmap": {"@container": "@id"}
+  }
+}

--- a/test-suite/tests/compact-m005-in.jsonld
+++ b/test-suite/tests/compact-m005-in.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example/idmap": [
+    {"http://example/label": [{"@value": "Object with @id <foo>"}], "@id": "http://example.org/foo"}
+  ]
+}]

--- a/test-suite/tests/compact-m005-out.jsonld
+++ b/test-suite/tests/compact-m005-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "ex": "http://example.org/",
+    "idmap": {"@container": "@id"}
+  },
+  "idmap": {
+    "ex:foo": {"label": "Object with @id <foo>"}
+  }
+}

--- a/test-suite/tests/compact-m006-context.jsonld
+++ b/test-suite/tests/compact-m006-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  }
+}

--- a/test-suite/tests/compact-m006-in.jsonld
+++ b/test-suite/tests/compact-m006-in.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example/typemap": [
+    {"http://example/label": [{"@value": "Object with @type <foo>"}], "@type": ["http://example/Foo"]}
+  ]
+}]

--- a/test-suite/tests/compact-m006-out.jsonld
+++ b/test-suite/tests/compact-m006-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  },
+  "typemap": {
+    "Foo": {"label": "Object with @type <foo>"}
+  }
+}

--- a/test-suite/tests/compact-m007-context.jsonld
+++ b/test-suite/tests/compact-m007-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"bar": "http://example.org/bar"}}
+  }
+}

--- a/test-suite/tests/compact-m007-in.jsonld
+++ b/test-suite/tests/compact-m007-in.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "http://example/a": [{
+      "@type": ["http://example/Foo"],
+      "http://example.org/bar": [{"@value": "baz"}]
+    }]
+  }
+]

--- a/test-suite/tests/compact-m007-out.jsonld
+++ b/test-suite/tests/compact-m007-out.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"bar": "http://example.org/bar"}}
+  },
+  "a": {"@type": "Foo", "bar": "baz"}
+}

--- a/test-suite/tests/compact-m008-context.jsonld
+++ b/test-suite/tests/compact-m008-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"bar": {"@type": "@id"}}},
+    "bar": {"@type": "http://www.w3.org/2001/XMLSchema#string"}
+  }
+}

--- a/test-suite/tests/compact-m008-in.jsonld
+++ b/test-suite/tests/compact-m008-in.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "http://example/a": [{
+      "@type": ["http://example/Foo"],
+      "http://example/bar": [{"@id": "http://example/baz"}]
+    }]
+  }
+]

--- a/test-suite/tests/compact-m008-out.jsonld
+++ b/test-suite/tests/compact-m008-out.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"bar": {"@type": "@id"}}},
+    "bar": {"@type": "http://www.w3.org/2001/XMLSchema#string"}
+  },
+  "a": {"@type": "Foo", "bar": "http://example/baz"}
+}

--- a/test-suite/tests/compact-m009-context.jsonld
+++ b/test-suite/tests/compact-m009-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "type": "@type",
+    "Foo": {"@context": {"bar": "http://example.org/bar"}}
+  }
+}

--- a/test-suite/tests/compact-m009-in.jsonld
+++ b/test-suite/tests/compact-m009-in.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "http://example/a": [{
+      "@type": ["http://example/Foo"],
+      "http://example.org/bar": [{"@value": "baz"}]
+    }]
+  }
+]

--- a/test-suite/tests/compact-m009-out.jsonld
+++ b/test-suite/tests/compact-m009-out.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "type": "@type",
+    "Foo": {"@context": {"bar": "http://example.org/bar"}}
+  },
+  "a": {"type": "Foo", "bar": "baz"}
+}

--- a/test-suite/tests/compact-m010-context.jsonld
+++ b/test-suite/tests/compact-m010-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"baz": {"@type": "@vocab"}}}
+  }
+}

--- a/test-suite/tests/compact-m010-in.jsonld
+++ b/test-suite/tests/compact-m010-in.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "@type": ["http://example/Foo"],
+    "http://example/bar": [{
+      "http://example/baz": [{"@id": "http://example/buzz"}]
+    }]
+  }
+]

--- a/test-suite/tests/compact-m010-out.jsonld
+++ b/test-suite/tests/compact-m010-out.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"baz": {"@type": "@vocab"}}}
+  },
+  "@type": "Foo",
+  "bar": {"baz": "buzz"}
+}

--- a/test-suite/tests/compact-m011-context.jsonld
+++ b/test-suite/tests/compact-m011-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "B": {"@context": {"c": "http://example.org/c"}}
+  }
+}

--- a/test-suite/tests/compact-m011-in.jsonld
+++ b/test-suite/tests/compact-m011-in.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example/a": [{
+    "@type": ["http://example/B"],
+    "http://example.com/a": [{"@value": "A in example.com"}],
+    "http://example.org/c": [{"@value": "C in example.org"}]
+  }],
+  "http://example/c": [{"@value": "C in example"}]
+}]

--- a/test-suite/tests/compact-m011-out.jsonld
+++ b/test-suite/tests/compact-m011-out.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "B": {"@context": {"c": "http://example.org/c"}}
+  },
+  "a": {
+    "@type": "B",
+    "c": "C in example.org",
+    "http://example.com/a": "A in example.com"
+  },
+  "c": "C in example"
+}

--- a/test-suite/tests/compact-m012-context.jsonld
+++ b/test-suite/tests/compact-m012-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"},
+    "Type": {"@context": {"a": "http://example.org/a"}}
+  }
+}

--- a/test-suite/tests/compact-m012-in.jsonld
+++ b/test-suite/tests/compact-m012-in.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example/typemap": [
+    {"http://example.org/a": [{"@value": "Object with @type <Type>"}], "@type": ["http://example/Type"]}
+  ]
+}]

--- a/test-suite/tests/compact-m012-out.jsonld
+++ b/test-suite/tests/compact-m012-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"},
+    "Type": {"@context": {"a": "http://example.org/a"}}
+  },
+  "typemap": {
+    "Type": {"a": "Object with @type <Type>"}
+  }
+}

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -685,6 +685,60 @@
       "expect": "compact-m006-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
     }, {
+      "@id": "#tm007",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "adding new term",
+      "purpose": "scoped context on @type",
+      "input": "compact-m007-in.jsonld",
+      "context": "compact-m007-context.jsonld",
+      "expect": "compact-m007-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm008",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "overriding a term",
+      "purpose": "scoped context on @type",
+      "input": "compact-m008-in.jsonld",
+      "context": "compact-m008-context.jsonld",
+      "expect": "compact-m008-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm009",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "alias of @type",
+      "purpose": "scoped context on @type",
+      "input": "compact-m009-in.jsonld",
+      "context": "compact-m009-context.jsonld",
+      "expect": "compact-m009-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm010",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "deep @context affects nested nodes",
+      "purpose": "scoped context on @type",
+      "input": "compact-m010-in.jsonld",
+      "context": "compact-m010-context.jsonld",
+      "expect": "compact-m010-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm011",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "scoped context layers on intemediate contexts",
+      "purpose": "scoped context on @type",
+      "input": "compact-m011-in.jsonld",
+      "context": "compact-m011-context.jsonld",
+      "expect": "compact-m011-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm012",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "When type is in a type map",
+      "purpose": "scoped context on @type",
+      "input": "compact-m012-in.jsonld",
+      "context": "compact-m012-context.jsonld",
+      "expect": "compact-m012-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Indexes to @nest for property with @nest",

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -667,6 +667,24 @@
       "expect": "compact-m004-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
     }, {
+      "@id": "#tm005",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Indexes to object using compact IRI @id",
+      "purpose": "Compaction using @container: @id",
+      "input": "compact-m005-in.jsonld",
+      "context": "compact-m005-context.jsonld",
+      "expect": "compact-m005-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm006",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Indexes using compacted @type",
+      "purpose": "Compaction using @container: @type",
+      "input": "compact-m006-in.jsonld",
+      "context": "compact-m006-context.jsonld",
+      "expect": "compact-m006-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Indexes to @nest for property with @nest",

--- a/test-suite/tests/expand-m005-in.jsonld
+++ b/test-suite/tests/expand-m005-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "idmap": {"@container": "@id"}
+  },
+  "idmap": {
+    "foo": {"label": "Object with @id <foo>"}
+  }
+}

--- a/test-suite/tests/expand-m005-out.jsonld
+++ b/test-suite/tests/expand-m005-out.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example/idmap": [
+    {"http://example/label": [{"@value": "Object with @id <foo>"}], "@id": "http://example.org/foo"}
+  ]
+}]

--- a/test-suite/tests/expand-m006-in.jsonld
+++ b/test-suite/tests/expand-m006-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"}
+  },
+  "typemap": {
+    "Foo": {"label": "Object with @type <foo>"}
+  }
+}

--- a/test-suite/tests/expand-m006-out.jsonld
+++ b/test-suite/tests/expand-m006-out.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example/typemap": [
+    {"http://example/label": [{"@value": "Object with @type <foo>"}], "@type": ["http://example/Foo"]}
+  ]
+}]

--- a/test-suite/tests/expand-m007-in.jsonld
+++ b/test-suite/tests/expand-m007-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "typemap": {"@id": "http://example/typemap", "@container": "@type"},
+    "label": "http://example/label"
+  },
+  "typemap": {
+    "Foo": {"label": "Object with @type <foo>"}
+  }
+}

--- a/test-suite/tests/expand-m007-out.jsonld
+++ b/test-suite/tests/expand-m007-out.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example/typemap": [
+    {"http://example/label": [{"@value": "Object with @type <foo>"}], "@type": ["http://example.org/Foo"]}
+  ]
+}]

--- a/test-suite/tests/expand-m008-in.jsonld
+++ b/test-suite/tests/expand-m008-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"bar": "http://example.org/bar"}}
+  },
+  "a": {"@type": "Foo", "bar": "baz"}
+}

--- a/test-suite/tests/expand-m008-out.jsonld
+++ b/test-suite/tests/expand-m008-out.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "http://example/a": [{
+      "@type": ["http://example/Foo"],
+      "http://example.org/bar": [{"@value": "baz"}]
+    }]
+  }
+]

--- a/test-suite/tests/expand-m009-in.jsonld
+++ b/test-suite/tests/expand-m009-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"bar": {"@type": "@id"}}},
+    "bar": {"@type": "http://www.w3.org/2001/XMLSchema#string"}
+  },
+  "a": {"@type": "Foo", "bar": "http://example/baz"}
+}

--- a/test-suite/tests/expand-m009-out.jsonld
+++ b/test-suite/tests/expand-m009-out.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "http://example/a": [{
+      "@type": ["http://example/Foo"],
+      "http://example/bar": [{"@id": "http://example/baz"}]
+    }]
+  }
+]

--- a/test-suite/tests/expand-m010-in.jsonld
+++ b/test-suite/tests/expand-m010-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "type": "@type",
+    "Foo": {"@context": {"bar": "http://example.org/bar"}}
+  },
+  "a": {"type": "Foo", "bar": "baz"}
+}

--- a/test-suite/tests/expand-m010-out.jsonld
+++ b/test-suite/tests/expand-m010-out.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "http://example/a": [{
+      "@type": ["http://example/Foo"],
+      "http://example.org/bar": [{"@value": "baz"}]
+    }]
+  }
+]

--- a/test-suite/tests/expand-m011-in.jsonld
+++ b/test-suite/tests/expand-m011-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "Foo": {"@context": {"baz": {"@type": "@vocab"}}}
+  },
+  "@type": "Foo",
+  "bar": {"baz": "buzz"}
+}

--- a/test-suite/tests/expand-m011-out.jsonld
+++ b/test-suite/tests/expand-m011-out.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "@type": ["http://example/Foo"],
+    "http://example/bar": [{
+      "http://example/baz": [{"@id": "http://example/buzz"}]
+    }]
+  }
+]

--- a/test-suite/tests/expand-m012-in.jsonld
+++ b/test-suite/tests/expand-m012-in.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "B": {"@context": {"c": "http://example.org/c"}}
+  },
+  "a": {
+    "@context": {"@vocab": "http://example.com/"},
+    "@type": "B",
+    "a": "A in example.com",
+    "c": "C in example.org"
+  },
+  "c": "C in example"
+}

--- a/test-suite/tests/expand-m012-out.jsonld
+++ b/test-suite/tests/expand-m012-out.jsonld
@@ -1,0 +1,8 @@
+[{
+  "http://example/a": [{
+    "@type": ["http://example/B"],
+    "http://example.com/a": [{"@value": "A in example.com"}],
+    "http://example.org/c": [{"@value": "C in example.org"}]
+  }],
+  "http://example/c": [{"@value": "C in example"}]
+}]

--- a/test-suite/tests/expand-m013-in.jsonld
+++ b/test-suite/tests/expand-m013-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "typemap": {"@container": "@type"},
+    "Type": {"@context": {"a": "http://example.org/a"}}
+  },
+  "typemap": {
+    "Type": {"a": "Object with @type <Type>"}
+  }
+}

--- a/test-suite/tests/expand-m013-out.jsonld
+++ b/test-suite/tests/expand-m013-out.jsonld
@@ -1,0 +1,5 @@
+[{
+  "http://example/typemap": [
+    {"http://example.org/a": [{"@value": "Object with @type <Type>"}], "@type": ["http://example/Type"]}
+  ]
+}]

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -654,6 +654,54 @@
       "input": "expand-m007-in.jsonld",
       "expect": "expand-m007-out.jsonld",
       "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm008",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "adding new term",
+      "purpose": "scoped context on @type",
+      "input": "expand-m008-in.jsonld",
+      "expect": "expand-m008-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm009",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "overriding a term",
+      "purpose": "scoped context on @type",
+      "input": "expand-m009-in.jsonld",
+      "expect": "expand-m009-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm010",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "alias of @type",
+      "purpose": "scoped context on @type",
+      "input": "expand-m010-in.jsonld",
+      "expect": "expand-m010-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm011",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "deep @context affects nested nodes",
+      "purpose": "scoped context on @type",
+      "input": "expand-m011-in.jsonld",
+      "expect": "expand-m011-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm012",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "scoped context layers on intemediate contexts",
+      "purpose": "scoped context on @type",
+      "input": "expand-m012-in.jsonld",
+      "expect": "expand-m012-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm013",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "When type is in a type map",
+      "purpose": "scoped context on @type",
+      "input": "expand-m013-in.jsonld",
+      "expect": "expand-m013-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -665,7 +665,7 @@
     }, {
       "@id": "#tn002",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Expands input using @nest",
+      "name": "Expands input using aliased @nest",
       "purpose": "Expansion using @nest",
       "input": "expand-n002-in.jsonld",
       "expect": "expand-n002-out.jsonld",
@@ -673,7 +673,7 @@
     }, {
       "@id": "#tn003",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Expands input using @nest",
+      "name": "Appends nested values when property at base and nested",
       "purpose": "Expansion using @nest",
       "input": "expand-n003-in.jsonld",
       "expect": "expand-n003-out.jsonld",
@@ -681,7 +681,7 @@
     }, {
       "@id": "#tn004",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Expands input using @nest",
+      "name": "Appends nested values from all @nest aliases in term order",
       "purpose": "Expansion using @nest",
       "input": "expand-n004-in.jsonld",
       "expect": "expand-n004-out.jsonld",
@@ -689,7 +689,7 @@
     }, {
       "@id": "#tn005",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Expands input using @nest",
+      "name": "Nested nested containers",
       "purpose": "Expansion using @nest",
       "input": "expand-n005-in.jsonld",
       "expect": "expand-n005-out.jsonld",
@@ -697,7 +697,7 @@
     }, {
       "@id": "#tn006",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Expands input using @nest",
+      "name": "Arrays of nested values",
       "purpose": "Expansion using @nest",
       "input": "expand-n006-in.jsonld",
       "expect": "expand-n006-out.jsonld",
@@ -705,7 +705,7 @@
     }, {
       "@id": "#tn007",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
-      "name": "Expands input using @nest",
+      "name": "A nest of arrays",
       "purpose": "Expansion using @nest",
       "input": "expand-n007-in.jsonld",
       "expect": "expand-n007-out.jsonld",

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -630,6 +630,30 @@
       "input": "expand-m004-in.jsonld",
       "expect": "expand-m004-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm005",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Adds expanded @id to object",
+      "purpose": "Expansion using @container: @id",
+      "input": "expand-m005-in.jsonld",
+      "expect": "expand-m005-out.jsonld",
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm006",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Adds vocabulary expanded @type to object",
+      "purpose": "Expansion using @container: @type",
+      "input": "expand-m006-in.jsonld",
+      "expect": "expand-m006-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tm007",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Adds document expanded @type to object",
+      "purpose": "Expansion using @container: @type",
+      "input": "expand-m007-in.jsonld",
+      "expect": "expand-m007-out.jsonld",
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1"}
    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],


### PR DESCRIPTION
This commit adds scoping based on `@type` for expansion and compaction. Also ensure that types used in type maps have any associated local context applied to their values.

Also, corrects some minor errors in id and type maps where values were not appropriately expanded ore compacted.

Fixes #415.