### PR TITLE
Use `foaf:nick` in first example using it, which is consistent with t…

### DIFF
--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -1897,7 +1897,7 @@ specified. The full <a>IRI</a> for
 {
 ...
   "@id": "http://example.org/people#joebob",
-  "nick": ****[ "joe", "bob", "JB" ]****,
+  "foaf:nick": ****[ "joe", "bob", "JB" ]****,
 ...
 }
 -->


### PR DESCRIPTION
…he next usage. Later on, the "nick" term is defined.

Fixes #361.