### PR TITLE
In expansion, allow a language map to have a `null` value

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1484,7 +1484,7 @@
                       <em>language value</em>.</li>
                     <li>For each <em>item</em> in <em>language value</em>:
                       <ol class="algorithm">
-                        <li><em>item</em> must be a <a>string</a>,
+                        <li><em>item</em> must be a <a>string</a>
                           <span class="changed">or <code>null</code></span>,
                           otherwise an
                           <a data-link-for="JsonLdErrorCode">invalid language map value</a>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1485,6 +1485,7 @@
                     <li>For each <em>item</em> in <em>language value</em>:
                       <ol class="algorithm">
                         <li><em>item</em> must be a <a>string</a>,
+                          <span class="changed">or <code>null</code></span>,
                           otherwise an
                           <a data-link-for="JsonLdErrorCode">invalid language map value</a>
                           error has been detected and processing is aborted.</li>
@@ -1492,7 +1493,8 @@
                           <em>expanded value</em> that consists of two
                           key-value pairs: (<code>@value</code>-<em>item</em>)
                           and (<code>@language</code>-lowercased
-                          <em>language</em>).</li>
+                          <em>language</em>),
+                          <span class="changed">unless <em>item</em> is <code>null</code></span>.</li>
                       </ol>
                     </li>
                   </ol>
@@ -4373,6 +4375,9 @@
       within the enclosing <a>node object</a> directly.</li>
     <li><code>@container</code> values within an <a>expanded term definition</a> may now
       include <code>@id</code> and <code>@type</code>, corresponding to <a>id maps</a> and <a>type maps</a>.</li>
+    <li>A <a>language map</a> may legitimately have a <code>null</code> value, but
+      the algorithm only allowed <a>string</a> values. This has been updated
+      to allow (and ignore) <code>null</code> values.</li>
   </ul>
 </section>
 

--- a/test-suite/tests/expand-l001-in.jsonld
+++ b/test-suite/tests/expand-l001-in.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "vocab": "http://example.com/vocab/",
+    "label": {
+      "@id": "vocab:label",
+      "@container": "@language"
+    }
+  },
+  "@id": "http://example.com/queen",
+  "label": {
+    "en": null,
+    "de": [ "Die Königin", null ]
+  }
+}

--- a/test-suite/tests/expand-l001-out.jsonld
+++ b/test-suite/tests/expand-l001-out.jsonld
@@ -1,0 +1,12 @@
+[
+  {
+    "@id": "http://example.com/queen",
+    "http://example.com/vocab/label":
+    [
+      {
+        "@value": "Die Königin",
+        "@language": "de"
+      }
+    ]
+  }
+]

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -758,6 +758,13 @@
       "input": "expand-n007-in.jsonld",
       "expect": "expand-n007-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
+   }, {
+      "@id": "#tl001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Language map with null value",
+      "purpose": "A language map may have a null value, which is ignored",
+      "input": "expand-l001-in.jsonld",
+      "expect": "expand-l001-out.jsonld"
     }
   ]
 }


### PR DESCRIPTION
which is allowed in the syntax. Such values are ignored.

Fixes #375.