### PR TITLE
Fix text describing a type map

### DIFF
--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -3437,14 +3437,15 @@ specified. The full <a>IRI</a> for
     <h2>Type Maps</h2>
 
     <p>An <a>type map</a> is used to associate an <a>IRI</a> with a value that allows easy
-      programatic access. An <a>id map</a> may be used as a term value within a <a>node object</a> if the <a>term</a>
-      is defined with <code>@container</code> set to <code>@id</code>. The keys of an <a>id map</a> MUST be <a>IRIs</a>
+      programatic access. A <a>type map</a> may be used as a term value within a <a>node object</a> if the <a>term</a>
+      is defined with <code>@container</code> set to <code>@type</code>. The keys of a <a>type map</a> MUST be <a>IRIs</a>
       (<a>relative IRI</a>, <a>compact IRI</a> (including <a>blank node identifiers</a>), or <a>absolute IRI</a>)
       and the values MUST be <a>node objects</a>.</p>
 
-    <p>If the value contains a property expanding to <code>@id</code>, it's value MUST
-      be equivalent to the referencing key. Otherwise, the property from the value is used as
-      the <code>@id</code> of the <a>node object</a> value when expanding.</p>
+    <p>If the value contains a property expanding to <code>@type</code>, and it's value
+      is contains the referencing key after suitable expansion of both the referencing key
+      and the value, then the <a>node object</a> already contains the type. Otherwise, the property from the value is
+      added as a <code>@type</code> of the <a>node object</a> value when expanding.</p>
   </section>
 
   <section class="changed">


### PR DESCRIPTION
Fixes the description of how type maps work in the syntax document, as reported by @jefferys.