### PR TITLE
Update IRI Compaction, Compaction, and Remove Preserve logic to cause…

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2085,6 +2085,18 @@
                 <li>Continue with the next <em>expanded property</em> from <em>element</em>.</li>
               </ol>
             </li>
+            <li class="changed">If <em>expanded property</em> is <code>@preserve</code>
+              then:
+              <ol class="algorithm">
+                <li>Initialize <em>compacted value</em> to the result of using this
+                  algorithm recursively, passing <a>active context</a>,
+                  <a>inverse context</a>, <em>property</em> for
+                  <a>active property</a>, and <em>expanded value</em>
+                  for <em>element</em>.</li>
+                <li>Add <em>expanded value</em> as the value of <code>@preserve</code>
+                  in <em>result</em> unless <em>expanded value</em> is an empty <a>array</a>.</li>
+              </ol>
+            </li>
             <li>If <em>expanded property</em> is <code>@index</code> and
               <a>active property</a> has a <a>container mapping</a>
               in <a>active context</a> that is <code>@index</code>,
@@ -2508,6 +2520,9 @@
               <a data-lt="active context">active context's</a>
               <a>default language</a>, if it has one, otherwise to
               <code>@none</code>.</li>
+            <li class="changed">If <em>value</em> is a <a>dictionary</a> containing
+              the property <code>@preserve</code>, use the first
+              element from the value of <code>@preserve</code> as <em>value</em>.</li>
             <li>Initialize <em>containers</em> to an empty <a>array</a>. This
               <a>array</a> will be used to keep track of an ordered list of
               preferred <a>container mapping</a>
@@ -4505,6 +4520,7 @@
     <li>The JSON syntax has been abstracted into an <a>internal representation</a>
       to allow for other seriazation formats that are functionally equivalent
       to JSON.</li>
+    <li>Preserved values are compacted using the properties of the referencing term.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -1056,6 +1056,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
 <p>Recursively, replace all key-value pairs in <em>compacted results</em>
   where the key is <code>@preserve</code> with the value from the key-pair.
   If the value from the key-pair is <code>@null</code>, replace the value with <code>null</code>.
+  <span class="changed">If, after replacement, an array contains a single array value, replace the array with that value.</span>
   If, after replacement, an array contains only the value <a>null</a> remove the value, leaving
   an empty <a>array</a>.</p>
 <p>Return <em>compacted results</em>.</p>
@@ -1478,6 +1479,7 @@ becomes a W3C Recommendation.</p>
     <li>The JSON syntax has been abstracted into an <a>internal representation</a>
       to allow for other seriazation formats that are functionally equivalent
       to JSON.</li>
+    <li>Preserved values are compacted using the properties of the referencing term.</li>
   </ul>
 </section>
 

--- a/test-suite/tests/frame-0051-frame.jsonld
+++ b/test-suite/tests/frame-0051-frame.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "name": "schema:name",
+    "url": { "@id": "schema:url", "@type": "schema:URL"}
+  },
+  "name": {},
+  "url": {"@default": {"@value": "http://example.com", "@type": "schema:URL"}}
+}

--- a/test-suite/tests/frame-0051-in.jsonld
+++ b/test-suite/tests/frame-0051-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "name": "schema:name",
+    "url": {"@id": "schema:url", "@type": "schema:URL"}
+  },
+  "name": "Jane Doe"
+}

--- a/test-suite/tests/frame-0051-out.jsonld
+++ b/test-suite/tests/frame-0051-out.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "name": "schema:name",
+    "url": {
+      "@id": "schema:url",
+      "@type": "schema:URL"
+    }
+  },
+  "@graph": [
+    {
+      "name": "Jane Doe",
+      "url": "http://example.com"
+    }
+  ]
+}

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -410,6 +410,14 @@
       "frame": "frame-0050-frame.jsonld",
       "expect": "frame-0050-out.jsonld"
     }, {
+      "@id": "#t0051",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Compacting values of @preserve",
+      "purpose": "When compacting the value of a property using @preserve, use the term definition for term to properly compact the value of @preserve.",
+      "input": "frame-0051-in.jsonld",
+      "frame": "frame-0051-frame.jsonld",
+      "expect": "frame-0051-out.jsonld"
+    }, {
       "@id": "#tp010",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "property CURIE conflict (prune bnodes)",


### PR DESCRIPTION
… values of `@preserve` to be compacted using the referencing term, and for term selection to consider the value of `@preserve`, rather than `@preserve` itself.

Adds a test to ensure appropriate handling by processors.
Fixes #496.