### PR TITLE
@container as array including @set.

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1067,11 +1067,18 @@
               <code>@container</code> key, which must be either
               <code>@list</code>, <code>@set</code>, <code>@index</code>,
               <span class="changed"><code>@id</code>, <code>@type</code></span>
-              or <code>@language</code>. Otherwise, an
+              or <code>@language</code>,
+              <span class="changed">
+                or an <a>array</a> containing exactly any one of those keyswords,
+                or a combination of <code>@set</code> and any of <code>@index</code>,
+                <code>@id</code>, <code>@type</code>, <code>@language</code>
+                in any order
+              </span>.
+              Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid container mapping</a>
               has been detected and processing is aborted.</li>
             <li class="changed">If processingMode is <code>json-ld-1.0</code> and the container value
-              is <code>@id</code> or <code>@type</code>, an
+              is <code>@id</code> or <code>@type</code>, or is otherwise not a <a>string</a>, an
               <a data-link-for="JsonLdErrorCode">invalid container mapping</a>
               has been detected and processing is aborted.</li>
             <li>Set the <a>container mapping</a> of <em>definition</em> to
@@ -1961,9 +1968,13 @@
               </ol>
             </li>
             <li>If <em>result</em> contains only one item (it has a length of
-              <code>1</code>), <a>active property</a> has no
-              <a>container mapping</a> in <a>active context</a>, and
-              <a data-link-for="JsonLdOptions">compactArrays</a>
+              <code>1</code>),
+              <span class="changed">
+                <a>active property</a> is not <code>@graph</code> or <code>@set</code>,
+                or the <a>container mapping</a> for <a>active property</a> in
+                <a>active context</a> does not include <code>@list</code> or <code>@set</code>,
+              </span>
+              and <a data-link-for="JsonLdOptions">compactArrays</a>
               is <code>true</code>, set <em>result</em> to its only item.</li>
             <li>Return <em>result</em>.</li>
           </ol>
@@ -2161,7 +2172,13 @@
                 <li>Initialize <em>container</em> to <code>null</code>. If there
                   is a <a>container mapping</a> for
                   <em>item active property</em> in <a>active context</a>,
-                  set <em>container</em> to its value.</li>
+                  set <em>container</em> to <span class="changed">the first</span>
+                  such value <span class="changed">other than <code>@set</code></span>.</li>
+                <li class="changed">Initialize <em>as array</em> to
+                  <code>true</code> or <code>false</code> depending on if the <a>container mapping</a> for
+                  <em>item active property</em> in <a>active context</a>
+                  includes <code>@set</code> or if <em>item active property</em>
+                  is <code>@graph</code> or <code>@list</code>.</li>
                 <li>Initialize <em>compacted item</em> to the result of using
                   this algorithm recursively, passing
                   <a>active context</a>, <a>inverse context</a>,
@@ -2204,7 +2221,7 @@
                   </ol>
                 </li>
                 <li>
-                  If <em>container</em> is <code>@language</code>,
+                  If <em>container</em> <span class="changed">includes</span> <code>@language</code>,
                   <code>@index</code>, <span class="changed"><code>@id</code>,
                     or <code>@type</code></span>:
                   <ol class="algorithm">
@@ -2242,6 +2259,9 @@
                       <em>compacted container</em> in <em>compacted value</em>
                       to those remaining values. Otherwise, remove that
                       key-value pair from <em>compacted item</em>.</li>
+                    <li class="changed">If <em>compacted item</em> is not an
+                      <a>array</a> and <em>as array</em> is <code>true</code>,
+                      set <em>compacted item</em> to an <a>array</a> containing that value.</li>
                     <li>If <em>map key</em> is not a key in <em>map object</em>,
                       then set this key's value in <em>map object</em>
                       to <em>compacted item</em>. Otherwise, if the value
@@ -2255,9 +2275,7 @@
                   <ol class="algorithm">
                     <li>If
                       <a data-link-for="JsonLdOptions">compactArrays</a>
-                      is <code>false</code>, <em>container</em> is <code>@set</code> or
-                      <code>@list</code>, or <em>expanded property</em> is
-                      <code>@list</code> or <code>@graph</code> and
+                      is <code>false</code>, <em>as array</em> is <code>true</code> and
                       <em>compacted item</em> is not an <a>array</a>,
                       set it to a new <a>array</a>
                       containing only <em>compacted item</em>.</li>
@@ -2362,10 +2380,14 @@
             <li>If the <a>term definition</a> is <code>null</code>,
               <a>term</a> cannot be selected during <a>compaction</a>,
               so continue to the next <a>term</a>.</li>
-            <li>Initialize <em>container</em> to <code>@none</code>. If there
-              is a <a>container mapping</a> in
-              <a>term definition</a>, set <em>container</em> to
-              its associated value.</li>
+            <li>Initialize <em>container</em> to <code>@none</code>. If
+              <span class="changed">
+                the <a>container mapping</a> in <a>term definition</a>
+                includes <code>@id</code>, <code>@index</code>,
+                <code>@language</code>, <code>@list</code>, <code>@type</code>, or
+              <code>@set</code> in that order</span>
+              set <em>container</em> to
+              <span class="changed">the first such value found</span>.</li>
             <li>Initialize <em>iri</em> to the value of the <a>IRI mapping</a>
               for the <a>term definition</a>.</li>
             <li>If <em>iri</em> is not a key in <em>result</em>, add
@@ -4507,6 +4529,11 @@
     <li>The JSON syntax has been abstracted into an <a>internal representation</a>
       to allow for other seriazation formats that are functionally equivalent
       to JSON.</li>
+    <li>The value for <code>@container</code> in an <a>expanded term definition</a>
+      can also be an <a>array</a> containing any appropriate container
+      keyword along with <code>@set</code> (other than <code>@list</code>).
+      This allows a way to ensure that such property values will always
+      be expressed in <a>array</a> form.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1069,7 +1069,7 @@
               <span class="changed"><code>@id</code>, <code>@type</code></span>
               or <code>@language</code>,
               <span class="changed">
-                or an <a>array</a> containing exactly any one of those keyswords,
+                or an <a>array</a> containing exactly any one of those keywords,
                 or a combination of <code>@set</code> and any of <code>@index</code>,
                 <code>@id</code>, <code>@type</code>, <code>@language</code>
                 in any order

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -374,7 +374,12 @@
         <a class="sectionRef" href="#typed-values"></a>.</dd>
       <dt><code>@container</code></dt>
       <dd>Used to set the default container type for a <a>term</a>.
-        This keyword is described in <a class="sectionRef" href="#sets-and-lists"></a>.</dd>
+        This keyword is described in <a class="sectionRef" href="#sets-and-lists"></a>,
+        <span class="changed"><a class="sectionRef" href="#data-indexing"></a>,
+          <a class="sectionRef" href="#language-indexing"></a>,
+          <a class="sectionRef" href="#node-identifier-indexing"></a>, and
+          <a class="sectionRef" href="#node-type-indexing"></a>
+        </span>.</dd>
       <dt><code>@list</code></dt>
       <dd>Used to express an ordered set of data.
         This keyword is described in <a class="sectionRef" href="#sets-and-lists"></a>.</dd>
@@ -2590,6 +2595,108 @@ specified. The full <a>IRI</a> for
       </tr>
     </tbody>
   </table>
+
+  <p class="changed">The value of <code>@container</code> can also
+    be an array containing both <code>@index</code> and <code>@set</code>.
+    When <em>compacting</em>, this ensures that a JSON-LD Processor will use
+    the <a>array</a> form for all values of indexes.</p>
+
+  <pre class="example changed" data-transform="updateExample"
+       title="Indexing data in JSON-LD with @set representation">
+  <!--
+  {
+    "@context": {
+       "schema": "http://schema.org/",
+       "name": "schema:name",
+       "body": "schema:articleBody",
+       "words": "schema:wordCount",
+       "post": {
+         "@id": "schema:blogPost",
+         "@container": ****["@index", "@set"]****
+       }
+    },
+    "@id": "http://example.com/",
+    "@type": "schema:Blog",
+    "name": "World Financial News",
+    "post": {
+       "en": ****[****{
+         "@id": "http://example.com/posts/1/en",
+         "body": "World commodities were up today with heavy trading of crude oil...",
+         "words": 1539
+       }****]****,
+       "de": ****[****{
+         "@id": "http://example.com/posts/1/de",
+         "body": "Die Werte an Warenbörsen stiegen im Sog eines starken Handels von Rohöl...",
+         "words": 1204
+       }****]****
+    }
+  }
+  -->
+  </pre>
+</section>
+
+<section class="informative changed">
+  <h2>Language Indexing</h2>
+
+  <p>JSON which includes string values in multiple languages may be
+    represented using a <a>language map</a> to allow for easily
+    indexing property values by language tag. This enables direct access to
+    lanugage values instead of having to scan an array in search of a specific item.
+    In JSON-LD such data can be specified by associating the
+    <code>@language</code> <a>keyword</a> with a
+    <code>@container</code> declaration in the context:</p>
+
+  <pre class="example" data-transform="updateExample"
+       title="Indexing languaged-tagged strings in JSON-LD">
+  <!--
+  {
+    "@context": {
+      "vocab": "http://example.com/vocab/",
+      "label": {
+        "@id": "vocab:label",
+        "@container": "@language"
+      }
+    },
+    "@id": "http://example.com/queen",
+    "label": {
+      "en": "The Queen",
+      "de": [ "Die Königin", "Ihre Majestät" ]
+    }
+  }
+  -->
+  </pre>
+
+  <p>In the example above, the <strong>label</strong> <a>term</a> has
+    been marked as an <a>language map</a>. The <strong>en</strong> and
+    <strong>de</strong> keys are implicitly associated with their respective
+    values by the JSON-LD Processor.  This allows a developer to
+    access the German version of the <strong>label</strong> using the
+    following code snippet: <code>obj.label.de</code>.</p>
+
+  <p>The value of <code>@container</code> can also
+    be an array containing both <code>@language</code> and <code>@set</code>.
+    When <em>compacting</em>, this ensures that a JSON-LD Processor will use
+    the <a>array</a> form for all values of language tags.</p>
+
+  <pre class="example" data-transform="updateExample"
+       title="Indexing languaged-tagged strings in JSON-LD with @set representation">
+  <!--
+  {
+    "@context": {
+      "vocab": "http://example.com/vocab/",
+      "label": {
+        "@id": "vocab:label",
+        "@container": ****[****"@language", ****"@set"]****
+      }
+    },
+    "@id": "http://example.com/queen",
+    "label": {
+      "en": ****[****"The Queen"****]****,
+      "de": [ "Die Königin", "Ihre Majestät" ]
+    }
+  }
+  -->
+  </pre>
 </section>
 
 <section class="informative changed">
@@ -2644,6 +2751,42 @@ specified. The full <a>IRI</a> for
     as that in <a class="sectionRef" href="#data-indexing"></a>
     using a JSON-LD processor.</p>
 
+  <p>The value of <code>@container</code> can also
+    be an array containing both <code>@id</code> and <code>@set</code>.
+    When <em>compacting</em>, this ensures that a JSON-LD Processor will use
+    the <a>array</a> form for all values of node identifiers.</p>
+
+  <pre class="example" data-transform="updateExample"
+       title="Indexing data in JSON-LD by node identifiers with @set representation">
+  <!--
+  {
+    "@context": {
+       "schema": "http://schema.org/",
+       "name": "schema:name",
+       "body": "schema:articleBody",
+       "words": "schema:wordCount",
+       "post": {
+         "@id": "schema:blogPost",
+         "@container": ****[****"@id", ****"@set"]****
+       }
+    },
+    "@id": "http://example.com/",
+    "@type": "schema:Blog",
+    "name": "World Financial News",
+    "post": {
+       "http://example.com/posts/1/en": ****[****{
+         "body": "World commodities were up today with heavy trading of crude oil...",
+         "words": 1539
+       }****]****,
+       "http://example.com/posts/1/de": ****[****{
+         "body": "Die Werte an Warenbörsen stiegen im Sog eines starken Handels von Rohöl...",
+         "words": 1204
+       }****]****
+    }
+  }
+  -->
+  </pre>
+
   <p class="note"><a>Id maps</a> are a new feature in JSON-LD 1.1, requiring
     <a>processing mode</a> set to <code>json-ld-1.1</code></p>
 </section>
@@ -2661,7 +2804,7 @@ specified. The full <a>IRI</a> for
     <code>@container</code> declaration in the context:</p>
 
   <pre class="example" data-transform="updateExample"
-       title="Indexing data in JSON-LD by node identifiers">
+       title="Indexing data in JSON-LD by type">
   <!--
   {
     "@context": {
@@ -2682,7 +2825,6 @@ specified. The full <a>IRI</a> for
         "@id": "https://spec-ops.io",
         "name": "Spec-Ops"
       }
-      
     }
   }
   -->
@@ -2692,6 +2834,39 @@ specified. The full <a>IRI</a> for
     been marked as an <a>type map</a>. The <code>schema:Corporpation</code> and
     <code>schema:ProfessionalService</code> keys will be interpreted
     as the <code>@type</code> property of the <a>node object</a> value.</p>
+
+  <p>The value of <code>@container</code> can also
+    be an array containing both <code>@type</code> and <code>@set</code>.
+    When <em>compacting</em>, this ensures that a JSON-LD Processor will use
+    the <a>array</a> form for all values of types.</p>
+
+  <pre class="example" data-transform="updateExample"
+       title="Indexing data in JSON-LD by type with @set representation">
+  <!--
+  {
+    "@context": {
+       "schema": "http://schema.org/",
+       "name": "schema:name",
+       "affiliation": {
+         "@id": "schema:affiliation",
+        "@container": ****[****"@type", ****"@set"]****
+       }
+    },
+    "name": "Manu Sporny",
+    "affiliation": {
+      "schema:Corporpation": ****[****{
+        "@id": "http://digitalbazaar.com/",
+        "name": "Digital Bazaar"
+      }****]****,
+      "schema:ProfessionalService": ****[****{
+        "@id": "https://spec-ops.io",
+        "name": "Spec-Ops"
+      }****]****
+      
+    }
+  }
+  -->
+  </pre>
 
   <p class="note"><a>Type maps</a> are a new feature in JSON-LD 1.1, requiring
     <a>processing mode</a> set to <code>json-ld-1.1</code></p>
@@ -2784,7 +2959,7 @@ specified. The full <a>IRI</a> for
 
   <p>The JSON-LD Processing Algorithms and API specification [[JSON-LD-API]]
     defines a method for <em>expanding</em> a JSON-LD document.
-    Expansion is the process of taking a JSON-LD document and applying a
+    <dfn data-cite="JSON-LD-API#dfn-expansion">Expansion</dfn> is the process of taking a JSON-LD document and applying a
     <code>@context</code> such that all IRIs, types, and values
     are expanded so that the <code>@context</code> is no longer necessary.</p>
 
@@ -2807,7 +2982,7 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p>Running the JSON-LD Expansion algorithm against the JSON-LD input document
+  <p>Running the JSON-LD <a data-cite="JSON-LD-API#expansion-algorithm">Expansion algorithm</a> against the JSON-LD input document
     provided above would result in the following output:</p>
 
   <pre class="example" data-transform="updateExample"
@@ -2836,7 +3011,7 @@ specified. The full <a>IRI</a> for
   <h3>Compacted Document Form</h3>
 
   <p>The JSON-LD Processing Algorithms and API specification [[JSON-LD-API]] defines
-    a method for <em>compacting</em> a JSON-LD document. Compaction is the process
+    a method for <em>compacting</em> a JSON-LD document. <dfn data-cite="JSON-LD-API#dfn-compaction">Compaction</dfn> is the process
     of applying a developer-supplied context to shorten <a>IRIs</a>
     to <a>terms</a> or <a>compact IRIs</a>
     and JSON-LD values expressed in expanded form to simple values such as
@@ -2880,7 +3055,7 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p>Running the JSON-LD Compaction algorithm given the context supplied above
+  <p>Running the JSON-LD <a data-cite="JSON-LD-API#compaction-algorithm">Compaction algorithm</a> given the context supplied above
     against the JSON-LD input document provided above would result in the following
     output:</p>
 
@@ -2911,7 +3086,7 @@ specified. The full <a>IRI</a> for
   <h3>Flattened Document Form</h3>
 
   <p>The JSON-LD Processing Algorithms and API specification [[JSON-LD-API]] defines
-    a method for <em>flattening</em> a JSON-LD document. Flattening collects all
+    a method for <em>flattening</em> a JSON-LD document. <dfn data-cite="JSON-LD-API#dfn-flattening">Flattening</dfn> collects all
     properties of a <a>node</a> in a single <a>JSON object</a> and labels
     all <a>blank nodes</a> with
     <a>blank node identifiers</a>.
@@ -2942,7 +3117,7 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p>Running the JSON-LD Flattening algorithm against the JSON-LD input document in
+  <p>Running the JSON-LD <a data-cite="JSON-LD-API#flattening-algorithm">Flattening algorithm</a> against the JSON-LD input document in
     the example above and using the same context would result in the following
     output:</p>
 
@@ -3367,14 +3542,17 @@ specified. The full <a>IRI</a> for
     <p>A <a>language map</a> is used to associate a language with a value in a
       way that allows easy programmatic access. A <a>language map</a> may be
       used as a term value within a <a>node object</a> if the <a>term</a> is defined
-      with <code>@container</code> set to <code>@language</code>. The keys of a
+      with <code>@container</code> set to <code>@language</code>,
+      <span class="changed">
+        or an array containing both <code>@language</code> and <code>@set</code>
+      </span>. The keys of a
       <a>language map</a> MUST be <a>strings</a> representing
       [[BCP47]] language codes and the values MUST be any of the following types:</p>
 
     <ul>
       <li><a>null</a>,</li>
       <li><a>string</a>, or</li>
-      <li>an <a>array</a> of zero or more of the above possibilities</li>
+      <li>an <a>array</a> of zero or more of the <a>strings</a></li>
     </ul>
 
     <p>See <a class="sectionRef" href="#string-internationalization"></a> for further discussion
@@ -3388,7 +3566,10 @@ specified. The full <a>IRI</a> for
       but should be preserved regardless, to be used in JSON-LD documents.
       An <a>index map</a> may
       be used as a <a>term</a> value within a <a>node object</a> if the
-      term is defined with <code>@container</code> set to <code>@index</code>.
+      term is defined with <code>@container</code> set to <code>@index</code>,
+      <span class="changed">
+        or an array containing both <code>@index</code> and <code>@set</code>
+      </span>.
       The values of the members of an <a>index map</a> MUST be one
       of the following types:</p>
 
@@ -3413,7 +3594,9 @@ specified. The full <a>IRI</a> for
 
     <p>An <a>id map</a> is used to associate an <a>IRI</a> with a value that allows easy
       programatic access. An <a>id map</a> may be used as a term value within a <a>node object</a> if the <a>term</a>
-      is defined with <code>@container</code> set to <code>@id</code>. The keys of an <a>id map</a> MUST be <a>IRIs</a>
+      is defined with <code>@container</code> set to <code>@id</code>,
+      or an array containing both <code>@id</code> and <code>@set</code>.
+      The keys of an <a>id map</a> MUST be <a>IRIs</a>
       (<a>relative IRI</a>, <a>compact IRI</a> (including <a>blank node identifiers</a>), or <a>absolute IRI</a>)
       and the values MUST be <a>node objects</a>.</p>
 
@@ -3427,7 +3610,9 @@ specified. The full <a>IRI</a> for
 
     <p>A <a>type map</a> is used to associate an <a>IRI</a> with a value that allows easy
       programatic access. A <a>type map</a> may be used as a term value within a <a>node object</a> if the <a>term</a>
-      is defined with <code>@container</code> set to <code>@type</code>. The keys of a <a>type map</a> MUST be <a>IRIs</a>
+      is defined with <code>@container</code> set to <code>@type</code>,
+      or an array containing both <code>@type</code> and <code>@set</code>.
+      The keys of a <a>type map</a> MUST be <a>IRIs</a>
       (<a>relative IRI</a>, <a>compact IRI</a> (including <a>blank node identifiers</a>), or <a>absolute IRI</a>)
       and the values MUST be <a>node objects</a>.</p>
 
@@ -3443,7 +3628,7 @@ specified. The full <a>IRI</a> for
     <p>A <a>nested property</a> is used to gather <a>properties</a> of a <a>node object</a> in a separate
       <a>JSON object</a>, or <a>array</a> of <a>JSON objects</a> which are not
       <a>value objects</a>. It is semantically transparent and is removed
-      during the process of expansion. Property nesting is recursive, and
+      during the process of <a>expansion</a>. Property nesting is recursive, and
       collections of nested properties may contain further nesting.</p>
 
     <p>Semantically, nesting is treated as if the properties and values were declared directly
@@ -3516,7 +3701,14 @@ specified. The full <a>IRI</a> for
 
   <p>If the <a>expanded term definition</a> contains the <code>@container</code>
     <a>keyword</a>, its value MUST be either <code>@list</code>, <code>@set</code>,
-    <code>@language</code>, <code>@index</code>, <span class="changed"><code>@id</code>, <code>@type</code></span> or be <a>null</a>. If the value
+    <code>@language</code>, <code>@index</code>, <span class="changed"><code>@id</code>, <code>@type</code></span> or be <a>null</a>
+    <span class="changed">
+      or an <a>array</a> containing exactly any one of those keywords,
+      or a combination of <code>@set</code> and any of <code>@index</code>,
+      <code>@id</code>, <code>@type</code>, <code>@language</code>
+      in any order
+    </span>.
+    If the value
     is <code>@language</code>, when the <a>term</a> is used outside of the
     <code>@context</code>, the associated value MUST be a <a>language map</a>.
     If the value is <code>@index</code>, when the <a>term</a> is used outside of
@@ -3631,7 +3823,7 @@ specified. The full <a>IRI</a> for
     <ol>
       <li>Expand the JSON-LD document, removing any context; this ensures
         that properties, types, and values are given their full representation
-        as <a>IRIs</a> and expanded values. Expansion
+        as <a>IRIs</a> and expanded values. <a>Expansion</a>
         is discussed further in <a class="sectionRef" href="#expanded-document-form"></a>.</li>
       <li>Flatten the document, which turns the document into an array of
         <a>node objects</a>. Flattening is discussed
@@ -3663,7 +3855,7 @@ specified. The full <a>IRI</a> for
     -->
     </pre>
 
-    <p>Running the JSON-LD Expansion and Flattening algorithms against the
+    <p>Running the JSON-LD <a data-cite="JSON-LD-API#expansion-algorithm">Expansion</a> and <a data-cite="JSON-LD-API#flattening-algorithm">Flattening</a> algorithms against the
       JSON-LD input document in the example above would result in the
       following output:</p>
 
@@ -3730,6 +3922,12 @@ specified. The full <a>IRI</a> for
     <li>The JSON syntax has been abstracted into an <a>internal representation</a>
       to allow for other serializations that are functionally equivalent
       to JSON.</li>
+    <li>Added <a href="#language-indexing" class="sectionRef"></a>.</li>
+    <li>The value for <code>@container</code> in an <a>expanded term definition</a>
+      can also be an <a>array</a> containing any appropriate container
+      keyword along with <code>@set</code> (other than <code>@list</code>).
+      This allows a way to ensure that such property values will always
+      be expressed in <a>array</a> form.</li>
   </ul>
 </section>
 

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -836,6 +836,24 @@
       "context": "compact-n010-context.jsonld",
       "expect": "compact-n010-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#ts001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "@context with single array values",
+      "purpose": "@context values may be in an array",
+      "input": "compact-s001-in.jsonld",
+      "context": "compact-s001-context.jsonld",
+      "expect": "compact-s001-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#ts001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "@context with array including @set uses array values",
+      "purpose": "@context values may include @set along with another compatible value",
+      "input": "compact-s002-in.jsonld",
+      "context": "compact-s002-context.jsonld",
+      "expect": "compact-s002-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1"}
     }
   ]
 }

--- a/test-suite/tests/compact-s001-context.jsonld
+++ b/test-suite/tests/compact-s001-context.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "mylist": {"@id": "http://example.com/mylist", "@container": ["@list"]},
+    "myset": {"@id": "http://example.com/myset", "@container": ["@set"]},
+    "myid": {"@id": "http://example.com/myid", "@container": ["@id"]},
+    "mytype": {"@id": "http://example.com/mytype", "@container": ["@type"]},
+    "mylanguage": {"@id": "http://example.com/mylanguage", "@container": ["@language"]},
+    "myindex": {"@id": "http://example.com/myindex", "@container": ["@index"]}
+  }
+}

--- a/test-suite/tests/compact-s001-in.jsonld
+++ b/test-suite/tests/compact-s001-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@id": "http://example.org/id",
+  "http://example.com/mylist": {"@list": ["foo"]},
+  "http://example.com/myset": "foo",
+  "http://example.com/myid": {"@id": "http://example/id", "@type": "http://example/type"},
+  "http://example.com/mytype": {"@id": "http://example/id", "@type": "http://example/type"},
+  "http://example.com/mylanguage": {"@value": "foo", "@language": "en"},
+  "http://example.com/myindex": {"@value": "foo", "@index": "bar"}
+}

--- a/test-suite/tests/compact-s001-out.jsonld
+++ b/test-suite/tests/compact-s001-out.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": {
+    "mylist": {"@id": "http://example.com/mylist", "@container": ["@list"]},
+    "myset": {"@id": "http://example.com/myset", "@container": ["@set"]},
+    "myid": {"@id": "http://example.com/myid", "@container": ["@id"]},
+    "mytype": {"@id": "http://example.com/mytype", "@container": ["@type"]},
+    "mylanguage": {"@id": "http://example.com/mylanguage", "@container": ["@language"]},
+    "myindex": {"@id": "http://example.com/myindex", "@container": ["@index"]}
+  },
+  "@id": "http://example.org/id",
+  "mylist": ["foo"],
+  "myset": ["foo"],
+  "myid": {"http://example/id": {"@type": "http://example/type"}},
+  "mytype": {"http://example/type": {"@id": "http://example/id"}},
+  "mylanguage": {"en": "foo"},
+  "myindex": {"bar": "foo"}
+}

--- a/test-suite/tests/compact-s002-context.jsonld
+++ b/test-suite/tests/compact-s002-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "myid": {"@id": "http://example.com/myid", "@container": ["@id", "@set"]},
+    "mytype": {"@id": "http://example.com/mytype", "@container": ["@type", "@set"]},
+    "mylanguage": {"@id": "http://example.com/mylanguage", "@container": ["@language", "@set"]},
+    "myindex": {"@id": "http://example.com/myindex", "@container": ["@index", "@set"]}
+  }
+}

--- a/test-suite/tests/compact-s002-in.jsonld
+++ b/test-suite/tests/compact-s002-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@id": "http://example.org/id",
+  "http://example.com/myid": {"@id": "http://example/id", "@type": "http://example/type"},
+  "http://example.com/mytype": {"@id": "http://example/id", "@type": "http://example/type"},
+  "http://example.com/mylanguage": {"@value": "foo", "@language": "en"},
+  "http://example.com/myindex": {"@value": "foo", "@index": "bar"}
+}

--- a/test-suite/tests/compact-s002-out.jsonld
+++ b/test-suite/tests/compact-s002-out.jsonld
@@ -1,0 +1,13 @@
+{
+  "@context": {
+    "myid": {"@id": "http://example.com/myid", "@container": ["@id", "@set"]},
+    "mytype": {"@id": "http://example.com/mytype", "@container": ["@type", "@set"]},
+    "mylanguage": {"@id": "http://example.com/mylanguage", "@container": ["@language", "@set"]},
+    "myindex": {"@id": "http://example.com/myindex", "@container": ["@index", "@set"]}
+  },
+  "@id": "http://example.org/id",
+  "myid": {"http://example/id": [{"@type": "http://example/type"}]},
+  "mytype": {"http://example/type": [{"@id": "http://example/id"}]},
+  "mylanguage": {"en": ["foo"]},
+  "myindex": {"bar": ["foo"]}
+}

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -429,6 +429,22 @@
       "input": "error-p006-in.jsonld",
       "context": "error-p006-context.jsonld",
       "expect": "invalid @version value"
+    }, {
+      "@id": "#ts001",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Using an array value for @context is illegal in JSON-LD 1.0",
+      "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
+      "input": "error-s001-in.jsonld",
+      "expect": "invalid container mapping",
+      "option": {"processingMode": "json-ld-1.0"}
+    }, {
+      "@id": "#ts002",
+      "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
+      "name": "Mapping @container: [@list, @set] is invalid",
+      "purpose": "Testing legal combinations of @set with other container values",
+      "input": "error-s002-in.jsonld",
+      "expect": "invalid container mapping",
+      "option": {"processingMode": "json-ld-1.1"}
     }
   ]
 }

--- a/test-suite/tests/error-s001-in.jsonld
+++ b/test-suite/tests/error-s001-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "term": {"@id": "http://example/term", "@container": ["@set"]}
+  },
+  "@id": "http://example/test#example",
+  "term": "foo"
+}

--- a/test-suite/tests/error-s002-in.jsonld
+++ b/test-suite/tests/error-s002-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "term": {"@id": "http://example/term", "@container": ["@list", "@set"]}
+  },
+  "@id": "http://example/test#example",
+  "term": "foo"
+}


### PR DESCRIPTION
Add grammar and algorithm changes to allow `@container` to be an array including `@set` along with another container type.

Fixes #269. Fixes #407.