### PR TITLE
Add test for compact property with @type as @id and @container as @list

### DIFF
--- a/test-suite/tests/compact-0074-context.jsonld
+++ b/test-suite/tests/compact-0074-context.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "name": {
+    "@type": "@id",
+    "@container": "@list",
+    "@id": "https://schema.org/name"
+  }
+  }
+}

--- a/test-suite/tests/compact-0074-in.jsonld
+++ b/test-suite/tests/compact-0074-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "name": {
+      "@type": "@id",
+      "@container": "@list",
+      "@id": "https://schema.org/name"
+    }
+  },
+  "name": []
+}

--- a/test-suite/tests/compact-0074-out.jsonld
+++ b/test-suite/tests/compact-0074-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "name": {
+      "@type": "@id",
+      "@container": "@list",
+      "@id": "https://schema.org/name"
+    }
+  },
+  "name": []
+}

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -594,6 +594,14 @@
       "context": "compact-0073-context.jsonld",
       "expect": "compact-0073-out.jsonld"
     }, {
+      "@id": "#t0074",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Container as a list with type of @id",
+      "purpose": "Ensure that compaction works for empty list when proparty has container declared as @list and type as @id",
+      "input": "compact-0074-in.jsonld",
+      "context": "compact-0074-context.jsonld",
+      "expect": "compact-0074-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "adding new term",


### PR DESCRIPTION
I add these tests because probably there is a bug in jsonld.js implementation which prevents compacting fields mapped as container list with type of id.

Not working example on JsonLD playground: [link](https://json-ld.org/playground/#startTab=tab-compacted&json-ld=%7B%22%40context%22%3A%7B%22name%22%3A%7B%22%40type%22%3A%22%40id%22%2C%22%40container%22%3A%22%40list%22%2C%22%40id%22%3A%22https%3A%2F%2Fschema.org%2Fname%22%7D%7D%2C%22name%22%3A%5B%5D%7D&context=%7B%22%40context%22%3A%7B%22name%22%3A%7B%22%40type%22%3A%22%40id%22%2C%22%40container%22%3A%22%40list%22%2C%22%40id%22%3A%22https%3A%2F%2Fschema.org%2Fname%22%7D%7D%7D)

Working example on Markus Lanthaler JsonLD playground: [link](http://www.markus-lanthaler.com/jsonld/playground/?json-ld=%7B%0A%20%20%22%40context%22%3A%20%7B%0A%20%20%20%20%22name%22%3A%20%7B%0A%20%20%20%20%20%20%22%40type%22%3A%20%22%40id%22%2C%0A%20%20%20%20%20%20%22%40container%22%3A%20%22%40list%22%2C%0A%20%20%20%20%20%20%22%40id%22%3A%20%22https%3A%2F%2Fschema.org%2Fname%22%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22name%22%3A%20%5B%5D%0A%7D&frame=%7B%7D&context=%7B%0A%20%20%22%40context%22%3A%20%7B%0A%20%20%20%20%22name%22%3A%20%7B%0A%20%20%20%20%20%20%22%40type%22%3A%20%22%40id%22%2C%0A%20%20%20%20%20%20%22%40container%22%3A%20%22%40list%22%2C%0A%20%20%20%20%20%20%22%40id%22%3A%20%22https%3A%2F%2Fschema.org%2Fname%22%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&startTab=tab-compacted)