### PR TITLE
Allow empty lists to be compacted by any term with container `@list` …

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2409,10 +2409,13 @@
               <em>result</em> using the variable <em>container map</em>.</li>
             <li>If <em>container map</em> has no <em>container</em> member,
               create one and set its value to a new
-              <a class="changed">dictionary</a> with two members. The first member is
-              <code>@language</code> and its value is a new empty
+              <a class="changed">dictionary</a> with <span class="changed">three</span> members.
+              The first member is <code>@language</code> and its value is a new empty
               <a class="changed">dictionary</a>, the second member is <code>@type</code>
-              and its value is a new empty <a class="changed">dictionary</a>.</li>
+              and its value is a new empty <a class="changed">dictionary</a>,
+              <span class="changed">and the third member is <code>@any</code>
+                and its value is a new <a>dictionary</a> with the member
+                <code>@none</code> set to the <a>term</a> being processed</span>.</li>
             <li>Reference the value associated with the <em>container</em> member
               in <em>container map</em> using the variable <em>type/language map</em>.</li>
             <li>If the <a>term definition</a> indicates that the <a>term</a>
@@ -2674,7 +2677,9 @@
               </ol>
             </li>
             <li>Otherwise, append <em>type/language value</em> and <code>@none</code>, in
-              that order, to <em>preferred values</em>.</li>
+              that order, to <em>preferred values</em>.
+              <span class="changed">If <em>value</em> is an empty <a>list object</a>,
+                set <em>type/language</em> to <code>@any</code>.</span></li>
             <li>Initialize <em>term</em> to the result of the
               <a href="#term-selection">Term Selection algorithm</a>, passing
               <a>inverse context</a>, <em>iri</em>, <em>containers</em>,


### PR DESCRIPTION
…that matches the property IRI:

* Update inverse context to creation to include an `@any` member for the _container_ member of _container map_ for a given _iri_.
* Update IRI Compaction to set _type/language_ to `@any` if value is an empty list object.

Fixes #508. PR #509 is appropriate with this change.