### PR TITLE
compactToRelative option and updates to compact IRI creation

### DIFF
--- a/spec/latest/common/common.js
+++ b/spec/latest/common/common.js
@@ -12,7 +12,7 @@ var jsonld = {
     },
     "JSON-LD-API": {
       title: "JSON-LD 1.1 Processing Algorithms and API",
-      href: "http://json-ld.org/spec/latest/json-ld/",
+      href: "http://json-ld.org/spec/latest/json-ld-api/",
       authors: ["Markus Lanthaler", "Gregg Kellogg", "Manu Sporny"],
       publisher: "W3C",
       status: 'CG Draft'

--- a/spec/latest/common/terms.html
+++ b/spec/latest/common/terms.html
@@ -252,7 +252,7 @@
     <dt><dfn data-lt="term definitions">term definition</dfn></dt><dd>
       A term definition is an entry in a <a>context</a>, where the key defines a <a>term</a> which may be used within
       a <a>JSON object</a> as a <a>property</a>, type, or elsewhere that a string is interpreted as a vocabulary item.
-      Its value is either a string, expanding to an absolute IRI, or an <a>expanded term definition</a>.
+      Its value is either a string (<dfn data-lt="simple terms|simple term|simple term definitions">simple term definition</dfn>), expanding to an absolute IRI, or an <a>expanded term definition</a>.
     </dd>
     <dt class="changed"><dfn data-lt="type maps">type map</dfn></dt><dd class="changed">
       An <a>type map</a> is a <a>JSON object</a> value of a <a>term</a> defined with

--- a/spec/latest/common/terms.html
+++ b/spec/latest/common/terms.html
@@ -213,10 +213,10 @@
     <dt><dfn data-lt="objects">object</dfn></dt><dd>
       An <a data-cite="RDF11-CONCEPTS#dfn-object" class="externalDFN">object</a> is a <a>node</a> in a <a>linked data graph</a> with at least one incoming edge.
       See <dfn data-cite="RDF11-CONCEPTS#dfn-object" class="preserve">RDF object</dfn>in [[RDF11-CONCEPTS]].</dd>
-      <dt><dfn data-lt="prefixes">prefix</dfn></dt><dd>
-      A <a>prefix</a> is a <a>term</a> that expands to a vocabulary <a>base IRI</a>. It
-      is typically used along with a <em>suffix</em> to form a <a>compact IRI</a> to create an IRI
-      within a vocabulary.</dd>
+    <dt><dfn data-lt="prefixes">prefix</dfn></dt><dd>
+      A <a>prefix</a> is the first component of a <a>compact IRI</a> which comes from a
+      <a>term</a> that maps to a string that, when prepended to the suffix of the <a>compact IRI</a>
+      results in an <a>absolute IRI</a>.</dd>
     <dt><dfn>processing mode</dfn></dt><dd>
       The processing mode defines how a JSON-LD document is processed.
       By default, all documents are assumed to be conformat with

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -768,12 +768,10 @@
           <ol class="algorithm">
             <li>If <em>context</em> is <code>null</code>, set <em>result</em> to a
               newly-initialized <a>active context</a> and continue with the
-              next <em>context</em>. The <a>base IRI</a> of the
-              <a>active context</a> is set to the IRI of the currently being processed
-              document (which might be different from the currently being processed context),
-              if available; otherwise to <code>null</code>. If set, the
-              <a data-link-for="JsonLdOptions">base</a>
-              option of a JSON-LD API Implementation overrides the <code>base IRI</code>.</li>
+              next <em>context</em>.
+              <span class="note">In JSON-LD 1.0, the <a>base IRI</a> was given
+                a default value here; this is now described conditionally
+                in <a href="#the-application-programming-interface" class="sectionRef"></a>.</span></li>
             <li>If <em>context</em> is a <a>string</a>,
               <ol class="algorithm">
                 <li>Set <em>context</em> to the result of resolving <em>value</em> against
@@ -4073,9 +4071,16 @@
             method using <a data-lt="jsonldprocessor-compact-input">input</a> and <a data-lt="jsonldprocessor-compact-options">options</a>.
           <li>If <a data-lt="jsonldprocessor-compact-context">context</a> is a <a class="changed">dictionary</a> having an <code>@context</code> member, set
             <em>context</em> to that member's value, otherwise to <a data-lt="jsonldprocessor-compact-context">context</a>.</li>
+          <li class="changed">Initialize an <a>active context</a> using <em>context</em>;
+            the <a>base IRI</a> is set to
+            the <a data-link-for="JsonldOptions">base</a> option from
+            <a data-lt="jsonldprocessor-compact-options">options</a>, if set;
+            otherwise, if the
+            <a data-link-for="JsonLdOptions">compactToRelative</a> option is
+            <strong>true</strong>, to the IRI of the currently being processed
+            document, if available; otherwise to <code>null</code>.</li>
           <li>Set <em>compacted output</em> to the result of using the
-            <a href="#compaction-algorithm">Compaction algorithm</a>, passing
-            <em>context</em> as <em>active context</em>,
+            <a href="#compaction-algorithm">Compaction algorithm</a>, using <em>active context</em>,
             an empty <a>dictionary</a> as <a>inverse context</a>,
             <code>null</code> as <em>property</em>,
             <em>expanded input</em> as <em>element</em>, and if passed, the
@@ -4175,12 +4180,20 @@
             method using <a data-lt="jsonldprocessor-flatten-input">input</a> and <a data-lt="jsonldprocessor-flatten-options">options</a>.
           <li>If <a data-lt="jsonldprocessor-flatten-context">context</a> is a <a class="changed">dictionary</a> having an <code>@context</code> member, set
             <em>context</em> to that member's value, otherwise to <a data-lt="jsonldprocessor-flatten-context">context</a>.</li>
+          <li class="changed">Initialize an <a>active context</a> using <em>context</em>;
+            the <a>base IRI</a> is set to
+            the <a data-link-for="JsonldOptions">base</a> option from
+            <a data-lt="jsonldprocessor-flatten-options">options</a>, if set;
+            otherwise, if the
+            <a data-link-for="JsonLdOptions">compactToRelative</a> option is
+            <strong>true</strong>, to the IRI of the currently being processed
+            document, if available; otherwise to <code>null</code>.</li>
           <li>Initialize an empty <em>identifier map</em> and a <em>counter</em> (set to <code>0</code>)
             to be used by the
             <a href="#generate-blank-node-identifier">Generate Blank Node Identifier algorithm</a>.</li>
           <li>Set <em>flattened output</em> to the result of using the
             <a href="#flattening-algorithm">Flattening algorithm</a>, passing
-            <em>expanded input</em> as <em>element</em>, <em>context</em>, and if passed, the
+            <em>expanded input</em> as <em>element</em>, <a>active context</a>, and if passed, the
             <a data-link-for="JsonldOptions">compactArrays</a> flag in <a data-lt="jsonldprocessor-flatten-options">options</a>
             (which is internally passed to the
             <a href="#compaction-algorithm">Compaction algorithm</a>).</li>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -684,7 +684,8 @@
       <a>term definition</a> consists of an <dfn data-lt="IRI mappings">IRI mapping</dfn>, a boolean
       flag <dfn data-lt="reverse properties">reverse property</dfn>, an optional <dfn data-lt="type mappings">type mapping</dfn>
       or <dfn data-lt="language mappings">language mapping</dfn>,
-      <span class="changed">an optional context</span>,
+      <span class="changed">an optional <a>context</a></span>,
+      <span class="changed">an optional <dfn>nest value</dfn>,</span>
       and an optional <dfn data-lt="container mappings">container mapping</dfn>.
       A <a>term definition</a> can not only be used to map a <a>term</a>
       to an IRI, but also to map a <a>term</a> to a <a>keyword</a>,
@@ -1116,7 +1117,7 @@
             <li>If processingMode is <code>json-ld-1.0</code>, an
               <a data-link-for="JsonLdErrorCode">invalid term definition</a>
               has been detected and processing is aborted.</li>
-            <li>Initialize <em>nest</em> to the value associated with the
+            <li>Initialize <a>nest value</a> in <em>defined</em> to the value associated with the
               <code>@nest</code> key, which must be a <a>string</a> and
               must not be a keyword other than <code>@nest</code>. Otherwise, an
               <a data-link-for="JsonLdErrorCode">invalid @nest value</a>
@@ -1125,7 +1126,7 @@
         </li>
         <li>If the value contains any key other than <code>@id</code>,
           <code>@reverse</code>, <code>@container</code>,
-          <code>@context</code>, <code class="changed">@nest</code>, or <code>@type</code>, an
+          <code class="changed">@context</code>, <code class="changed">@nest</code>, or <code>@type</code>, an
           <a data-link-for="JsonLdErrorCode">invalid term definition</a> error has
           been detected and processing is aborted.</li>
         <li>Set the <a>term definition</a> of <em>term</em> in
@@ -2135,8 +2136,7 @@
                   <code>true</code> for <em>vocab</em>, and
                   <em>inside reverse</em>.</li>
                 <li class="changed">If the <a>term definition</a> for <em>item active property</em>
-                  in the <em>active context</em> has a <code>@nest</code>
-                  member, that value (<em>nest term</em>) must be
+                  in the <em>active context</em> has a <a>nest value</a>, that value (<em>nest term</em>) must be
                   <code>@nest</code>, or a <a>term definition</a> in the
                   <em>active context</em> that expands to <code>@nest</code>,
                   otherwise an <a data-link-for="JsonLdErrorCode">invalid @nest
@@ -2170,7 +2170,7 @@
                   <code>true</code> for <em>vocab</em>, and
                   <em>inside reverse</em>.</li>
                 <li class="changed">If the <a>term definition</a> for <em>item active property</em>
-                  in the <em>active context</em> has a <code>@nest</code>
+                  in the <em>active context</em> has a <a>nest value</a>
                   member, that value (<em>nest term</em>) must be
                   <code>@nest</code>, or a <a>term definition</a> in the
                   <em>active context</em> that expands to <code>@nest</code>,

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -4556,6 +4556,8 @@
       keyword along with <code>@set</code> (other than <code>@list</code>).
       This allows a way to ensure that such property values will always
       be expressed in <a>array</a> form.</li>
+    <li>Added support for the <a data-link-for="JsonLdOptions">compactToRelative</a> option to allow IRI compaction (<a href="#iri-compaction" class="sectionRef"></a>)
+      to document relative IRIs to be disabled.</li>
   </ul>
 </section>
 
@@ -4567,7 +4569,6 @@
   <p class="issue" data-number="333"></p>
   <p class="issue" data-number="357"></p>
   <p class="issue" data-number="405"></p>
-  <p class="issue" data-number="468"></p>
   <p class="issue" data-number="480"></p>
   <p class="issue" data-number="489"></p>
   <p class="issue" data-number="492"></p>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -4565,14 +4565,10 @@
   <h2>Open Issues</h2>
   <p>The following is a list of open issues being worked on for the next release.</p>
   <p class="issue" data-number="195"></p>
-  <p class="issue" data-number="269"></p>
   <p class="issue" data-number="333"></p>
   <p class="issue" data-number="357"></p>
   <p class="issue" data-number="405"></p>
   <p class="issue" data-number="480"></p>
-  <p class="issue" data-number="489"></p>
-  <p class="issue" data-number="492"></p>
-  <p class="issue" data-number="493"></p>
   <p class="issue" data-number="495"></p>
 </section>
 

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2511,9 +2511,9 @@
         if there is one. If the <a>IRI</a> could not be compacted, an
         attempt is made to find a <a>compact IRI</a>.
         <span class="changed">A term will be used to create a <a>compact IRI</a>
-          only if the term ends with a colon (<code>:</code>), or if the term
-          maps to a string ending with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a>,
-          with preference given to term ending with a colon (<code>:</code>).</span>
+          only if the term ends with a colon (<code>:</code>), or if
+          a <a>simple term definition</a> is used where its value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a>,
+          with preference given to term maps to a string ending with a colon (<code>:</code>).</span>
         If there is no appropriate <a>compact IRI</a>,
         <span class="changed">and the <a data-link-for="JsonLdOptions">compactToRelative</a> option is <code>true</code>,</span>
         the <a>IRI</a> is
@@ -4606,11 +4606,11 @@
       be expressed in <a>array</a> form.</li>
     <li>Added support for the <a data-link-for="JsonLdOptions">compactToRelative</a> option to allow IRI compaction (<a href="#iri-compaction" class="sectionRef"></a>)
       to document relative IRIs to be disabled.</li>
-    <li>In JSON-LD 1.1, terms will be used as compact IRI prefixes
+    <li>In JSON-LD 1.1, terms will be used as <a>compact IRI</a> prefixes
       when compacting only if
-      they are <a>simple term definitions</a> and either end with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
-      or where the term itself ends with a colon (<code>:</code>).
-      When compacting, preference is given to terms ending in a colon.</li>
+      a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
+      or where the <a>term</a> itself ends with a colon (<code>:</code>).
+      When compacting, preference is given to <a>terms</a> ending in a colon.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1034,11 +1034,12 @@
               error has been detected and processing is aborted; if it equals <code>@context</code>, an
               <a data-link-for="JsonLdErrorCode">invalid keyword alias</a>
               error has been detected and processing is aborted.</li>
-            <li class="changed">If <a>processing mode</a> is <code>json-ld-1.0</code>, and the,
+            <li class="changed">If <em>term</em> does not contain a colon (<code>:</code>),
+              and if <a>processing mode</a> is <code>json-ld-1.0</code>, and the,
               <a>IRI mapping</a> of <em>definition</em> ends with a URI
               <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
               set the <a>prefix flag</a> in <em>definition</em> to <code>true</code>.
-              Otherwise, if the <a>IRI mapping</a> ends with a URI
+              If processing mode is not json-ld-1.0, and the <a>IRI mapping</a> ends with a URI
               <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
               set the <a>prefix flag</a> in <em>definition</em> to <code>true</code>, only if
               <em>value</em> was originally a <a>string</a>.</li>
@@ -1135,7 +1136,8 @@
         </li>
         <li class="changed">If <em>value</em> contains the key <code>@prefix</code>:
           <ol class="algorithm">
-            <li>If processingMode is <code>json-ld-1.0</code>, an
+            <li>If processingMode is <code>json-ld-1.0</code>, or if
+              <em>term</em> contains a colon (<code>:</code>), an
               <a data-link-for="JsonLdErrorCode">invalid term definition</a>
               has been detected and processing is aborted.</li>
             <li>Initialize the <em>prefix flag</em> to the value associated with the

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2512,7 +2512,9 @@
         <a data-lt="active context">active context's</a> <a>vocabulary mapping</a>,
         if there is one. If the <a>IRI</a> could not be compacted, an
         attempt is made to find a <a>compact IRI</a>. If there is no
-        appropriate <a>compact IRI</a>, the <a>IRI</a> is
+        appropriate <a>compact IRI</a>,
+        <span class="changed">and the <a data-link-for="JsonLdOptions">compactToRelative</a> option is <code>true</code>,</span>
+        the <a>IRI</a> is
         transformed to a <a>relative IRI</a> using the document's
         <a>base IRI</a>. Finally, if the <a>IRI</a> or
         <a>keyword</a> still could not be compacted, it is returned
@@ -2729,7 +2731,7 @@
         <li>If <em>compact IRI</em> is not <code>null</code>, return <em>compact IRI</em>.</li>
         <li>If <em>vocab</em> is <code>false</code> then
           transform <em>iri</em> to a <a>relative IRI</a> using
-          the document's base <a>IRI</a>.</li>
+          the <span class="changed"><a>base IRI</a> from <a>active context</a>, if it exists</span>.</li>
         <li>Finally, return <em>iri</em> as is.</li>
       </ol>
     </section>
@@ -4209,6 +4211,7 @@
         (JsonLdDictionary? or USVString) expandContext = null;
         boolean                produceGeneralizedRdf = true;
         USVString              processingMode = null;
+        boolean                compactToRelative = true;
       };
     --></pre>
 
@@ -4243,6 +4246,9 @@
         different optimizations. Developers must not define modes beginning
         with <code>json-ld</code> as they are reserved for future versions
         of this specification.</dd>
+      <dt class="changed"><dfn data-dfn-for="JsonLdOptions">compactToRelative</dfn></dt>
+      <dd class="changed">Determines if IRIs are compacted relative to the
+        <a data-link-for="JsonLdOptions">base</a> option or document location when <a>compacting</a>.</dd>
     </dl>
   </section> <!-- end JsonLdOptions -->
 

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2511,8 +2511,12 @@
         <a>IRI</a>, an attempt is made to compact the <a>IRI</a> using the
         <a data-lt="active context">active context's</a> <a>vocabulary mapping</a>,
         if there is one. If the <a>IRI</a> could not be compacted, an
-        attempt is made to find a <a>compact IRI</a>. If there is no
-        appropriate <a>compact IRI</a>,
+        attempt is made to find a <a>compact IRI</a>.
+        <span class="changed">A term will be used to create a <a>compact IRI</a>
+          only if the term ends with a colon (<code>:</code>), or if the term
+          maps to a string ending with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a>,
+          with preference given to term ending with a colon (<code>:</code>).</span>
+        If there is no appropriate <a>compact IRI</a>,
         <span class="changed">and the <a data-link-for="JsonLdOptions">compactToRelative</a> option is <code>true</code>,</span>
         the <a>IRI</a> is
         transformed to a <a>relative IRI</a> using the document's
@@ -2701,13 +2705,44 @@
           Try to create a <a>compact IRI</a>, starting by initializing
           <em>compact IRI</em> to <code>null</code>. This variable will be used to
           tore the created <a>compact IRI</a>, if any.</li>
-        <li>For each key <a>term</a> and value <a>term definition</a> in
+        <li class="changed">For each key <a>term</a> and value <a>term definition</a> in
+          the <a>active context</a>:
+          <ol class="algorithm">
+            <li>If the <a>term</a> does not end with a colon (<code>:</code>),
+              then continue to the next <a>term</a>.</li>
+            <li>If the <a>term definition</a> is not a <a>simple term definitions</a> then continue to the
+              next <a>term</a>, because <a>expanded term definitions</a> are not used for
+              creating <a>compact IRIs</a>.</li>
+            <li>If the <a>term definition</a> is <code>null</code>,
+              its <a>IRI mapping</a> equals <em>iri</em>, or its
+              <a>IRI mapping</a> is not a substring at the beginning of
+              <em>iri</em>, the <a>term</a> cannot be used as a <a>prefix</a>
+              because it is not a partial match with <em>iri</em>.
+              Continue with the next <a>term</a>.</li>
+            <li>Initialize <em>candidate</em> by concatenating <a>term</a>
+              and the substring of <em>iri</em>
+              that follows after the value of the
+              <a data-lt="term definition">term definition's</a>
+              <a>IRI mapping</a>.</li>
+            <li>If either <em>compact IRI</em> is <code>null</code> or <em>candidate</em> is
+              shorter or the same length but lexicographically less than
+              <em>compact IRI</em> and <em>candidate</em> does not have a
+              <a>term definition</a> in <a>active context</a> or if the
+              <a>term definition</a> has an <a>IRI mapping</a>
+              that equals <em>iri</em> and <em>value</em> is <code>null</code>,
+              set <em>compact IRI</em> to <em>candidate</em>.</li>
+          </ol>
+        </li>
+        <li><span class="changed">If <em>compact IRI</em> is <strong>null</strong>, then</span> for each key <a>term</a> and value <a>term definition</a> in
           the <a>active context</a>:
           <ol class="algorithm">
             <li>If the <a>term</a> contains a colon (<code>:</code>),
               then continue to the next <a>term</a> because
               <a>terms</a> with colons can't be
               used as <a>prefixes</a>.</li>
+            <li class="changed">If the <a>term definition</a> is not a <a>simple term definitions</a> then continue to the
+              next <a>term</a>, because <a>expanded term definitions</a> are not used for
+              creating <a>compact IRIs</a>.</li>
             <li>If the <a>term definition</a> is <code>null</code>,
               its <a>IRI mapping</a> equals <em>iri</em>, or its
               <a>IRI mapping</a> is not a substring at the beginning of
@@ -4558,6 +4593,11 @@
       be expressed in <a>array</a> form.</li>
     <li>Added support for the <a data-link-for="JsonLdOptions">compactToRelative</a> option to allow IRI compaction (<a href="#iri-compaction" class="sectionRef"></a>)
       to document relative IRIs to be disabled.</li>
+    <li>In JSON-LD 1.1, terms will be used as compact IRI prefixes
+      when compacting only if
+      they are <a>simple term definitions</a> and either end with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
+      or where the term itself ends with a colon (<code>:</code>).
+      When compacting, preference is given to terms ending in a colon.</li>
   </ul>
 </section>
 
@@ -4567,8 +4607,9 @@
   <p class="issue" data-number="195"></p>
   <p class="issue" data-number="333"></p>
   <p class="issue" data-number="357"></p>
-  <p class="issue" data-number="405"></p>
+  <p class="issue" data-number="470"></p>
   <p class="issue" data-number="480"></p>
+  <p class="issue" data-number="488"></p>
   <p class="issue" data-number="495"></p>
 </section>
 

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -686,6 +686,7 @@
       or <dfn data-lt="language mappings">language mapping</dfn>,
       <span class="changed">an optional <a>context</a></span>,
       <span class="changed">an optional <dfn>nest value</dfn>,</span>
+      <span class="changed">an optional <dfn>prefix flag</dfn>,</span>
       and an optional <dfn data-lt="container mappings">container mapping</dfn>.
       A <a>term definition</a> can not only be used to map a <a>term</a>
       to an IRI, but also to map a <a>term</a> to a <a>keyword</a>,
@@ -1033,6 +1034,14 @@
               error has been detected and processing is aborted; if it equals <code>@context</code>, an
               <a data-link-for="JsonLdErrorCode">invalid keyword alias</a>
               error has been detected and processing is aborted.</li>
+            <li class="changed">If <a>processing mode</a> is <code>json-ld-1.0</code>, and the,
+              <a>IRI mapping</a> of <em>definition</em> ends with a URI
+              <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
+              set the <a>prefix flag</a> in <em>definition</em> to <code>true</code>.
+              Otherwise, if the <a>IRI mapping</a> ends with a URI
+              <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
+              set the <a>prefix flag</a> in <em>definition</em> to <code>true</code>, only if
+              <em>value</em> was originally a <a>string</a>.</li>
           </ol>
         </li>
         <li>
@@ -1124,9 +1133,21 @@
               error has been detected and processing is aborted.</li>
           </ol>
         </li>
+        <li class="changed">If <em>value</em> contains the key <code>@prefix</code>:
+          <ol class="algorithm">
+            <li>If processingMode is <code>json-ld-1.0</code>, an
+              <a data-link-for="JsonLdErrorCode">invalid term definition</a>
+              has been detected and processing is aborted.</li>
+            <li>Initialize the <em>prefix flag</em> to the value associated with the
+              <code>@prefix</code> key, which must be a <a>boolean</a>. Otherwise, an
+              <a data-link-for="JsonLdErrorCode">invalid @prefix value</a>
+              error has been detected and processing is aborted.</li>
+          </ol>
+        </li>
         <li>If the value contains any key other than <code>@id</code>,
           <code>@reverse</code>, <code>@container</code>,
-          <code class="changed">@context</code>, <code class="changed">@nest</code>, or <code>@type</code>, an
+          <code class="changed">@context</code>, <code class="changed">@nest</code>,
+          <code class="changed">@prefix</code>, or <code>@type</code>, an
           <a data-link-for="JsonLdErrorCode">invalid term definition</a> error has
           been detected and processing is aborted.</li>
         <li>Set the <a>term definition</a> of <em>term</em> in
@@ -2511,9 +2532,8 @@
         if there is one. If the <a>IRI</a> could not be compacted, an
         attempt is made to find a <a>compact IRI</a>.
         <span class="changed">A term will be used to create a <a>compact IRI</a>
-          only if the term ends with a colon (<code>:</code>), or if
-          a <a>simple term definition</a> is used where its value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a>,
-          with preference given to term maps to a string ending with a colon (<code>:</code>).</span>
+          only if the <a>term definition</a> contains the <a>prefix flag</a>
+          with the value <code>true</code>.</span>
         If there is no appropriate <a>compact IRI</a>,
         <span class="changed">and the <a data-link-for="JsonLdOptions">compactToRelative</a> option is <code>true</code>,</span>
         the <a>IRI</a> is
@@ -2703,49 +2723,16 @@
           Try to create a <a>compact IRI</a>, starting by initializing
           <em>compact IRI</em> to <code>null</code>. This variable will be used to
           tore the created <a>compact IRI</a>, if any.</li>
-        <li class="changed">For each key <a>term</a> and value <a>term definition</a> in
+        <li>or each key <a>term</a> and value <a>term definition</a> in
           the <a>active context</a>:
           <ol class="algorithm">
-            <li>If the <a>term</a> does not end with a colon (<code>:</code>),
-              then continue to the next <a>term</a>.</li>
-            <li>If the <a>term definition</a> is not a <a>simple term definitions</a> then continue to the
-              next <a>term</a>, because <a>expanded term definitions</a> are not used for
-              creating <a>compact IRIs</a>.</li>
             <li>If the <a>term definition</a> is <code>null</code>,
-              its <a>IRI mapping</a> equals <em>iri</em>, or its
+              its <a>IRI mapping</a> equals <em>iri</em>, its
               <a>IRI mapping</a> is not a substring at the beginning of
-              <em>iri</em>, the <a>term</a> cannot be used as a <a>prefix</a>
-              because it is not a partial match with <em>iri</em>.
-              Continue with the next <a>term</a>.</li>
-            <li>Initialize <em>candidate</em> by concatenating <a>term</a>
-              and the substring of <em>iri</em>
-              that follows after the value of the
-              <a data-lt="term definition">term definition's</a>
-              <a>IRI mapping</a>.</li>
-            <li>If either <em>compact IRI</em> is <code>null</code> or <em>candidate</em> is
-              shorter or the same length but lexicographically less than
-              <em>compact IRI</em> and <em>candidate</em> does not have a
-              <a>term definition</a> in <a>active context</a> or if the
-              <a>term definition</a> has an <a>IRI mapping</a>
-              that equals <em>iri</em> and <em>value</em> is <code>null</code>,
-              set <em>compact IRI</em> to <em>candidate</em>.</li>
-          </ol>
-        </li>
-        <li><span class="changed">If <em>compact IRI</em> is <strong>null</strong>, then</span> for each key <a>term</a> and value <a>term definition</a> in
-          the <a>active context</a>:
-          <ol class="algorithm">
-            <li>If the <a>term</a> contains a colon (<code>:</code>),
-              then continue to the next <a>term</a> because
-              <a>terms</a> with colons can't be
-              used as <a>prefixes</a>.</li>
-            <li class="changed">If the <a>term definition</a> is not a <a>simple term definitions</a> then continue to the
-              next <a>term</a>, because <a>expanded term definitions</a> are not used for
-              creating <a>compact IRIs</a>.</li>
-            <li>If the <a>term definition</a> is <code>null</code>,
-              its <a>IRI mapping</a> equals <em>iri</em>, or its
-              <a>IRI mapping</a> is not a substring at the beginning of
-              <em>iri</em>, the <a>term</a> cannot be used as a <a>prefix</a>
-              because it is not a partial match with <em>iri</em>.
+              <em>iri</em>,
+              <span class="changed"> or the term definition does not contain
+                the <a>prefix flag</a> having a value of <code>true</code>,</span>
+              the <a>term</a> cannot be used as a <a>prefix</a>.
               Continue with the next <a>term</a>.</li>
             <li>Initialize <em>candidate</em> by concatenating <a>term</a>,
               a colon (<code>:</code>), and the substring of <em>iri</em>
@@ -4406,6 +4393,7 @@
             "invalid @id value",
             "invalid @index value",
             "invalid @nest value",
+            "invalid @prefix value",
             "invalid @reverse value",
             "invalid @version value",
             "invalid base IRI",
@@ -4461,6 +4449,8 @@
           not a <a>string</a>.</dd>
         <dt class="changed"><dfn>invalid @nest value</dfn></dt>
         <dd class="changed">An invalid value for <code>@nest</code> has been found.</dd>
+        <dt class="changed"><dfn>invalid @prefix value</dfn></dt>
+        <dd class="changed">An invalid value for <code>@prefix</code> has been found.</dd>
         <dt><dfn>invalid @reverse value</dfn></dt>
         <dd>An invalid value for an <code>@reverse</code> member has been detected,
           i.e., the value was not a <a class="changed">dictionary</a>.</dd>
@@ -4609,8 +4599,10 @@
     <li>In JSON-LD 1.1, terms will be used as <a>compact IRI</a> prefixes
       when compacting only if
       a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
-      or where the <a>term</a> itself ends with a colon (<code>:</code>).
-      When compacting, preference is given to <a>terms</a> ending in a colon.</li>
+      or if their <a>expanded term definition</a> contains
+      a <code>@prefix</code> member with the value <a>true</a>. The 1.0 algorithm has
+      been updated to only consider terms that map to a value that ends with a URI
+      <a data-cite="RFC3986#section-2.2">gen-delim</a> character.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -1222,13 +1222,21 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
       <li>Set <em>context</em> to the value of <code>@context</code>
         from <a data-lt="JsonLdProcessor-frame-frame">frame</a>, if it exists, or to
         a new empty <a>context</a>, otherwise.</li>
+      <li class="changed">Initialize an <a>active context</a> using <em>context</em>;
+        the <a>base IRI</a> is set to
+        the <a data-cite="JSON-LD-API#dom-jsonldoptions-base">base</a> option from
+        <a data-lt="jsonldprocessor-frame-options">options</a>, if set;
+        otherwise, if the
+        <a data-cite="JSON-LD-API#dom-jsonldoptions-compacttorelative">compactToRelative</a> option is
+        <strong>true</strong>, to the IRI of the currently being processed
+        document, if available; otherwise to <code>null</code>.</li>
       <li>If <a data-lt="JsonLdProcessor-frame-frame">frame</a> has a top-level
         property which expands to <code>@graph</code> set the <a data-link-for="JsonLdOptions">frameDefault</a>
         option to <a data-lt="JsonLdProcessor-frame-options">options</a> with the
         value <code>true</code>.</li>
       <li>Set <em>framed</em> to the result of using the
         <a href="#framing-algorithm">Framing algorithm</a>, passing
-        <em>expanded input</em>, <em>expanded frame</em>, <em>context</em>, and <em>options</em>.</li>
+        <em>expanded input</em>, <em>expanded frame</em>, <a>active context</a>, and <em>options</em>.</li>
       <li>Fulfill the <em>promise</em> passing <em>framed</em>.</li>
     </ol>
 

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -1043,12 +1043,11 @@
     underscore (<code>_</code>), the value is interpreted as <a>blank node identifier</a>
     instead.</p>
 
-  <p class="changed">In JSON-LD 1.1, terms will be used as compact IRI prefixes
+  <p>In JSON-LD 1.1, terms will be used as <a>compact IRI</a> prefixes
     when compacting only if
-    they are <a>simple term definitions</a> and either end with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character (e.g,
-    <code>/</code>, <code>#</code> and others, see RFC3986) or where the term
-    itself ends with a colon (<code>:</code>). When compacting, preference
-    is given to terms ending in a colon.</p>
+    a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character
+    (e.g, <code>/</code>, <code>#</code> and others, see [[!RFC3986]]),
+    or where the <a>term</a> itself ends with a colon (<code>:</code>)</p>
 
   <p>It's also possible to use compact IRIs within the context as shown in the
     following example:</p>
@@ -3943,11 +3942,11 @@ specified. The full <a>IRI</a> for
       keyword along with <code>@set</code> (other than <code>@list</code>).
       This allows a way to ensure that such property values will always
       be expressed in <a>array</a> form.</li>
-    <li>In JSON-LD 1.1, terms will be used as compact IRI prefixes
+    <li>In JSON-LD 1.1, terms will be used as <a>compact IRI</a> prefixes
       when compacting only if
-      they are <a>simple term definitions</a> and either end with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
-      or where the term itself ends with a colon (<code>:</code>).
-      When compacting, preference is given to terms ending in a colon.</li>
+      a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
+      or where the <a>term</a> itself ends with a colon (<code>:</code>).
+      When compacting, preference is given to <a>terms</a> ending in a colon.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -3944,10 +3944,7 @@ specified. The full <a>IRI</a> for
   <h4>Open Issues</h4>
   <p>The following is a list of open issues being worked on for the next release.</p>
   <p class="issue" data-number="195"></p>
-  <p class="issue" data-number="269"></p>
   <p class="issue" data-number="333"></p>
-  <p class="issue" data-number="407"></p>
-  <p class="issue" data-number="429"></p>
   <p class="issue" data-number="481"></p>
 </section>
 

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -1043,6 +1043,12 @@
     underscore (<code>_</code>), the value is interpreted as <a>blank node identifier</a>
     instead.</p>
 
+  <p class="changed">In JSON-LD 1.1, terms will be used as compact IRI prefixes
+    when compacting only if
+    they are <a>simple term definitions</a> and either end with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character (e.g,
+    <code>/</code>, <code>#</code> and others, see RFC3986) or where the term
+    itself ends with a colon (<code>:</code>). When compacting, preference
+    is given to terms ending in a colon.</p>
 
   <p>It's also possible to use compact IRIs within the context as shown in the
     following example:</p>
@@ -2228,7 +2234,7 @@ specified. The full <a>IRI</a> for
   <p>Scoping on <code>@type</code> is useful when common properties are used to relate things of different types, where the vocabularies in use within different entities calls for different context scoping. For example, `hasPart`/`partOf` may be common terms used in a document, but mean different things depending on the context.</p>
 
   <p class="note">Scoped Contexts are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code></p>
+    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
 </section>
 
 
@@ -2788,7 +2794,7 @@ specified. The full <a>IRI</a> for
   </pre>
 
   <p class="note"><a>Id maps</a> are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code></p>
+    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
 </section>
 
 <section class="informative changed">
@@ -2869,7 +2875,7 @@ specified. The full <a>IRI</a> for
   </pre>
 
   <p class="note"><a>Type maps</a> are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code></p>
+    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
 </section>
 
 <section class="informative changed">
@@ -2951,7 +2957,7 @@ specified. The full <a>IRI</a> for
   </pre>
 
   <p class="note"><a>Nested properties</a> are a new feature in JSON-LD 1.1, requiring
-    <a>processing mode</a> set to <code>json-ld-1.1</code></p>
+    <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>
 </section>
 
 <section class="informative">
@@ -3937,6 +3943,11 @@ specified. The full <a>IRI</a> for
       keyword along with <code>@set</code> (other than <code>@list</code>).
       This allows a way to ensure that such property values will always
       be expressed in <a>array</a> form.</li>
+    <li>In JSON-LD 1.1, terms will be used as compact IRI prefixes
+      when compacting only if
+      they are <a>simple term definitions</a> and either end with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
+      or where the term itself ends with a colon (<code>:</code>).
+      When compacting, preference is given to terms ending in a colon.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -404,6 +404,9 @@
         This keyword is described in <a class="sectionRef" href="#named-graphs"></a>.</dd>
       <dt class="changed"><code>@nest</code></dt><dd class="changed">Collects a set of <a>nested properties</a> within
         a <a>node object</a>.</dd>
+      <dt class="changed"><code>@prefix</code></dt><dd class="changed">
+        With the value <a>true</a>, allows this <a>term</a> to be used to construct a <a>compact IRI</a>
+        when compacting.</dd>
       <dt class="changed"><code>@version</code></dt><dd class="changed">
         Used in a <a>context definition</a> to set the <a>processing mode</a>.
         New features since <a data-cite="JSON-LD-20140116">JSON-LD 1.0</a> [[!JSON-LD-20140116]] described in this specification are
@@ -1043,11 +1046,20 @@
     underscore (<code>_</code>), the value is interpreted as <a>blank node identifier</a>
     instead.</p>
 
-  <p>In JSON-LD 1.1, terms will be used as <a>compact IRI</a> prefixes
-    when compacting only if
-    a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character
-    (e.g, <code>/</code>, <code>#</code> and others, see [[!RFC3986]]),
-    or where the <a>term</a> itself ends with a colon (<code>:</code>)</p>
+  <p class="changed">In JSON-LD 1.0, terms will be used as <a>compact IRI</a> prefixes when
+  compacting only if they map to a value that ends with a URI <a
+  data-cite="RFC3986#section-2.2">gen-delim</a> character (e.g, <code>/</code>,
+  <code>#</code> and others, see [[!RFC3986]]).</p>
+
+  <p class="note">This represents a small change to the 1.0 algorithm to prevent IRIs
+    that are not really intended to be used as prefixes from being used for creating
+    <a>compact IRIs</a>.</p>
+
+  <p class="changed">When <a>processing mode</a> is set to <code>json-ld-1.1</code>, terms will be used as <a>compact IRI</a> prefixes
+    when compacting only if their <a>expanded term definition</a> contains
+    a <code>@prefix</code> member with the value <a>true</a>, or if it has a
+    a <a>simple term definition</a>  where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character
+    (e.g, <code>/</code>, <code>#</code> and others, see [[!RFC3986]]).</p>
 
   <p>It's also possible to use compact IRIs within the context as shown in the
     following example:</p>
@@ -3945,8 +3957,10 @@ specified. The full <a>IRI</a> for
     <li>In JSON-LD 1.1, terms will be used as <a>compact IRI</a> prefixes
       when compacting only if
       a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
-      or where the <a>term</a> itself ends with a colon (<code>:</code>).
-      When compacting, preference is given to <a>terms</a> ending in a colon.</li>
+      or if their <a>expanded term definition</a> contains
+      a <code>@prefix</code> member with the value <a>true</a>. The 1.0 algorithm has
+      been updated to only consider terms that map to a value that ends with a URI
+      <a data-cite="RFC3986#section-2.2">gen-delim</a> character.</li>
   </ul>
 </section>
 

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -3699,7 +3699,8 @@ specified. The full <a>IRI</a> for
 
   <p>An <a>expanded term definition</a> MUST be a <a>JSON object</a>
     composed of zero or more keys from <code>@id</code>, <code>@reverse</code>,
-    <code>@type</code>, <code>@language</code>, <code class="changed">@context</code> or <code>@container</code>. An
+    <code>@type</code>, <code>@language</code>, <code class="changed">@context</code>,
+    <code class="changed">@prefix</code> or <code>@container</code>. An
     <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
 
   <p>If an <a>expanded term definition</a> has an <code>@reverse</code> member,
@@ -3744,13 +3745,16 @@ specified. The full <a>IRI</a> for
   <p class="changed">If an <a>expanded term definition</a> has an <code>@context</code> member,
     it MUST be a valid <code>context definition</code>.</p>
 
+  <p class="changed">If the <a>expanded term definition</a> contains the <code>@nest</code>
+    <a>keyword</a>, its value MUST be either <code>@nest</code>, or a term
+    which expands to <code>@nest</code>.</p>
+
+  <p class="changed">If the <a>expanded term definition</a> contains the <code>@prefix</code>
+    <a>keyword</a>, its value MUST be <code>true</code> or <code>false</code>.</p>
+
   <p><a>Terms</a> MUST NOT be used in a circular manner. That is,
     the definition of a term cannot depend on the definition of another term if that other
     term also depends on the first term.</p>
-
-  <p>If the <a>expanded term definition</a> contains the <code>@nest</code>
-    <a>keyword</a>, its value MUST be either <code>@nest</code>, or a term
-    which expands to <code>@nest</code>.</p>
 
   <p>See <a class="sectionRef" href="#the-context"></a> for further discussion on contexts.</p>
 </section>

--- a/test-suite/context.jsonld
+++ b/test-suite/context.jsonld
@@ -20,6 +20,7 @@
     "description":          "rdfs:comment",
     "base":                 { "@type": "@id" },
     "compactArrays":        { "@type": "xsd:boolean" },
+    "compactToRelative":    { "@type": "xsd:boolean" },
     "documentLoader":       { "@type": "xsd:string" },
     "expandContext":        { "@type": "xsd:string" },
     "processingMode":       { "@type": "xsd:string" },

--- a/test-suite/tests/compact-0038-out.jsonld
+++ b/test-suite/tests/compact-0038-out.jsonld
@@ -20,19 +20,19 @@
   "title": {
     "en": {
         "@type": "site-cd:field-types/title_field",
-        "title:/value": "This is the English title"
+        "site-cd:node/article/title/value": "This is the English title"
     },
     "es": {
       "@type": "site-cd:field-types/title_field",
-      "title:/value": "Este es el t’tulo espa–ol"
+      "site-cd:node/article/title/value": "Este es el t’tulo espa–ol"
     }
   },
   "body": {
     "en": {
       "@type": "site-cd:field-types/text_with_summary",
-      "body:/value": "This is the English body. There is no Spanish body, so this will be displayed for both the English and Spanish versions.",
-      "body:/summary": "This is the teaser for the body.",
-      "body:/format": "full_html"
+      "site-cd:node/article/body/value": "This is the English body. There is no Spanish body, so this will be displayed for both the English and Spanish versions.",
+      "site-cd:node/article/body/summary": "This is the teaser for the body.",
+      "site-cd:node/article/body/format": "full_html"
     }
   },
   "field_tags": {

--- a/test-suite/tests/compact-0045-context.jsonld
+++ b/test-suite/tests/compact-0045-context.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "term": "http://example.com/terms-are-not-considered-in-id",
-    "compact-iris": "http://example.com/compact-iris-",
+    "compact-iris": "http://example.com/compact-iris#",
     "property": "http://example.com/property",
     "@vocab": "http://example.org/vocab-is-not-considered-for-id"
   },

--- a/test-suite/tests/compact-0045-in.jsonld
+++ b/test-suite/tests/compact-0045-in.jsonld
@@ -3,7 +3,7 @@
     "@id": "http://json-ld.org/test-suite/tests/term",
     "http://example.com/property": [
       {
-        "@id": "http://example.com/compact-iris-are-considered",
+        "@id": "http://example.com/compact-iris#are-considered",
         "http://example.com/property": [
           { "@value": "@id supports the following values: relative, absolute, and compact IRIs" }
         ]

--- a/test-suite/tests/compact-0045-out.jsonld
+++ b/test-suite/tests/compact-0045-out.jsonld
@@ -1,7 +1,7 @@
 {
   "@context": {
     "term": "http://example.com/terms-are-not-considered-in-id",
-    "compact-iris": "http://example.com/compact-iris-",
+    "compact-iris": "http://example.com/compact-iris#",
     "property": "http://example.com/property",
     "@vocab": "http://example.org/vocab-is-not-considered-for-id"
   },

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -837,6 +837,28 @@
       "expect": "compact-n010-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
     }, {
+      "@id": "#tr001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Expands and compacts to document base by default",
+      "purpose": "Compact IRI attempts to compact document-relative IRIs",
+      "input": "compact-r001-in.jsonld",
+      "context": "compact-r001-context.jsonld",
+      "expect": "compact-r001-out.jsonld",
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1"}
+    }, {
+      "@id": "#tr002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Expands and does not compact to document base with compactToRelative false",
+      "purpose": "With compactToRelative option set to false, IRIs which could be made relative to the document base are not made relative.",
+      "input": "compact-r002-in.jsonld",
+      "context": "compact-r002-context.jsonld",
+      "expect": "compact-r002-out.jsonld",
+      "option": {
+        "base": "http://example.org/",
+        "processingMode": "json-ld-1.1",
+        "compactToRelative": false
+      }
+    }, {
       "@id": "#ts001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "@context with single array values",
@@ -846,7 +868,7 @@
       "expect": "compact-s001-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
     }, {
-      "@id": "#ts001",
+      "@id": "#ts002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "@context with array including @set uses array values",
       "purpose": "@context values may include @set along with another compatible value",

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -886,7 +886,6 @@
       "context": "compact-r002-context.jsonld",
       "expect": "compact-r002-out.jsonld",
       "option": {
-        "base": "http://example.org/",
         "processingMode": "json-ld-1.1",
         "compactToRelative": false
       }

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -837,6 +837,38 @@
       "expect": "compact-n010-out.jsonld",
       "option": {"processingMode": "json-ld-1.1"}
     }, {
+      "@id": "#tp001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact IRI using term ending with ':'",
+      "purpose": "Compacting to compact IRIs favors terms ending in ':'",
+      "input": "compact-p001-in.jsonld",
+      "context": "compact-p001-context.jsonld",
+      "expect": "compact-p001-out.jsonld"
+    }, {
+      "@id": "#tp002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact IRI does not use expanded term definition",
+      "purpose": "Terms with an expanded term definition are not used for creating compact IRIs",
+      "input": "compact-p002-in.jsonld",
+      "context": "compact-p002-context.jsonld",
+      "expect": "compact-p002-out.jsonld"
+    }, {
+      "@id": "#tp003",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact IRI does not use simple term that does not end with a gen-delim",
+      "purpose": "Terms not ending with a gen-delim are not used for creating compact IRIs",
+      "input": "compact-p003-in.jsonld",
+      "context": "compact-p003-context.jsonld",
+      "expect": "compact-p003-out.jsonld"
+    }, {
+      "@id": "#tp004",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact IRIs using simple terms ending with gen-delim",
+      "purpose": "All simple terms ending with gen-delim are suitable for compaction",
+      "input": "compact-p004-in.jsonld",
+      "context": "compact-p004-context.jsonld",
+      "expect": "compact-p004-out.jsonld"
+    }, {
       "@id": "#tr001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Expands and compacts to document base by default",

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -839,16 +839,18 @@
     }, {
       "@id": "#tp001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
-      "name": "Compact IRI using term ending with ':'",
-      "purpose": "Compacting to compact IRIs favors terms ending in ':'",
+      "name": "Compact IRI does may use an expanded term definition in 1.0",
+      "purpose": "Terms with an expanded term definition may be used for creating compact IRIs",
+      "option": {"processingMode": "json-ld-1.0"},
       "input": "compact-p001-in.jsonld",
       "context": "compact-p001-context.jsonld",
       "expect": "compact-p001-out.jsonld"
     }, {
       "@id": "#tp002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
-      "name": "Compact IRI does not use expanded term definition",
+      "name": "Compact IRI does not use expanded term definition in 1.1",
       "purpose": "Terms with an expanded term definition are not used for creating compact IRIs",
+      "option": {"processingMode": "json-ld-1.1"},
       "input": "compact-p002-in.jsonld",
       "context": "compact-p002-context.jsonld",
       "expect": "compact-p002-out.jsonld"
@@ -868,6 +870,24 @@
       "input": "compact-p004-in.jsonld",
       "context": "compact-p004-context.jsonld",
       "expect": "compact-p004-out.jsonld"
+    }, {
+      "@id": "#tp005",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact IRI uses term with definition including @prefix: true",
+      "purpose": "Expanded term definition may set prefix explicitly in 1.1",
+      "option": {"processingMode": "json-ld-1.1"},
+      "input": "compact-p005-in.jsonld",
+      "context": "compact-p005-context.jsonld",
+      "expect": "compact-p005-out.jsonld"
+    }, {
+      "@id": "#tp006",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact IRI uses term with definition including @prefix: true",
+      "purpose": "Expanded term definition may set prefix explicitly in 1.1",
+      "option": {"processingMode": "json-ld-1.1"},
+      "input": "compact-p006-in.jsonld",
+      "context": "compact-p006-context.jsonld",
+      "expect": "compact-p006-out.jsonld"
     }, {
       "@id": "#tr001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -889,6 +889,14 @@
       "context": "compact-p006-context.jsonld",
       "expect": "compact-p006-out.jsonld"
     }, {
+      "@id": "#tp007",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact IRI not used as prefix",
+      "purpose": "Terms including a colon are excluded from being used as a prefix",
+      "input": "compact-p007-in.jsonld",
+      "context": "compact-p007-context.jsonld",
+      "expect": "compact-p007-out.jsonld"
+    }, {
       "@id": "#tr001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Expands and compacts to document base by default",

--- a/test-suite/tests/compact-p001-context.jsonld
+++ b/test-suite/tests/compact-p001-context.jsonld
@@ -1,6 +1,5 @@
 {
   "@context": {
-    "ex": "http://example.org/",
-    "exx:": "http://example.org/"
+    "ex": {"@id": "http://example.org/"}
   }
 }

--- a/test-suite/tests/compact-p001-context.jsonld
+++ b/test-suite/tests/compact-p001-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "exx:": "http://example.org/"
+  }
+}

--- a/test-suite/tests/compact-p001-in.jsonld
+++ b/test-suite/tests/compact-p001-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@id": "http://example.org/id1",
+  "@type": ["http://example.org/Type1", "http://example.org/Type2"],
+  "http://example.org/term": {"@id": "http://example.org/id2"}
+}

--- a/test-suite/tests/compact-p001-out.jsonld
+++ b/test-suite/tests/compact-p001-out.jsonld
@@ -1,9 +1,8 @@
 {
   "@context": {
-    "ex": "http://example.org/",
-    "exx:": "http://example.org/"
+    "ex": {"@id": "http://example.org/"}
   },
-  "@id": "exx:id1",
-  "@type": ["exx:Type1", "exx:Type2"],
-  "exx:term": {"@id": "exx:id2"}
+  "@id": "ex:id1",
+  "@type": ["ex:Type1", "ex:Type2"],
+  "ex:term": {"@id": "ex:id2"}
 }

--- a/test-suite/tests/compact-p001-out.jsonld
+++ b/test-suite/tests/compact-p001-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "exx:": "http://example.org/"
+  },
+  "@id": "exx:id1",
+  "@type": ["exx:Type1", "exx:Type2"],
+  "exx:term": {"@id": "exx:id2"}
+}

--- a/test-suite/tests/compact-p002-context.jsonld
+++ b/test-suite/tests/compact-p002-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "ex": {"@id": "http://example.org/"}
+  }
+}

--- a/test-suite/tests/compact-p002-in.jsonld
+++ b/test-suite/tests/compact-p002-in.jsonld
@@ -1,0 +1,5 @@
+{
+  "@id": "http://example.org/id1",
+  "@type": ["http://example.org/Type1", "http://example.org/Type2"],
+  "http://example.org/term": {"@id": "http://example.org/id2"}
+}

--- a/test-suite/tests/compact-p002-out.jsonld
+++ b/test-suite/tests/compact-p002-out.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "ex": {"@id": "http://example.org/"}
+  },
+  "@id": "http://example.org/id1",
+  "@type": ["http://example.org/Type1", "http://example.org/Type2"],
+  "http://example.org/term": {"@id": "http://example.org/id2"}
+}

--- a/test-suite/tests/compact-p003-context.jsonld
+++ b/test-suite/tests/compact-p003-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "compact-iris:": "http://example.com/compact-iris-",
+    "property": "http://example.com/property"
+  }
+}

--- a/test-suite/tests/compact-p003-in.jsonld
+++ b/test-suite/tests/compact-p003-in.jsonld
@@ -1,0 +1,6 @@
+{
+  "http://example.com/property": {
+    "@id": "http://example.com/compact-iris-are-considered",
+    "http://example.com/property": "Terms ending in ':' given special consideration"
+  }
+}

--- a/test-suite/tests/compact-p003-out.jsonld
+++ b/test-suite/tests/compact-p003-out.jsonld
@@ -4,7 +4,7 @@
     "property": "http://example.com/property"
   },
   "property": {
-    "@id": "compact-iris:are-considered",
-    "property": "Terms ending in ':' given special consideration"
+    "@id": "http://example.com/compact-iris-are-considered",
+    "property": "Prefix terms must end in a gen-delim"
   }
 }

--- a/test-suite/tests/compact-p003-out.jsonld
+++ b/test-suite/tests/compact-p003-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "compact-iris:": "http://example.com/compact-iris-",
+    "property": "http://example.com/property"
+  },
+  "property": {
+    "@id": "compact-iris:are-considered",
+    "property": "Terms ending in ':' given special consideration"
+  }
+}

--- a/test-suite/tests/compact-p004-context.jsonld
+++ b/test-suite/tests/compact-p004-context.jsonld
@@ -1,11 +1,11 @@
 {
   "@context": {
-    "ex": "http://example.org/",
-    "colon:": "ex::",
-    "question:": "ex:?",
-    "hash:": "ex:#",
-    "lbracket:": "ex:[",
-    "rbracket:": "ex:]",
-    "at:": "ex:@"
+    "ex": "http://example.com/",
+    "colon": "http://example.org/:",
+    "question": "http://example.org/?",
+    "hash": "http://example.org/#",
+    "lbracket": "http://example.org/[",
+    "rbracket": "http://example.org/]",
+    "at": "http://example.org/@"
   }
 }

--- a/test-suite/tests/compact-p004-context.jsonld
+++ b/test-suite/tests/compact-p004-context.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "colon:": "ex::",
+    "question:": "ex:?",
+    "hash:": "ex:#",
+    "lbracket:": "ex:[",
+    "rbracket:": "ex:]",
+    "at:": "ex:@"
+  }
+}

--- a/test-suite/tests/compact-p004-in.jsonld
+++ b/test-suite/tests/compact-p004-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "http://example.org/foo": "Use term with IRI ending in '/'",
+  "http://example.org/:foo": "Use term with IRI ending in ':'",
+  "http://example.org/?foo": "Use term with IRI ending in '?'",
+  "http://example.org/#foo": "Use term with IRI ending in '#'",
+  "http://example.org/[foo": "Use term with IRI ending in '['",
+  "http://example.org/]foo": "Use term with IRI ending in ']'",
+  "http://example.org/@foo": "Use term with IRI ending in '@'"
+}

--- a/test-suite/tests/compact-p004-in.jsonld
+++ b/test-suite/tests/compact-p004-in.jsonld
@@ -1,5 +1,5 @@
 {
-  "http://example.org/foo": "Use term with IRI ending in '/'",
+  "http://example.com/foo": "Use term with IRI ending in '/'",
   "http://example.org/:foo": "Use term with IRI ending in ':'",
   "http://example.org/?foo": "Use term with IRI ending in '?'",
   "http://example.org/#foo": "Use term with IRI ending in '#'",

--- a/test-suite/tests/compact-p004-out.jsonld
+++ b/test-suite/tests/compact-p004-out.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": {
+    "ex": "http://example.org/",
+    "colon:": "ex::",
+    "question:": "ex:?",
+    "hash:": "ex:#",
+    "lbracket:": "ex:[",
+    "rbracket:": "ex:]",
+    "at:": "ex:@"
+  },
+  "ex:foo": "Use term with IRI ending in '/'",
+  "colon:foo": "Use term with IRI ending in ':'",
+  "question:foo": "Use term with IRI ending in '?'",
+  "hash:foo": "Use term with IRI ending in '#'",
+  "lbracket:foo": "Use term with IRI ending in '['",
+  "rbracket:foo": "Use term with IRI ending in ']'",
+  "at:foo": "Use term with IRI ending in '@'"
+}

--- a/test-suite/tests/compact-p004-out.jsonld
+++ b/test-suite/tests/compact-p004-out.jsonld
@@ -1,12 +1,12 @@
 {
   "@context": {
-    "ex": "http://example.org/",
-    "colon:": "ex::",
-    "question:": "ex:?",
-    "hash:": "ex:#",
-    "lbracket:": "ex:[",
-    "rbracket:": "ex:]",
-    "at:": "ex:@"
+    "ex": "http://example.com/",
+    "colon": "http://example.org/:",
+    "question": "http://example.org/?",
+    "hash": "http://example.org/#",
+    "lbracket": "http://example.org/[",
+    "rbracket": "http://example.org/]",
+    "at": "http://example.org/@"
   },
   "ex:foo": "Use term with IRI ending in '/'",
   "colon:foo": "Use term with IRI ending in ':'",

--- a/test-suite/tests/compact-p005-context.jsonld
+++ b/test-suite/tests/compact-p005-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "compact-iris": {"@id": "http://example.com/compact-iris-", "@prefix": true},
+    "property": "http://example.com/property"
+  }
+}

--- a/test-suite/tests/compact-p005-in.jsonld
+++ b/test-suite/tests/compact-p005-in.jsonld
@@ -1,6 +1,6 @@
 {
   "http://example.com/property": {
     "@id": "http://example.com/compact-iris-are-considered",
-    "http://example.com/property": "Prefix terms must end in a gen-delim"
+    "http://example.com/property": "@prefix does not require a gen-delim"
   }
 }

--- a/test-suite/tests/compact-p005-out.jsonld
+++ b/test-suite/tests/compact-p005-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "compact-iris": {"@id": "http://example.com/compact-iris-", "@prefix": true},
+    "property": "http://example.com/property"
+  },
+  "property": {
+    "@id": "compact-iris:are-considered",
+    "property": "@prefix does not require a gen-delim"
+  }
+}

--- a/test-suite/tests/compact-p006-context.jsonld
+++ b/test-suite/tests/compact-p006-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "compact-iris": {"@id": "http://example.com/compact-iris-", "@prefix": true},
+    "property": "http://example.com/property"
+  }
+}

--- a/test-suite/tests/compact-p006-in.jsonld
+++ b/test-suite/tests/compact-p006-in.jsonld
@@ -1,6 +1,6 @@
 {
   "http://example.com/property": {
     "@id": "http://example.com/compact-iris-are-considered",
-    "http://example.com/property": "Prefix terms must end in a gen-delim"
+    "http://example.com/property": "@prefix does not require a gen-delim"
   }
 }

--- a/test-suite/tests/compact-p006-out.jsonld
+++ b/test-suite/tests/compact-p006-out.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "compact-iris": {"@id": "http://example.com/compact-iris-", "@prefix": true},
+    "property": "http://example.com/property"
+  },
+  "property": {
+    "@id": "compact-iris:are-considered",
+    "property": "@prefix does not require a gen-delim"
+  }
+}

--- a/test-suite/tests/compact-p007-context.jsonld
+++ b/test-suite/tests/compact-p007-context.jsonld
@@ -1,0 +1,6 @@
+{
+  "@context": {
+    "foo": "http://example.org/",
+    "foo:bar": "foo:baz/"
+  }
+}

--- a/test-suite/tests/compact-p007-in.jsonld
+++ b/test-suite/tests/compact-p007-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@id": "http://example.org/baz/a",
+  "http://example.org/baz/b": "c"
+}

--- a/test-suite/tests/compact-p007-out.jsonld
+++ b/test-suite/tests/compact-p007-out.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "foo": "http://example.org/",
+    "foo:bar": "foo:baz/"
+  },
+  "@id": "foo:baz/a",
+  "foo:baz/b": "c"
+}

--- a/test-suite/tests/compact-r001-context.jsonld
+++ b/test-suite/tests/compact-r001-context.jsonld
@@ -1,0 +1,3 @@
+{
+  "@context": {"b": "http://example.com/b"}
+}

--- a/test-suite/tests/compact-r001-in.jsonld
+++ b/test-suite/tests/compact-r001-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@id": "a",
+  "http://example.com/b": {"@id": "c"}
+}

--- a/test-suite/tests/compact-r001-out.jsonld
+++ b/test-suite/tests/compact-r001-out.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {"b": "http://example.com/b"},
+  "@id": "a",
+  "b": {"@id": "c"}
+}

--- a/test-suite/tests/compact-r002-context.jsonld
+++ b/test-suite/tests/compact-r002-context.jsonld
@@ -1,0 +1,3 @@
+{
+  "@context": {"b": "http://example.com/b"}
+}

--- a/test-suite/tests/compact-r002-in.jsonld
+++ b/test-suite/tests/compact-r002-in.jsonld
@@ -1,0 +1,4 @@
+{
+  "@id": "a",
+  "http://example.com/b": {"@id": "c"}
+}

--- a/test-suite/tests/compact-r002-in.jsonld
+++ b/test-suite/tests/compact-r002-in.jsonld
@@ -1,4 +1,4 @@
 {
-  "@id": "a",
-  "http://example.com/b": {"@id": "c"}
+  "@id": "http://example.org/a",
+  "http://example.com/b": {"@id": "http://example.org/c"}
 }

--- a/test-suite/tests/compact-r002-out.jsonld
+++ b/test-suite/tests/compact-r002-out.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {"b": "http://example.com/b"},
+  "@id": "http://example.org/a",
+  "b": {"@id": "http://example.org/c"}
+}

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -430,6 +430,24 @@
       "context": "error-p006-context.jsonld",
       "expect": "invalid @version value"
     }, {
+      "@id": "#tp007",
+      "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
+      "name": "@prefix is not allowed in 1.0",
+      "purpose": "@prefix is not allowed in a term definitionin 1.0",
+      "option": {"processingMode": "json-ld-1.0"},
+      "input": "error-p007-in.jsonld",
+      "context": "error-p007-context.jsonld",
+      "expect": "invalid term definition"
+    }, {
+      "@id": "#tp008",
+      "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
+      "name": "@prefix must be a boolean",
+      "purpose": "@prefix must be a boolean in a term definition in 1.0",
+      "option": {"processingMode": "json-ld-1.1"},
+      "input": "error-p008-in.jsonld",
+      "context": "error-p008-context.jsonld",
+      "expect": "invalid @prefix value"
+    }, {
       "@id": "#ts001",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Using an array value for @context is illegal in JSON-LD 1.0",

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -442,11 +442,20 @@
       "@id": "#tp008",
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@prefix must be a boolean",
-      "purpose": "@prefix must be a boolean in a term definition in 1.0",
+      "purpose": "@prefix must be a boolean in a term definition in 1.1",
       "option": {"processingMode": "json-ld-1.1"},
       "input": "error-p008-in.jsonld",
       "context": "error-p008-context.jsonld",
       "expect": "invalid @prefix value"
+    }, {
+      "@id": "#tp009",
+      "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
+      "name": "@prefix not allowed on compact IRI term",
+      "purpose": "If processingMode is json-ld-1.0, or if term contains a colon (:), an invalid term definition has been detected and processing is aborted.",
+      "option": {"processingMode": "json-ld-1.1"},
+      "input": "error-p009-in.jsonld",
+      "context": "error-p009-context.jsonld",
+      "expect": "invalid term definition"
     }, {
       "@id": "#ts001",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],

--- a/test-suite/tests/error-p007-context.jsonld
+++ b/test-suite/tests/error-p007-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "foo": {"@id": "http://example/foo", "@prefix": true}
+  }
+}

--- a/test-suite/tests/error-p007-in.jsonld
+++ b/test-suite/tests/error-p007-in.jsonld
@@ -1,0 +1,3 @@
+{
+  "http://example/foo": "bar"
+}

--- a/test-suite/tests/error-p008-context.jsonld
+++ b/test-suite/tests/error-p008-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "foo": {"@id": "http://example/foo", "@prefix": "string"}
+  }
+}

--- a/test-suite/tests/error-p008-in.jsonld
+++ b/test-suite/tests/error-p008-in.jsonld
@@ -1,0 +1,3 @@
+{
+  "http://example/foo": "bar"
+}

--- a/test-suite/tests/error-p009-context.jsonld
+++ b/test-suite/tests/error-p009-context.jsonld
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "foo:bar": {"@id": "http://example/foo/bar/", "@prefix": true}
+  }
+}

--- a/test-suite/tests/error-p009-in.jsonld
+++ b/test-suite/tests/error-p009-in.jsonld
@@ -1,0 +1,3 @@
+{
+  "http://example/foo/bar/": "bar"
+}

--- a/test-suite/vocab.html
+++ b/test-suite/vocab.html
@@ -1,392 +1,433 @@
 <!DOCTYPE html>
 <html prefix='jld: http://jsonld.org/test-suite/vocab# mf: http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#'>
-  <head>
-    <meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
-    <meta content='width=device-width, initial-scale=1.0' name='viewport'>
-    <link href='../static/css/bootstrap/bootstrap.css' rel='stylesheet' type='text/css'>
-    <link href='../static/css/bootstrap/bootstrap-responsive.css' rel='stylesheet' type='text/css'>
-    <link href='../static/css/bootstrap/font-awesome.css' rel='stylesheet' type='text/css'>
-    <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js' type='text/javascript'></script>
-    <script src='//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.0.0-rc.3/handlebars.min.js' type='text/javascript'></script>
-    <style>
-      dd code {display: inline;}
-      footer {text-align: center;}
-    </style>
-    <title>
-      Test case manifest vocabulary extensions
-    </title>
-  </head>
-  <body resource='http://json-ld.org/test-suite/vocab#'>
-    <meta property='dc:creator' value='Gregg Kellogg'>
-    <link href='http://json-ld.org/test-suite/vocab#' property='dc:identifier'>
-    <div class='navbar navbar-static-top'>
-      <div class='navbar-inner'>
-        <div class='row-fluid'>
-          <a class='btn btn-navbar' data-target='.nav-collapse' data-toggle='collapse'>
-            <span class='icon-bar'></span>
-            <span class='icon-bar'></span>
-            <span class='icon-bar'></span>
-          </a>
-          <a class='brand active' href='../'>
-            <img alt='JSON-LD logo' src='../images/json-ld-data-24.png'>
-            JSON-LD
-          </a>
-          <div class='nav-collapse'></div>
-          <ul class='nav'>
-            <li>
-              <a href='../playground/'>
-                <span class='icon-beer'></span>
-                Playground
-              </a>
-            </li>
-            <li>
-              <a href='../learn.html'>
-                <span class='icon-book'></span>
-                Documentation
-              </a>
-            </li>
-            <li class='dropdown'>
-              <a class='dropdown-toggle' data-toggle='dropdown' href='#'>
-                <span class='icon-folder-open'></span>
-                Specifications
-                <b class='caret'></b>
-              </a>
-              <ul class='dropdown-menu'>
-                <li class='nav-header'>
-                  <strong>
-                    Latest
-                  </strong>
-                </li>
-                <li>
-                  <a href='../spec/latest/json-ld/'>
-                    Syntax
-                  </a>
-                </li>
-                <li>
-                  <a href='../spec/latest/json-ld-api/'>
-                    API
-                  </a>
-                </li>
-                <li>
-                  <a href='../spec/latest/json-ld-framing/'>
-                    Framing
-                  </a>
-                </li>
-                <li class='divider'></li>
-                <li class='nav-header'>
-                  <strong>
-                    Previous Drafts
-                  </strong>
-                </li>
-                <li>
-                  <a href='../spec#syntax'>
-                    Syntax
-                  </a>
-                </li>
-                <li>
-                  <a href='../spec#api'>
-                    API
-                  </a>
-                </li>
-                <li>
-                  <a href='../spec#framing'>
-                    Framing
-                  </a>
-                </li>
-              </ul>
-            </li>
-            <li>
-              <a href='../images/'>
-                <span class='icon-picture'>
-                  Branding
-                </span>
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-    <div class='hero-unit'>
-      <h1 property='dc:title'>Test case manifest vocabulary extensions</h1>
-      <p property='dc:description rdfs:comment'>Test case manifest vocabulary extensions</p>
-    </div>
-    <div class='container'>
-      <div class='row'>
-        <h2 class='span12' id='classes' style='text-align: center;'>
-          Test Case Classes
-        </h2>
-      </div>
-      <div class='row'>
-        <section class='offset2 span8'>
-          <dl>
-            <dt about='jld:CompactTest' property='rdfs:label' typeof='rdfs:Class'>Compact Evaluation Test</dt>
-            <dd about='jld:CompactTest' property='rdfs:comment'><p>A <code>CompactTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#widl-JsonLdProcessor-compact-Promise-any-input-JsonLdContext-context-JsonLdOptions-options">compact</a> method with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing a JSON-LD file in expanded form, context from <code>:input</code> (aliased as &quot;context&quot; in the test manifest) and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p></dd>
-            <dt about='jld:ExpandTest' property='rdfs:label' typeof='rdfs:Class'>Expand Evaluation Test</dt>
-            <dd about='jld:ExpandTest' property='rdfs:comment'><p>A <code>ExpandTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#widl-JsonLdProcessor-expand-Promise-any-input-JsonLdOptions-options">expand</a> method with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing a JSON-LD file, and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p></dd>
-            <dt about='jld:FlattenTest' property='rdfs:label' typeof='rdfs:Class'>Flatten Evaluation Test</dt>
-            <dd about='jld:FlattenTest' property='rdfs:comment'><p>A <code>FlattenTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#widl-JsonLdProcessor-flatten-Promise-any-input-JsonLdContext-context-JsonLdOptions-options">flatten</a> method with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing a JSON-LD file, optional context from <code>:input</code> (aliased as &quot;context&quot; in the test manifest) and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p></dd>
-            <dt about='jld:FrameTest' property='rdfs:label' typeof='rdfs:Class'>Frame Evaluation Test</dt>
-            <dd about='jld:FrameTest' property='rdfs:comment'><p>A <code>FrameTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-framing/#widl-JsonLdProcessor-frame-void-object-or-object---or-IRI-input-object-or-IRI-frame-JsonLdCallback-callback-JsonLdOptions-options">frame</a> method with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing a JSON-LD file, frame from <code>:input</code> (aliased as &quot;frame&quot; in the test manifest) and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p></dd>
-            <dt about='jld:FromRDFTest' property='rdfs:label' typeof='rdfs:Class'>From RDF Evaluation Test</dt>
-            <dd about='jld:FromRDFTest' property='rdfs:comment'><p>A <code>FromRDFTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#rdf-to-object-conversion">RDF to Object Conversion</a> algorithm with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing an N-Quads file and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p></dd>
-            <dt about='jld:NegativeSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>Negative Syntax Test</dt>
-            <dd about='jld:NegativeSyntaxTest' property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.</p></dd>
-            <dt about='jld:NegativeEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>Positive Evaluation Test</dt>
-            <dd about='jld:NegativeEvaluationTest' property='rdfs:comment'><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) results in the error identified by the literal value of <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p></dd>
-            <dt about='jld:PositiveEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>Positive Evaluation Test</dt>
-            <dd about='jld:PositiveEvaluationTest' property='rdfs:comment'><p>A Positive Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) exactly matches the output file specified as <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p></dd>
-            <dt about='jld:NegativeEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>Positive Evaluation Test</dt>
-            <dd about='jld:NegativeEvaluationTest' property='rdfs:comment'><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) results in the error identified by the literal value of <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p></dd>
-            <dt about='jld:PositiveSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>Positive Syntax Test</dt>
-            <dd about='jld:PositiveSyntaxTest' property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.</p></dd>
-            <dt about='jld:Option' property='rdfs:label' typeof='rdfs:Class'>Processor Options</dt>
-            <dd about='jld:Option' property='rdfs:comment'><p>Options passed to the test runner to affect invocation of the appropriate API method.</p></dd>
-            <dt about='jld:Test' property='rdfs:label' typeof='rdfs:Class'>Superclass of all JSON-LD tests</dt>
-            <dd about='jld:Test' property='rdfs:comment'><p>All JSON-LD tests have an input file referenced using <code>mf:action</code> (aliased as &quot;input&quot; in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to &quot;json-ld-1.1&quot;, unless specified explicitly as a test option.</p></dd>
-            <dt about='jld:ToRDFTest' property='rdfs:label' typeof='rdfs:Class'>To RDF Evaluation Test</dt>
-            <dd about='jld:ToRDFTest' property='rdfs:comment'><p>A <code>ToRDFTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF algorithm</a> with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing an JSON-LD file and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> are N-Quads serialized in lexographical order and MUST be compared either string comparison or Dataset as defined in <a href="http://www.w3.org/TR/rdf11-concepts/#section-dataset-isomorphism">RDF11-CONCEPTS</a>.</p></dd>
-          </dl>
-        </section>
-      </div>
-      <div class='row'>
-        <h2 class='span12' id='classes' style='text-align: center;'>
-          Test Case Properties
-        </h2>
-      </div>
-      <div class='row'>
-        <section class='offset2 span8'>
-          <dl>
-            <dt about='jld:httpLink' property='rdfs:label' typeof='rdf:Property'>HTTP link</dt>
-            <dd about='jld:httpLink'>
-              <span property='rdfs:comment'><p>An HTTP Link header to be added to the result of requesting the input file.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-            <dt about='jld:httpStatus' property='rdfs:label' typeof='rdf:Property'>HTTP status</dt>
-            <dd about='jld:httpStatus'>
-              <span property='rdfs:comment'><p>The HTTP status code that must be returned when the input file is requested. This is typically used along with the <code>redirectTo</code> property.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-            <dt about='jld:base' property='rdfs:label' typeof='rdf:Property'>base</dt>
-            <dd about='jld:base'>
-              <span property='rdfs:comment'><p>The base IRI to use when expanding or compacting the document. If set, this overrides the input document&#39;s IRI.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
-              </div>
-            </dd>
-            <dt about='jld:compactArrays' property='rdfs:label' typeof='rdf:Property'>compact arrays</dt>
-            <dd about='jld:compactArrays'>
-              <span property='rdfs:comment'><p>If set to <code>true</code>, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-            <dt about='jld:contentType' property='rdfs:label' typeof='rdf:Property'>content type</dt>
-            <dd about='jld:contentType'>
-              <span property='rdfs:comment'><p>The HTTP Content-Type used for the input file, in case it is a non-registered type.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-            <dt about='jld:expandContext' property='rdfs:label' typeof='rdf:Property'>expand context</dt>
-            <dd about='jld:expandContext'>
-              <span property='rdfs:comment'><p>A context that is used to initialize the active context when expanding a document.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
-              </div>
-            </dd>
-            <dt about='jld:input' property='rdfs:label' typeof='rdf:Property'>input</dt>
-            <dd about='jld:input'>
-              <span property='rdfs:comment'><p>Secondary input file</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
-              </div>
-            </dd>
-            <dt about='jld:option' property='rdfs:label' typeof='rdf:Property'>option</dt>
-            <dd about='jld:option'>
-              <span property='rdfs:comment'><p>Options affecting processing</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='jld:Option'>jld:Option</code>
-              </div>
-            </dd>
-            <dt about='jld:processingMode' property='rdfs:label' typeof='rdf:Property'>processing mode</dt>
-            <dd about='jld:processingMode'>
-              <span property='rdfs:comment'><p>If set to &quot;json-ld-1.1&quot;, the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:string'>xsd:string</code>
-              </div>
-            </dd>
-            <dt about='jld:produceGeneralizedRdf' property='rdfs:label' typeof='rdf:Property'>produce generalized RDF</dt>
-            <dd about='jld:produceGeneralizedRdf'>
-              <span property='rdfs:comment'><p>Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:ToRDFTest'>jld:ToRDFTest</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-            <dt about='jld:redirectTo' property='rdfs:label' typeof='rdf:Property'>redirect to</dt>
-            <dd about='jld:redirectTo'>
-              <span property='rdfs:comment'><p>The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-            <dt about='jld:useRdfType' property='rdfs:label' typeof='rdf:Property'>use RDF types</dt>
-            <dd about='jld:useRdfType'>
-              <span property='rdfs:comment'><p>If the <em>use rdf type</em> flag is set to <code>true</code>, statements with an <code>rdf:type</code> predicate will not use <code>@type</code>, but will be transformed as a normal property.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:FromRDFTest'>jld:FromRDFTest</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-            <dt about='jld:useDocumentLoader' property='rdfs:label' typeof='rdf:Property'>use document loader</dt>
-            <dd about='jld:useDocumentLoader'>
-              <span property='rdfs:comment'><p>Test runners must implement a callback method with a method signature as defined in <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#idl-def-LoadDocumentCallback">LoadDocumentCallback</a>. Specifying this option requires the test runner to provide this callback to the appropriate API method using the <code>documentLoader</code> option.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-            <dt about='jld:useNativeTypes' property='rdfs:label' typeof='rdf:Property'>use native types</dt>
-            <dd about='jld:useNativeTypes'>
-              <span property='rdfs:comment'><p>If the <em>use native types</em> flag is set to <code>true</code>, RDF literals with a datatype IRI that equal <code>xsd:integer</code> or <code>xsd:double</code> are converted to a JSON numbers and RDF literals with a datatype IRI that equals <code>xsd:boolean</code> are converted to <code>true</code> or <code>false</code> based on their lexical form.</p></span>
-              <div>
-                <strong>
-                  domain:
-                </strong>
-                <code property='rdfs:domain' resource='jld:FromRDFTest'>jld:FromRDFTest</code>
-              </div>
-              <div>
-                <strong>
-                  range:
-                </strong>
-                <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
-              </div>
-            </dd>
-          </dl>
-        </section>
-      </div>
-    </div>
-    <footer>
-      <span property='dc:publisher'>W3C Linked JSON Community Group</span>
-    </footer>
-    <script src='../static/js/bootstrap/bootstrap.js' type='text/javascript'></script>
-  </body>
+<head>
+<meta content='text/html;charset=utf-8' http-equiv='Content-Type'>
+<meta content='width=device-width, initial-scale=1.0' name='viewport'>
+<link href='../static/css/bootstrap/bootstrap.css' rel='stylesheet' type='text/css'>
+<link href='../static/css/bootstrap/bootstrap-responsive.css' rel='stylesheet' type='text/css'>
+<link href='../static/css/bootstrap/font-awesome.css' rel='stylesheet' type='text/css'>
+<script src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js' type='text/javascript'></script>
+<script src='//cdnjs.cloudflare.com/ajax/libs/handlebars.js/1.0.0-rc.3/handlebars.min.js' type='text/javascript'></script>
+<style>
+  dd code {display: inline;}
+  footer {text-align: center;}
+</style>
+<title>
+Test case manifest vocabulary extensions
+</title>
+</head>
+<body resource='http://json-ld.org/test-suite/vocab#'>
+<meta property='dc:creator' value='Gregg Kellogg'>
+<link href='http://json-ld.org/test-suite/vocab#' property='dc:identifier'>
+<div class='navbar navbar-static-top'>
+<div class='navbar-inner'>
+<div class='row-fluid'>
+<a class='btn btn-navbar' data-target='.nav-collapse' data-toggle='collapse'>
+<span class='icon-bar'></span>
+<span class='icon-bar'></span>
+<span class='icon-bar'></span>
+</a>
+<a class='brand active' href='../'>
+<img alt='JSON-LD logo' src='../images/json-ld-data-24.png'>
+JSON-LD
+</a>
+<div class='nav-collapse'></div>
+<ul class='nav'>
+<li>
+<a href='../playground/'>
+<span class='icon-beer'></span>
+Playground
+</a>
+</li>
+<li>
+<a href='../learn.html'>
+<span class='icon-book'></span>
+Documentation
+</a>
+</li>
+<li class='dropdown'>
+<a class='dropdown-toggle' data-toggle='dropdown' href='#'>
+<span class='icon-folder-open'></span>
+Specifications
+<b class='caret'></b>
+</a>
+<ul class='dropdown-menu'>
+<li class='nav-header'>
+<strong>
+Latest
+</strong>
+</li>
+<li>
+<a href='../spec/latest/json-ld/'>
+Syntax
+</a>
+</li>
+<li>
+<a href='../spec/latest/json-ld-api/'>
+API
+</a>
+</li>
+<li>
+<a href='../spec/latest/json-ld-framing/'>
+Framing
+</a>
+</li>
+<li class='divider'></li>
+<li class='nav-header'>
+<strong>
+Previous Drafts
+</strong>
+</li>
+<li>
+<a href='../spec#syntax'>
+Syntax
+</a>
+</li>
+<li>
+<a href='../spec#api'>
+API
+</a>
+</li>
+<li>
+<a href='../spec#framing'>
+Framing
+</a>
+</li>
+</ul>
+</li>
+<li>
+<a href='../images/'>
+<span class='icon-picture'>
+Branding
+</span>
+</a>
+</li>
+</ul>
+</div>
+</div>
+</div>
+<div class='hero-unit'>
+<h1 property='dc:title'>Test case manifest vocabulary extensions</h1>
+<p property='dc:description rdfs:comment'>Test case manifest vocabulary extensions</p>
+</div>
+<div class='container'>
+<div class='row'>
+<h2 class='span12' id='classes' style='text-align: center;'>
+Test Case Classes
+</h2>
+</div>
+<div class='row'>
+<section class='offset2 span8'>
+<dl>
+<dt about='jld:CompactTest' property='rdfs:label' typeof='rdfs:Class'>Compact Evaluation Test</dt>
+<dd about='jld:CompactTest' property='rdfs:comment'><p>A <code>CompactTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#widl-JsonLdProcessor-compact-Promise-any-input-JsonLdContext-context-JsonLdOptions-options">compact</a> method with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing a JSON-LD file in expanded form, context from <code>:input</code> (aliased as &quot;context&quot; in the test manifest) and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p>
+</dd>
+<dt about='jld:ExpandTest' property='rdfs:label' typeof='rdfs:Class'>Expand Evaluation Test</dt>
+<dd about='jld:ExpandTest' property='rdfs:comment'><p>A <code>ExpandTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#widl-JsonLdProcessor-expand-Promise-any-input-JsonLdOptions-options">expand</a> method with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing a JSON-LD file, and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p>
+</dd>
+<dt about='jld:FlattenTest' property='rdfs:label' typeof='rdfs:Class'>Flatten Evaluation Test</dt>
+<dd about='jld:FlattenTest' property='rdfs:comment'><p>A <code>FlattenTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#widl-JsonLdProcessor-flatten-Promise-any-input-JsonLdContext-context-JsonLdOptions-options">flatten</a> method with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing a JSON-LD file, optional context from <code>:input</code> (aliased as &quot;context&quot; in the test manifest) and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p>
+</dd>
+<dt about='jld:FrameTest' property='rdfs:label' typeof='rdfs:Class'>Frame Evaluation Test</dt>
+<dd about='jld:FrameTest' property='rdfs:comment'><p>A <code>FrameTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-framing/#widl-JsonLdProcessor-frame-void-object-or-object---or-IRI-input-object-or-IRI-frame-JsonLdCallback-callback-JsonLdOptions-options">frame</a> method with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing a JSON-LD file, frame from <code>:input</code> (aliased as &quot;frame&quot; in the test manifest) and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p>
+</dd>
+<dt about='jld:FromRDFTest' property='rdfs:label' typeof='rdfs:Class'>From RDF Evaluation Test</dt>
+<dd about='jld:FromRDFTest' property='rdfs:comment'><p>A <code>FromRDFTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#rdf-to-object-conversion">RDF to Object Conversion</a> algorithm with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing an N-Quads file and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> MUST be compared using JSON object comparison with the processor output.</p>
+</dd>
+<dt about='jld:NegativeSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>Negative Syntax Test</dt>
+<dd about='jld:NegativeSyntaxTest' property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action. Negative syntax tests are tests of which the result should be a parser error.</p>
+</dd>
+<dt about='jld:NegativeEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>Positive Evaluation Test</dt>
+<dd about='jld:NegativeEvaluationTest' property='rdfs:comment'><p>A Negative Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) results in the error identified by the literal value of <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p>
+</dd>
+<dt about='jld:PositiveEvaluationTest' property='rdfs:label' typeof='rdfs:Class'>Positive Evaluation Test</dt>
+<dd about='jld:PositiveEvaluationTest' property='rdfs:comment'><p>A Positive Evaluation test is successful when the result of processing the input file specified as <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) exactly matches the output file specified as <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest) using the comparison defined in another class. The specifics of invoking test, including the interpretation of options (<code>:option</code>) and other input files are specified through another class.</p>
+</dd>
+<dt about='jld:PositiveSyntaxTest' property='rdfs:label' typeof='rdfs:Class'>Positive Syntax Test</dt>
+<dd about='jld:PositiveSyntaxTest' property='rdfs:comment'><p>A type of test specifically for syntax testing. Syntax tests are not required to have an associated result, only an action.</p>
+</dd>
+<dt about='jld:Option' property='rdfs:label' typeof='rdfs:Class'>Processor Options</dt>
+<dd about='jld:Option' property='rdfs:comment'><p>Options passed to the test runner to affect invocation of the appropriate API method.</p>
+</dd>
+<dt about='jld:Test' property='rdfs:label' typeof='rdfs:Class'>Superclass of all JSON-LD tests</dt>
+<dd about='jld:Test' property='rdfs:comment'><p>All JSON-LD tests have an input file referenced using <code>mf:action</code> (aliased as &quot;input&quot; in test manifest). Positive and Negative Evaluation Tests also have a result file referenced using <code>mf:result</code> (aliased as &quot;expect&quot; in test manifest). Other tests may take different inputs and options as defined for each test class. Tests should be run with the processingMode option set to &quot;json-ld-1.1&quot;, unless specified explicitly as a test option.</p>
+</dd>
+<dt about='jld:ToRDFTest' property='rdfs:label' typeof='rdfs:Class'>To RDF Evaluation Test</dt>
+<dd about='jld:ToRDFTest' property='rdfs:comment'><p>A <code>ToRDFTest</code> modifies either a <code>PositiveEvaluationTest</code>, <code>NegativeEvaluationTest</code>, <code>PositiveSyntaxTest</code> or <code>NegativeSyntaxTest</code>. Tests are run using the <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#deserialize-json-ld-to-rdf-algorithm">Deserialize JSON-LD to RDF algorithm</a> with the input argument from <code>mf:action</code> (aliased as &quot;input&quot; in test manifest) referencing an JSON-LD file and optional options from <code>:option</code>. The expected results for a <code>PositiveEvaluationTest</code> are N-Quads serialized in lexographical order and MUST be compared either string comparison or Dataset as defined in <a href="http://www.w3.org/TR/rdf11-concepts/#section-dataset-isomorphism">RDF11-CONCEPTS</a>.</p>
+</dd>
+</dl>
+</section>
+</div>
+<div class='row'>
+<h2 class='span12' id='classes' style='text-align: center;'>
+Test Case Properties
+</h2>
+</div>
+<div class='row'>
+<section class='offset2 span8'>
+<dl>
+<dt about='jld:httpLink' property='rdfs:label' typeof='rdf:Property'>HTTP link</dt>
+<dd about='jld:httpLink'>
+<span property='rdfs:comment'><p>An HTTP Link header to be added to the result of requesting the input file.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:httpStatus' property='rdfs:label' typeof='rdf:Property'>HTTP status</dt>
+<dd about='jld:httpStatus'>
+<span property='rdfs:comment'><p>The HTTP status code that must be returned when the input file is requested. This is typically used along with the <code>redirectTo</code> property.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:base' property='rdfs:label' typeof='rdf:Property'>base</dt>
+<dd about='jld:base'>
+<span property='rdfs:comment'><p>The base IRI to use when expanding or compacting the document. If set, this overrides the input document&#39;s IRI.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
+</div>
+</dd>
+<dt about='jld:compactArrays' property='rdfs:label' typeof='rdf:Property'>compact arrays</dt>
+<dd about='jld:compactArrays'>
+<span property='rdfs:comment'><p>If set to <code>true</code>, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:compactToRelative' property='rdfs:label' typeof='rdf:Property'>compact to relative</dt>
+<dd about='jld:compactToRelative'>
+<span property='rdfs:comment'><p>If set to <code>false</code>, the JSON-LD processor will not attempt to compact using document-relative IRIs.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:contentType' property='rdfs:label' typeof='rdf:Property'>content type</dt>
+<dd about='jld:contentType'>
+<span property='rdfs:comment'><p>The HTTP Content-Type used for the input file, in case it is a non-registered type.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:expandContext' property='rdfs:label' typeof='rdf:Property'>expand context</dt>
+<dd about='jld:expandContext'>
+<span property='rdfs:comment'><p>A context that is used to initialize the active context when expanding a document.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
+</div>
+</dd>
+<dt about='jld:input' property='rdfs:label' typeof='rdf:Property'>input</dt>
+<dd about='jld:input'>
+<span property='rdfs:comment'><p>Secondary input file</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='rdfs:Resource'>rdfs:Resource</code>
+</div>
+</dd>
+<dt about='jld:option' property='rdfs:label' typeof='rdf:Property'>option</dt>
+<dd about='jld:option'>
+<span property='rdfs:comment'><p>Options affecting processing</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Test'>jld:Test</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='jld:Option'>jld:Option</code>
+</div>
+</dd>
+<dt about='jld:processingMode' property='rdfs:label' typeof='rdf:Property'>processing mode</dt>
+<dd about='jld:processingMode'>
+<span property='rdfs:comment'><p>If set to &quot;json-ld-1.1&quot;, the JSON-LD processor must produce exactly the same results as the algorithms defined in this specification. If set to another value, the JSON-LD processor is allowed to extend or modify the algorithms defined in this specification to enable application-specific optimizations. The definition of such optimizations is beyond the scope of this specification and thus not defined. Consequently, different implementations may implement different optimizations. Developers must not define modes beginning with json-ld as they are reserved for future versions of this specification.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:string'>xsd:string</code>
+</div>
+</dd>
+<dt about='jld:produceGeneralizedRdf' property='rdfs:label' typeof='rdf:Property'>produce generalized RDF</dt>
+<dd about='jld:produceGeneralizedRdf'>
+<span property='rdfs:comment'><p>Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:redirectTo' property='rdfs:label' typeof='rdf:Property'>redirect to</dt>
+<dd about='jld:redirectTo'>
+<span property='rdfs:comment'><p>The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:useRdfType' property='rdfs:label' typeof='rdf:Property'>use RDF types</dt>
+<dd about='jld:useRdfType'>
+<span property='rdfs:comment'><p>If the <em>use rdf type</em> flag is set to <code>true</code>, statements with an <code>rdf:type</code> predicate will not use <code>@type</code>, but will be transformed as a normal property.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:useDocumentLoader' property='rdfs:label' typeof='rdf:Property'>use document loader</dt>
+<dd about='jld:useDocumentLoader'>
+<span property='rdfs:comment'><p>Test runners must implement a callback method with a method signature as defined in <a href="http://json-ld.org/spec/latest/json-ld-api/index.html#idl-def-LoadDocumentCallback">LoadDocumentCallback</a>. Specifying this option requires the test runner to provide this callback to the appropriate API method using the <code>documentLoader</code> option.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+<dt about='jld:useNativeTypes' property='rdfs:label' typeof='rdf:Property'>use native types</dt>
+<dd about='jld:useNativeTypes'>
+<span property='rdfs:comment'><p>If the <em>use native types</em> flag is set to <code>true</code>, RDF literals with a datatype IRI that equal <code>xsd:integer</code> or <code>xsd:double</code> are converted to a JSON numbers and RDF literals with a datatype IRI that equals <code>xsd:boolean</code> are converted to <code>true</code> or <code>false</code> based on their lexical form.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
+</div>
+</dd>
+</dl>
+</section>
+</div>
+</div>
+<footer>
+<span property='dc:publisher'>W3C Linked JSON Community Group</span>
+</footer>
+<script src='../static/js/bootstrap/bootstrap.js' type='text/javascript'></script>
+</body>
 </html>

--- a/test-suite/vocab.jsonld
+++ b/test-suite/vocab.jsonld
@@ -113,7 +113,7 @@
       "@id": "jld:base",
       "@type": "rdf:Property",
       "rdfs:comment": "The base IRI to use when expanding or compacting the document. If set, this overrides the input document's IRI.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "base",
       "rdfs:range": "rdfs:Resource"
     },
@@ -121,15 +121,23 @@
       "@id": "jld:compactArrays",
       "@type": "rdf:Property",
       "rdfs:comment": "If set to `true`, the JSON-LD processor replaces arrays with just one element with that element during compaction. If set to false, all arrays will remain arrays even if they have just one element.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "compact arrays",
+      "rdfs:range": "xsd:boolean"
+    },
+    {
+      "@id": "jld:compactToRelative",
+      "@type": "rdf:Property",
+      "rdfs:comment": "If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.",
+      "rdfs:domain": "jld:Option",
+      "rdfs:label": "compact to relative",
       "rdfs:range": "xsd:boolean"
     },
     {
       "@id": "jld:contentType",
       "@type": "rdf:Property",
       "rdfs:comment": "The HTTP Content-Type used for the input file, in case it is a non-registered type.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "content type",
       "rdfs:range": "xsd:boolean"
     },
@@ -137,7 +145,7 @@
       "@id": "jld:expandContext",
       "@type": "rdf:Property",
       "rdfs:comment": "A context that is used to initialize the active context when expanding a document.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "expand context",
       "rdfs:range": "rdfs:Resource"
     },
@@ -145,7 +153,7 @@
       "@id": "jld:httpLink",
       "@type": "rdf:Property",
       "rdfs:comment": "An HTTP Link header to be added to the result of requesting the input file.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "HTTP link",
       "rdfs:range": "xsd:boolean"
     },
@@ -153,7 +161,7 @@
       "@id": "jld:httpStatus",
       "@type": "rdf:Property",
       "rdfs:comment": "The HTTP status code that must be returned when the input file is requested. This is typically used along with the `redirectTo` property.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "HTTP status",
       "rdfs:range": "xsd:boolean"
     },
@@ -185,7 +193,7 @@
       "@id": "jld:produceGeneralizedRdf",
       "@type": "rdf:Property",
       "rdfs:comment": "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output.",
-      "rdfs:domain": "jld:ToRDFTest",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "produce generalized RDF",
       "rdfs:range": "xsd:boolean"
     },
@@ -193,7 +201,7 @@
       "@id": "jld:redirectTo",
       "@type": "rdf:Property",
       "rdfs:comment": "The location of a URL for redirection. A request made of the input file must be redirected to the designated URL.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "redirect to",
       "rdfs:range": "xsd:boolean"
     },
@@ -201,7 +209,7 @@
       "@id": "jld:useDocumentLoader",
       "@type": "rdf:Property",
       "rdfs:comment": "Test runners must implement a callback method with a method signature as defined in [LoadDocumentCallback](http://json-ld.org/spec/latest/json-ld-api/index.html#idl-def-LoadDocumentCallback). Specifying this option requires the test runner to provide this callback to the appropriate API method using the `documentLoader` option.",
-      "rdfs:domain": "jld:Test",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "use document loader",
       "rdfs:range": "xsd:boolean"
     },
@@ -209,7 +217,7 @@
       "@id": "jld:useNativeTypes",
       "@type": "rdf:Property",
       "rdfs:comment": "If the _use native types_ flag is set to `true`, RDF literals with a datatype IRI that equal `xsd:integer` or `xsd:double` are converted to a JSON numbers and RDF literals with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based on their lexical form.",
-      "rdfs:domain": "jld:FromRDFTest",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "use native types",
       "rdfs:range": "xsd:boolean"
     },
@@ -217,7 +225,7 @@
       "@id": "jld:useRdfType",
       "@type": "rdf:Property",
       "rdfs:comment": "If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate will not use `@type`, but will be transformed as a normal property.",
-      "rdfs:domain": "jld:FromRDFTest",
+      "rdfs:domain": "jld:Option",
       "rdfs:label": "use RDF types",
       "rdfs:range": "xsd:boolean"
     }

--- a/test-suite/vocab.ttl
+++ b/test-suite/vocab.ttl
@@ -171,7 +171,7 @@
     The base IRI to use when expanding or compacting the document.
     If set, this overrides the input document's IRI.
   """ ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
   rdfs:range   rdfs:Resource .
 
 :compactArrays a rdf:Property ;
@@ -181,7 +181,15 @@
     with that element during compaction.
     If set to false, all arrays will remain arrays even if they have just one element.
   """ ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:boolean .
+
+:compactToRelative a rdf:Property ;
+  rdfs:label "compact to relative";
+  rdfs:comment """
+    If set to `false`, the JSON-LD processor will not attempt to compact using document-relative IRIs.
+  """ ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
 
 :useDocumentLoader a rdf:Property ;
@@ -192,13 +200,13 @@
     Specifying this option requires the test runner to provide this callback to the appropriate
     API method using the `documentLoader` option.
   """ ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
 
 :expandContext a rdf:Property ;
   rdfs:label "expand context";
   rdfs:comment "A context that is used to initialize the active context when expanding a document." ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
   rdfs:range   rdfs:Resource .
 
 :processingMode a rdf:Property ;
@@ -218,7 +226,7 @@
 :produceGeneralizedRdf a rdf:Property ;
   rdfs:label "produce generalized RDF";
   rdfs:comment "Unless the produce generalized RDF flag is set to true, RDF triples containing a blank node predicate are excluded from output." ;
-  rdfs:domain	 :ToRDFTest ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
 
 :useNativeTypes a rdf:Property ;
@@ -229,7 +237,7 @@
     with a datatype IRI that equals `xsd:boolean` are converted to `true` or `false` based
     on their lexical form.
     """ ;
-  rdfs:domain	 :FromRDFTest ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
 
 :useRdfType a rdf:Property ;
@@ -238,7 +246,7 @@
     If the _use rdf type_ flag is set to `true`, statements with an `rdf:type` predicate
     will not use `@type`, but will be transformed as a normal property.
     """ ;
-  rdfs:domain	 :FromRDFTest ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
 
 :contentType a rdf:Property ;
@@ -246,7 +254,7 @@
   rdfs:comment """
     The HTTP Content-Type used for the input file, in case it is a non-registered type.
     """ ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
 
 :redirectTo a rdf:Property ;
@@ -255,7 +263,7 @@
     The location of a URL for redirection. A request made of the input file must be redirected
     to the designated URL.
     """ ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
 
 :httpStatus a rdf:Property ;
@@ -264,7 +272,7 @@
     The HTTP status code that must be returned when the input file is requested. This
     is typically used along with the `redirectTo` property.
     """ ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
 
 :httpLink a rdf:Property ;
@@ -272,5 +280,5 @@
   rdfs:comment """
     An HTTP Link header to be added to the result of requesting the input file.
     """ ;
-  rdfs:domain	 :Test ;
+  rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .


### PR DESCRIPTION
* Added `compactToRelative` option and tests. Fixed test vocabulary to match reality. Fixes #468.
* Change algorithm for creating compact IRIs to favor terms ending with colon `':'` (in which case no colon is added) or end with a gen-delim and require that such terms be simple terms.