### PR TITLE
Mark 1.1 tests with "specVersion": "1.1", which is independent of "processingMode".

### DIFF
--- a/test-suite/context.jsonld
+++ b/test-suite/context.jsonld
@@ -7,9 +7,9 @@
     "rdfs":     "http://www.w3.org/2000/01/rdf-schema#",
     "xsd":      "http://www.w3.org/2001/XMLSchema#",
 
-    "context":    { "@id": "input", "@type": "@id" },
+    "context":    { "@type": "@id" },
     "expect":     { "@id": "mf:result", "@type": "@id" },
-    "frame":      { "@id": "input", "@type": "@id" },
+    "frame":      { "@type": "@id" },
     "input":      { "@id": "mf:action", "@type": "@id" },
     "option":     { "@type": "@id"},
     "sequence":   { "@id": "mf:entries", "@type": "@id", "@container": "@list" },
@@ -23,10 +23,11 @@
     "compactToRelative":    { "@type": "xsd:boolean" },
     "documentLoader":       { "@type": "xsd:string" },
     "expandContext":        { "@type": "xsd:string" },
+    "httpStatus":           { "@type": "xsd:integer" },
+    "httpLink":             { "@type": "xsd:string", "@container": "@set" },
     "processingMode":       { "@type": "xsd:string" },
     "produceGeneralizedRdf":{ "@type": "xsd:boolean" },
-    "useNativeTypes":       { "@type": "xsd:boolean" },
-    "httpStatus":           { "@type": "xsd:integer"},
-    "httpLink":             { "@container": "@set"}
+    "specVersion":          { "@type": "xsd:string" },
+    "useNativeTypes":       { "@type": "xsd:boolean" }
   }
 }

--- a/test-suite/manifest.jsonld
+++ b/test-suite/manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "description": "This manifest loads additional manifests for specific behavior tests",

--- a/test-suite/tests/compact-0038a-out.jsonld
+++ b/test-suite/tests/compact-0038a-out.jsonld
@@ -20,19 +20,19 @@
   "title": {
     "en": {
         "@type": "site-cd:field-types/title_field",
-        "title:/value": "This is the English title"
+        "site-cd:node/article/title/value": "This is the English title"
     },
     "es": {
       "@type": "site-cd:field-types/title_field",
-      "title:/value": "Este es el t’tulo espa–ol"
+      "site-cd:node/article/title/value": "Este es el t’tulo espa–ol"
     }
   },
   "body": {
     "en": {
       "@type": "site-cd:field-types/text_with_summary",
-      "body:/value": "This is the English body. There is no Spanish body, so this will be displayed for both the English and Spanish versions.",
-      "body:/summary": "This is the teaser for the body.",
-      "body:/format": "full_html"
+      "site-cd:node/article/body/value": "This is the English body. There is no Spanish body, so this will be displayed for both the English and Spanish versions.",
+      "site-cd:node/article/body/summary": "This is the teaser for the body.",
+      "site-cd:node/article/body/format": "full_html"
     }
   },
   "field_tags": {

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -307,7 +307,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Index map round-tripping",
       "purpose": "Complext round-tripping use case from Drupal",
-      "option": {"specVersion": "1.0"},
+      "option": {"specVersion": "json-ld-1.0"},
       "input": "compact-0038-in.jsonld",
       "context": "compact-0038-context.jsonld",
       "expect": "compact-0038-out.jsonld"
@@ -316,7 +316,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Index map round-tripping",
       "purpose": "Complext round-tripping use case from Drupal",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "compact-0038-in.jsonld",
       "context": "compact-0038-context.jsonld",
       "expect": "compact-0038a-out.jsonld"
@@ -636,7 +636,7 @@
       "input": "compact-c001-in.jsonld",
       "context": "compact-c001-context.jsonld",
       "expect": "compact-c001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -645,7 +645,7 @@
       "input": "compact-c002-in.jsonld",
       "context": "compact-c002-context.jsonld",
       "expect": "compact-c002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc003",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -654,7 +654,7 @@
       "input": "compact-c003-in.jsonld",
       "context": "compact-c003-context.jsonld",
       "expect": "compact-c003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc004",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -663,7 +663,7 @@
       "input": "compact-c004-in.jsonld",
       "context": "compact-c004-context.jsonld",
       "expect": "compact-c004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc005",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -672,7 +672,7 @@
       "input": "compact-c005-in.jsonld",
       "context": "compact-c005-context.jsonld",
       "expect": "compact-c005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -681,7 +681,7 @@
       "input": "compact-m001-in.jsonld",
       "context": "compact-m001-context.jsonld",
       "expect": "compact-m001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -690,7 +690,7 @@
       "input": "compact-m002-in.jsonld",
       "context": "compact-m002-context.jsonld",
       "expect": "compact-m002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm003",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -699,7 +699,7 @@
       "input": "compact-m003-in.jsonld",
       "context": "compact-m003-context.jsonld",
       "expect": "compact-m003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm004",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -708,7 +708,7 @@
       "input": "compact-m004-in.jsonld",
       "context": "compact-m004-context.jsonld",
       "expect": "compact-m004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm005",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -717,7 +717,7 @@
       "input": "compact-m005-in.jsonld",
       "context": "compact-m005-context.jsonld",
       "expect": "compact-m005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm006",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -726,7 +726,7 @@
       "input": "compact-m006-in.jsonld",
       "context": "compact-m006-context.jsonld",
       "expect": "compact-m006-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm007",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -735,7 +735,7 @@
       "input": "compact-m007-in.jsonld",
       "context": "compact-m007-context.jsonld",
       "expect": "compact-m007-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm008",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -744,7 +744,7 @@
       "input": "compact-m008-in.jsonld",
       "context": "compact-m008-context.jsonld",
       "expect": "compact-m008-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm009",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -753,7 +753,7 @@
       "input": "compact-m009-in.jsonld",
       "context": "compact-m009-context.jsonld",
       "expect": "compact-m009-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm010",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -762,7 +762,7 @@
       "input": "compact-m010-in.jsonld",
       "context": "compact-m010-context.jsonld",
       "expect": "compact-m010-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm011",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -771,7 +771,7 @@
       "input": "compact-m011-in.jsonld",
       "context": "compact-m011-context.jsonld",
       "expect": "compact-m011-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm012",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -780,7 +780,7 @@
       "input": "compact-m012-in.jsonld",
       "context": "compact-m012-context.jsonld",
       "expect": "compact-m012-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -789,7 +789,7 @@
       "input": "compact-n001-in.jsonld",
       "context": "compact-n001-context.jsonld",
       "expect": "compact-n001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -798,7 +798,7 @@
       "input": "compact-n002-in.jsonld",
       "context": "compact-n002-context.jsonld",
       "expect": "compact-n002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn003",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -807,7 +807,7 @@
       "input": "compact-n003-in.jsonld",
       "context": "compact-n003-context.jsonld",
       "expect": "compact-n003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn004",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -816,7 +816,7 @@
       "input": "compact-n004-in.jsonld",
       "context": "compact-n004-context.jsonld",
       "expect": "compact-n004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn005",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -825,7 +825,7 @@
       "input": "compact-n005-in.jsonld",
       "context": "compact-n005-context.jsonld",
       "expect": "compact-n005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn006",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -834,7 +834,7 @@
       "input": "compact-n006-in.jsonld",
       "context": "compact-n006-context.jsonld",
       "expect": "compact-n006-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn007",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -843,7 +843,7 @@
       "input": "compact-n007-in.jsonld",
       "context": "compact-n007-context.jsonld",
       "expect": "compact-n007-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn008",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -852,7 +852,7 @@
       "input": "compact-n008-in.jsonld",
       "context": "compact-n008-context.jsonld",
       "expect": "compact-n008-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn009",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -861,7 +861,7 @@
       "input": "compact-n009-in.jsonld",
       "context": "compact-n009-context.jsonld",
       "expect": "compact-n009-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn010",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -870,13 +870,13 @@
       "input": "compact-n010-in.jsonld",
       "context": "compact-n010-context.jsonld",
       "expect": "compact-n010-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI may use an expanded term definition in 1.0",
       "purpose": "Terms with an expanded term definition may be used for creating compact IRIs",
-      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"},
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "json-ld-1.1"},
       "input": "compact-p001-in.jsonld",
       "context": "compact-p001-context.jsonld",
       "expect": "compact-p001-out.jsonld"
@@ -885,7 +885,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI does not use expanded term definition in 1.1",
       "purpose": "Terms with an expanded term definition are not used for creating compact IRIs",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "compact-p002-in.jsonld",
       "context": "compact-p002-context.jsonld",
       "expect": "compact-p002-out.jsonld"
@@ -894,7 +894,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI does not use simple term that does not end with a gen-delim",
       "purpose": "Terms not ending with a gen-delim are not used for creating compact IRIs",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "compact-p003-in.jsonld",
       "context": "compact-p003-context.jsonld",
       "expect": "compact-p003-out.jsonld"
@@ -903,7 +903,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRIs using simple terms ending with gen-delim",
       "purpose": "All simple terms ending with gen-delim are suitable for compaction",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "compact-p004-in.jsonld",
       "context": "compact-p004-context.jsonld",
       "expect": "compact-p004-out.jsonld"
@@ -912,7 +912,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI uses term with definition including @prefix: true",
       "purpose": "Expanded term definition may set prefix explicitly in 1.1",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "compact-p005-in.jsonld",
       "context": "compact-p005-context.jsonld",
       "expect": "compact-p005-out.jsonld"
@@ -921,7 +921,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI uses term with definition including @prefix: true",
       "purpose": "Expanded term definition may set prefix explicitly in 1.1",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "compact-p006-in.jsonld",
       "context": "compact-p006-context.jsonld",
       "expect": "compact-p006-out.jsonld"
@@ -930,7 +930,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI not used as prefix",
       "purpose": "Terms including a colon are excluded from being used as a prefix",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "compact-p007-in.jsonld",
       "context": "compact-p007-context.jsonld",
       "expect": "compact-p007-out.jsonld"
@@ -942,7 +942,7 @@
       "input": "compact-r001-in.jsonld",
       "context": "compact-r001-context.jsonld",
       "expect": "compact-r001-out.jsonld",
-      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tr002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -952,7 +952,7 @@
       "context": "compact-r002-context.jsonld",
       "expect": "compact-r002-out.jsonld",
       "option": {
-        "processingMode": "json-ld-1.1", "specVersion": "1.1",
+        "processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1",
         "compactToRelative": false
       }
     }, {
@@ -963,7 +963,7 @@
       "input": "compact-s001-in.jsonld",
       "context": "compact-s001-context.jsonld",
       "expect": "compact-s001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#ts002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -972,7 +972,7 @@
       "input": "compact-s002-in.jsonld",
       "context": "compact-s002-context.jsonld",
       "expect": "compact-s002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }
   ]
 }

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -307,9 +307,19 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Index map round-tripping",
       "purpose": "Complext round-tripping use case from Drupal",
+      "option": {"specVersion": "1.0"},
       "input": "compact-0038-in.jsonld",
       "context": "compact-0038-context.jsonld",
       "expect": "compact-0038-out.jsonld"
+    }, {
+      "@id": "#ta038",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Index map round-tripping",
+      "purpose": "Complext round-tripping use case from Drupal",
+      "option": {"specVersion": "1.1"},
+      "input": "compact-0038-in.jsonld",
+      "context": "compact-0038-context.jsonld",
+      "expect": "compact-0038a-out.jsonld"
     }, {
       "@id": "#t0039",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -626,7 +636,7 @@
       "input": "compact-c001-in.jsonld",
       "context": "compact-c001-context.jsonld",
       "expect": "compact-c001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tc002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -635,7 +645,7 @@
       "input": "compact-c002-in.jsonld",
       "context": "compact-c002-context.jsonld",
       "expect": "compact-c002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tc003",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -644,7 +654,7 @@
       "input": "compact-c003-in.jsonld",
       "context": "compact-c003-context.jsonld",
       "expect": "compact-c003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tc004",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -653,7 +663,7 @@
       "input": "compact-c004-in.jsonld",
       "context": "compact-c004-context.jsonld",
       "expect": "compact-c004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tc005",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -662,7 +672,7 @@
       "input": "compact-c005-in.jsonld",
       "context": "compact-c005-context.jsonld",
       "expect": "compact-c005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
    }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -671,7 +681,7 @@
       "input": "compact-m001-in.jsonld",
       "context": "compact-m001-context.jsonld",
       "expect": "compact-m001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -680,7 +690,7 @@
       "input": "compact-m002-in.jsonld",
       "context": "compact-m002-context.jsonld",
       "expect": "compact-m002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm003",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -689,7 +699,7 @@
       "input": "compact-m003-in.jsonld",
       "context": "compact-m003-context.jsonld",
       "expect": "compact-m003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm004",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -698,7 +708,7 @@
       "input": "compact-m004-in.jsonld",
       "context": "compact-m004-context.jsonld",
       "expect": "compact-m004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm005",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -707,7 +717,7 @@
       "input": "compact-m005-in.jsonld",
       "context": "compact-m005-context.jsonld",
       "expect": "compact-m005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm006",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -716,7 +726,7 @@
       "input": "compact-m006-in.jsonld",
       "context": "compact-m006-context.jsonld",
       "expect": "compact-m006-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm007",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -725,7 +735,7 @@
       "input": "compact-m007-in.jsonld",
       "context": "compact-m007-context.jsonld",
       "expect": "compact-m007-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm008",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -734,7 +744,7 @@
       "input": "compact-m008-in.jsonld",
       "context": "compact-m008-context.jsonld",
       "expect": "compact-m008-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm009",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -743,7 +753,7 @@
       "input": "compact-m009-in.jsonld",
       "context": "compact-m009-context.jsonld",
       "expect": "compact-m009-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm010",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -752,7 +762,7 @@
       "input": "compact-m010-in.jsonld",
       "context": "compact-m010-context.jsonld",
       "expect": "compact-m010-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm011",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -761,7 +771,7 @@
       "input": "compact-m011-in.jsonld",
       "context": "compact-m011-context.jsonld",
       "expect": "compact-m011-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm012",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -770,7 +780,7 @@
       "input": "compact-m012-in.jsonld",
       "context": "compact-m012-context.jsonld",
       "expect": "compact-m012-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -779,7 +789,7 @@
       "input": "compact-n001-in.jsonld",
       "context": "compact-n001-context.jsonld",
       "expect": "compact-n001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -788,7 +798,7 @@
       "input": "compact-n002-in.jsonld",
       "context": "compact-n002-context.jsonld",
       "expect": "compact-n002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn003",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -797,7 +807,7 @@
       "input": "compact-n003-in.jsonld",
       "context": "compact-n003-context.jsonld",
       "expect": "compact-n003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn004",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -806,7 +816,7 @@
       "input": "compact-n004-in.jsonld",
       "context": "compact-n004-context.jsonld",
       "expect": "compact-n004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn005",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -815,7 +825,7 @@
       "input": "compact-n005-in.jsonld",
       "context": "compact-n005-context.jsonld",
       "expect": "compact-n005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn006",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -824,7 +834,7 @@
       "input": "compact-n006-in.jsonld",
       "context": "compact-n006-context.jsonld",
       "expect": "compact-n006-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn007",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -833,7 +843,7 @@
       "input": "compact-n007-in.jsonld",
       "context": "compact-n007-context.jsonld",
       "expect": "compact-n007-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn008",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -842,7 +852,7 @@
       "input": "compact-n008-in.jsonld",
       "context": "compact-n008-context.jsonld",
       "expect": "compact-n008-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn009",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -851,7 +861,7 @@
       "input": "compact-n009-in.jsonld",
       "context": "compact-n009-context.jsonld",
       "expect": "compact-n009-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn010",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -860,13 +870,13 @@
       "input": "compact-n010-in.jsonld",
       "context": "compact-n010-context.jsonld",
       "expect": "compact-n010-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tp001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI may use an expanded term definition in 1.0",
       "purpose": "Terms with an expanded term definition may be used for creating compact IRIs",
-      "option": {"processingMode": "json-ld-1.0"},
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"},
       "input": "compact-p001-in.jsonld",
       "context": "compact-p001-context.jsonld",
       "expect": "compact-p001-out.jsonld"
@@ -875,7 +885,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI does not use expanded term definition in 1.1",
       "purpose": "Terms with an expanded term definition are not used for creating compact IRIs",
-      "option": {"processingMode": "json-ld-1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
       "input": "compact-p002-in.jsonld",
       "context": "compact-p002-context.jsonld",
       "expect": "compact-p002-out.jsonld"
@@ -884,6 +894,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI does not use simple term that does not end with a gen-delim",
       "purpose": "Terms not ending with a gen-delim are not used for creating compact IRIs",
+      "option": {"specVersion": "1.1"},
       "input": "compact-p003-in.jsonld",
       "context": "compact-p003-context.jsonld",
       "expect": "compact-p003-out.jsonld"
@@ -892,6 +903,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRIs using simple terms ending with gen-delim",
       "purpose": "All simple terms ending with gen-delim are suitable for compaction",
+      "option": {"specVersion": "1.1"},
       "input": "compact-p004-in.jsonld",
       "context": "compact-p004-context.jsonld",
       "expect": "compact-p004-out.jsonld"
@@ -900,7 +912,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI uses term with definition including @prefix: true",
       "purpose": "Expanded term definition may set prefix explicitly in 1.1",
-      "option": {"processingMode": "json-ld-1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
       "input": "compact-p005-in.jsonld",
       "context": "compact-p005-context.jsonld",
       "expect": "compact-p005-out.jsonld"
@@ -909,7 +921,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI uses term with definition including @prefix: true",
       "purpose": "Expanded term definition may set prefix explicitly in 1.1",
-      "option": {"processingMode": "json-ld-1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
       "input": "compact-p006-in.jsonld",
       "context": "compact-p006-context.jsonld",
       "expect": "compact-p006-out.jsonld"
@@ -918,6 +930,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
       "name": "Compact IRI not used as prefix",
       "purpose": "Terms including a colon are excluded from being used as a prefix",
+      "option": {"specVersion": "1.1"},
       "input": "compact-p007-in.jsonld",
       "context": "compact-p007-context.jsonld",
       "expect": "compact-p007-out.jsonld"
@@ -929,7 +942,7 @@
       "input": "compact-r001-in.jsonld",
       "context": "compact-r001-context.jsonld",
       "expect": "compact-r001-out.jsonld",
-      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1"}
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tr002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -939,7 +952,7 @@
       "context": "compact-r002-context.jsonld",
       "expect": "compact-r002-out.jsonld",
       "option": {
-        "processingMode": "json-ld-1.1",
+        "processingMode": "json-ld-1.1", "specVersion": "1.1",
         "compactToRelative": false
       }
     }, {
@@ -950,7 +963,7 @@
       "input": "compact-s001-in.jsonld",
       "context": "compact-s001-context.jsonld",
       "expect": "compact-s001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#ts002",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
@@ -959,7 +972,7 @@
       "input": "compact-s002-in.jsonld",
       "context": "compact-s002-context.jsonld",
       "expect": "compact-s002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }
   ]
 }

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Compaction",

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "description": "JSON-LD to Expansion tests use object compare",

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -153,7 +153,7 @@
       "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
       "input": "error-0021-in.jsonld",
       "expect": "invalid container mapping",
-      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#t0022",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -307,7 +307,7 @@
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
       "name": "Conflicting indexes",
       "purpose": "Verifies that an exception is raised in Flattening when conflicting indexes are found",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "error-0043-in.jsonld",
       "expect": "conflicting indexes"
     }, {
@@ -317,7 +317,7 @@
       "purpose": "Verifies that an exception is raised on expansion when a invalid term definition is found",
       "input": "error-c001-in.jsonld",
       "expect": "invalid term definition",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#tm021",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -325,7 +325,7 @@
       "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
       "input": "error-m021-in.jsonld",
       "expect": "invalid container mapping",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -333,7 +333,7 @@
       "purpose": "container: @nest",
       "input": "error-n001-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn002",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -341,7 +341,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n002-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn003",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -349,7 +349,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n003-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn004",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -357,7 +357,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n004-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn005",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -365,7 +365,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n005-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn006",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -373,7 +373,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n006-in.jsonld",
       "expect": "invalid reverse property",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn007",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
@@ -382,13 +382,13 @@
       "input": "error-n007-in.jsonld",
       "context": "error-n007-context.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp001",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Processing mode is implicitly json-ld-1.0",
       "purpose": "If not specified using processingMode, processing mode is taken as json-ld-1.0",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "error-p001-in.jsonld",
       "expect": "invalid container mapping"
     }, {
@@ -398,13 +398,13 @@
       "purpose": "If not specified using processingMode, processing mode is taken as json-ld-1.0",
       "input": "error-p002-in.jsonld",
       "expect": "processing mode conflict",
-      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp003",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@version must be 1.1",
       "purpose": "If @version is specified, it must be 1.1",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "error-p003-in.jsonld",
       "expect": "invalid @version value"
     }, {
@@ -412,7 +412,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "Processing mode is implicitly json-ld-1.0",
       "purpose": "If not specified using processingMode, processing mode is taken as json-ld-1.0",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "error-p004-in.jsonld",
       "context": "error-p004-context.jsonld",
       "expect": "invalid container mapping"
@@ -424,13 +424,13 @@
       "input": "error-p005-in.jsonld",
       "context": "error-p005-context.jsonld",
       "expect": "processing mode conflict",
-      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp006",
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@version must be 1.1",
       "purpose": "If @version is specified, it must be 1.1",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "error-p006-in.jsonld",
       "context": "error-p006-context.jsonld",
       "expect": "invalid @version value"
@@ -439,7 +439,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@prefix is not allowed in 1.0",
       "purpose": "@prefix is not allowed in a term definitionin 1.0",
-      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"},
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "json-ld-1.1"},
       "input": "error-p007-in.jsonld",
       "context": "error-p007-context.jsonld",
       "expect": "invalid term definition"
@@ -448,7 +448,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@prefix must be a boolean",
       "purpose": "@prefix must be a boolean in a term definition in 1.1",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "error-p008-in.jsonld",
       "context": "error-p008-context.jsonld",
       "expect": "invalid @prefix value"
@@ -457,7 +457,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@prefix not allowed on compact IRI term",
       "purpose": "If processingMode is json-ld-1.0, or if term contains a colon (:), an invalid term definition has been detected and processing is aborted.",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"},
       "input": "error-p009-in.jsonld",
       "context": "error-p009-context.jsonld",
       "expect": "invalid term definition"
@@ -468,7 +468,7 @@
       "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
       "input": "error-s001-in.jsonld",
       "expect": "invalid container mapping",
-      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#ts002",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -476,7 +476,7 @@
       "purpose": "Testing legal combinations of @set with other container values",
       "input": "error-s002-in.jsonld",
       "expect": "invalid container mapping",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }
   ]
 }

--- a/test-suite/tests/error-manifest.jsonld
+++ b/test-suite/tests/error-manifest.jsonld
@@ -153,7 +153,7 @@
       "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
       "input": "error-0021-in.jsonld",
       "expect": "invalid container mapping",
-      "option": {"processingMode": "json-ld-1.0"}
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"}
     }, {
       "@id": "#t0022",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -307,6 +307,7 @@
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
       "name": "Conflicting indexes",
       "purpose": "Verifies that an exception is raised in Flattening when conflicting indexes are found",
+      "option": {"specVersion": "1.1"},
       "input": "error-0043-in.jsonld",
       "expect": "conflicting indexes"
     }, {
@@ -316,7 +317,7 @@
       "purpose": "Verifies that an exception is raised on expansion when a invalid term definition is found",
       "input": "error-c001-in.jsonld",
       "expect": "invalid term definition",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
    }, {
       "@id": "#tm021",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -324,7 +325,7 @@
       "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
       "input": "error-m021-in.jsonld",
       "expect": "invalid container mapping",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn001",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -332,7 +333,7 @@
       "purpose": "container: @nest",
       "input": "error-n001-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn002",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -340,7 +341,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n002-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn003",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -348,7 +349,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n003-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn004",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -356,7 +357,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n004-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn005",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -364,7 +365,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n005-in.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn006",
       "@type": [ "jld:NegativeEvaluationTest", "jld:FlattenTest" ],
@@ -372,7 +373,7 @@
       "purpose": "Transparent Nesting",
       "input": "error-n006-in.jsonld",
       "expect": "invalid reverse property",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn007",
       "@type": [ "jld:NegativeEvaluationTest", "jld:CompactTest" ],
@@ -381,12 +382,13 @@
       "input": "error-n007-in.jsonld",
       "context": "error-n007-context.jsonld",
       "expect": "invalid @nest value",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tp001",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "Processing mode is implicitly json-ld-1.0",
       "purpose": "If not specified using processingMode, processing mode is taken as json-ld-1.0",
+      "option": {"specVersion": "1.1"},
       "input": "error-p001-in.jsonld",
       "expect": "invalid container mapping"
     }, {
@@ -396,12 +398,13 @@
       "purpose": "If not specified using processingMode, processing mode is taken as json-ld-1.0",
       "input": "error-p002-in.jsonld",
       "expect": "processing mode conflict",
-      "option": {"processingMode": "json-ld-1.0"}
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"}
     }, {
       "@id": "#tp003",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
       "name": "@version must be 1.1",
       "purpose": "If @version is specified, it must be 1.1",
+      "option": {"specVersion": "1.1"},
       "input": "error-p003-in.jsonld",
       "expect": "invalid @version value"
     }, {
@@ -409,6 +412,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "Processing mode is implicitly json-ld-1.0",
       "purpose": "If not specified using processingMode, processing mode is taken as json-ld-1.0",
+      "option": {"specVersion": "1.1"},
       "input": "error-p004-in.jsonld",
       "context": "error-p004-context.jsonld",
       "expect": "invalid container mapping"
@@ -420,12 +424,13 @@
       "input": "error-p005-in.jsonld",
       "context": "error-p005-context.jsonld",
       "expect": "processing mode conflict",
-      "option": {"processingMode": "json-ld-1.0"}
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"}
     }, {
       "@id": "#tp006",
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@version must be 1.1",
       "purpose": "If @version is specified, it must be 1.1",
+      "option": {"specVersion": "1.1"},
       "input": "error-p006-in.jsonld",
       "context": "error-p006-context.jsonld",
       "expect": "invalid @version value"
@@ -434,7 +439,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@prefix is not allowed in 1.0",
       "purpose": "@prefix is not allowed in a term definitionin 1.0",
-      "option": {"processingMode": "json-ld-1.0"},
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"},
       "input": "error-p007-in.jsonld",
       "context": "error-p007-context.jsonld",
       "expect": "invalid term definition"
@@ -443,7 +448,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@prefix must be a boolean",
       "purpose": "@prefix must be a boolean in a term definition in 1.1",
-      "option": {"processingMode": "json-ld-1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
       "input": "error-p008-in.jsonld",
       "context": "error-p008-context.jsonld",
       "expect": "invalid @prefix value"
@@ -452,7 +457,7 @@
       "@type": ["jld:NegativeEvaluationTest", "jld:CompactTest"],
       "name": "@prefix not allowed on compact IRI term",
       "purpose": "If processingMode is json-ld-1.0, or if term contains a colon (:), an invalid term definition has been detected and processing is aborted.",
-      "option": {"processingMode": "json-ld-1.1"},
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"},
       "input": "error-p009-in.jsonld",
       "context": "error-p009-context.jsonld",
       "expect": "invalid term definition"
@@ -463,7 +468,7 @@
       "purpose": "Verifies that an exception is raised on expansion when a invalid container mapping is found",
       "input": "error-s001-in.jsonld",
       "expect": "invalid container mapping",
-      "option": {"processingMode": "json-ld-1.0"}
+      "option": {"processingMode": "json-ld-1.0", "specVersion": "1.1"}
     }, {
       "@id": "#ts002",
       "@type": ["jld:NegativeEvaluationTest", "jld:ExpandTest"],
@@ -471,7 +476,7 @@
       "purpose": "Testing legal combinations of @set with other container values",
       "input": "error-s002-in.jsonld",
       "expect": "invalid container mapping",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }
   ]
 }

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -565,7 +565,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c001-in.jsonld",
       "expect": "expand-c001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tc002",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -573,7 +573,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c002-in.jsonld",
       "expect": "expand-c002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tc003",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -581,7 +581,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c003-in.jsonld",
       "expect": "expand-c003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tc004",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -589,7 +589,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c004-in.jsonld",
       "expect": "expand-c004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tc005",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -597,7 +597,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c005-in.jsonld",
       "expect": "expand-c005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
    }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -605,7 +605,7 @@
       "purpose": "Expansion using @container: @id",
       "input": "expand-m001-in.jsonld",
       "expect": "expand-m001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm002",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -613,7 +613,7 @@
       "purpose": "Expansion using @container: @id",
       "input": "expand-m002-in.jsonld",
       "expect": "expand-m002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm003",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -621,7 +621,7 @@
       "purpose": "Expansion using @container: @type",
       "input": "expand-m003-in.jsonld",
       "expect": "expand-m003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm004",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -629,7 +629,7 @@
       "purpose": "Expansion using @container: @type",
       "input": "expand-m004-in.jsonld",
       "expect": "expand-m004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm005",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -637,7 +637,7 @@
       "purpose": "Expansion using @container: @id",
       "input": "expand-m005-in.jsonld",
       "expect": "expand-m005-out.jsonld",
-      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1"}
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm006",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -645,7 +645,7 @@
       "purpose": "Expansion using @container: @type",
       "input": "expand-m006-in.jsonld",
       "expect": "expand-m006-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm007",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -653,7 +653,7 @@
       "purpose": "Expansion using @container: @type",
       "input": "expand-m007-in.jsonld",
       "expect": "expand-m007-out.jsonld",
-      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1"}
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm008",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -661,7 +661,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m008-in.jsonld",
       "expect": "expand-m008-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm009",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -669,7 +669,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m009-in.jsonld",
       "expect": "expand-m009-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm010",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -677,7 +677,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m010-in.jsonld",
       "expect": "expand-m010-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm011",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -685,7 +685,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m011-in.jsonld",
       "expect": "expand-m011-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm012",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -693,7 +693,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m012-in.jsonld",
       "expect": "expand-m012-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tm013",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -701,7 +701,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m013-in.jsonld",
       "expect": "expand-m013-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -709,7 +709,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n001-in.jsonld",
       "expect": "expand-n001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn002",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -717,7 +717,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n002-in.jsonld",
       "expect": "expand-n002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn003",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -725,7 +725,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n003-in.jsonld",
       "expect": "expand-n003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn004",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -733,7 +733,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n004-in.jsonld",
       "expect": "expand-n004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn005",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -741,7 +741,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n005-in.jsonld",
       "expect": "expand-n005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn006",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -749,7 +749,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n006-in.jsonld",
       "expect": "expand-n006-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
     }, {
       "@id": "#tn007",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -757,12 +757,13 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n007-in.jsonld",
       "expect": "expand-n007-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Language map with null value",
       "purpose": "A language map may have a null value, which is ignored",
+      "option": {"specVersion": "1.1"},
       "input": "expand-l001-in.jsonld",
       "expect": "expand-l001-out.jsonld"
     }

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -565,7 +565,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c001-in.jsonld",
       "expect": "expand-c001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc002",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -573,7 +573,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c002-in.jsonld",
       "expect": "expand-c002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc003",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -581,7 +581,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c003-in.jsonld",
       "expect": "expand-c003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc004",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -589,7 +589,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c004-in.jsonld",
       "expect": "expand-c004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc005",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -597,7 +597,7 @@
       "purpose": "Expansion using a scoped context uses term scope for selecting proper term",
       "input": "expand-c005-in.jsonld",
       "expect": "expand-c005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -605,7 +605,7 @@
       "purpose": "Expansion using @container: @id",
       "input": "expand-m001-in.jsonld",
       "expect": "expand-m001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm002",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -613,7 +613,7 @@
       "purpose": "Expansion using @container: @id",
       "input": "expand-m002-in.jsonld",
       "expect": "expand-m002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm003",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -621,7 +621,7 @@
       "purpose": "Expansion using @container: @type",
       "input": "expand-m003-in.jsonld",
       "expect": "expand-m003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm004",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -629,7 +629,7 @@
       "purpose": "Expansion using @container: @type",
       "input": "expand-m004-in.jsonld",
       "expect": "expand-m004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm005",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -637,7 +637,7 @@
       "purpose": "Expansion using @container: @id",
       "input": "expand-m005-in.jsonld",
       "expect": "expand-m005-out.jsonld",
-      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm006",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -645,7 +645,7 @@
       "purpose": "Expansion using @container: @type",
       "input": "expand-m006-in.jsonld",
       "expect": "expand-m006-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm007",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -653,7 +653,7 @@
       "purpose": "Expansion using @container: @type",
       "input": "expand-m007-in.jsonld",
       "expect": "expand-m007-out.jsonld",
-      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"base": "http://example.org/", "processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm008",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -661,7 +661,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m008-in.jsonld",
       "expect": "expand-m008-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm009",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -669,7 +669,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m009-in.jsonld",
       "expect": "expand-m009-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm010",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -677,7 +677,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m010-in.jsonld",
       "expect": "expand-m010-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm011",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -685,7 +685,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m011-in.jsonld",
       "expect": "expand-m011-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm012",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -693,7 +693,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m012-in.jsonld",
       "expect": "expand-m012-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tm013",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -701,7 +701,7 @@
       "purpose": "scoped context on @type",
       "input": "expand-m013-in.jsonld",
       "expect": "expand-m013-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#tn001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -709,7 +709,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n001-in.jsonld",
       "expect": "expand-n001-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn002",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -717,7 +717,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n002-in.jsonld",
       "expect": "expand-n002-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn003",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -725,7 +725,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n003-in.jsonld",
       "expect": "expand-n003-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn004",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -733,7 +733,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n004-in.jsonld",
       "expect": "expand-n004-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn005",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -741,7 +741,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n005-in.jsonld",
       "expect": "expand-n005-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn006",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -749,7 +749,7 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n006-in.jsonld",
       "expect": "expand-n006-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tn007",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
@@ -757,13 +757,13 @@
       "purpose": "Expansion using @nest",
       "input": "expand-n007-in.jsonld",
       "expect": "expand-n007-out.jsonld",
-      "option": {"processingMode": "json-ld-1.1", "specVersion": "1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "Language map with null value",
       "purpose": "A language map may have a null value, which is ignored",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "expand-l001-in.jsonld",
       "expect": "expand-l001-out.jsonld"
     }

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "description": "JSON-LD to Expansion tests use object compare",

--- a/test-suite/tests/flatten-manifest.jsonld
+++ b/test-suite/tests/flatten-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Flattening",

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -189,7 +189,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "No match on []",
       "purpose": "No match if node has a property where frame has an empty array for that same property.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0023-in.jsonld",
       "frame": "frame-0023-frame.jsonld",
       "expect": "frame-0023-out.jsonld"
@@ -198,7 +198,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "match on any common properties if @requireAll: true",
       "purpose": "Match if @requireAll is false and both node and frame contain common non-keyword properties of any value.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0024-in.jsonld",
       "frame": "frame-0024-frame.jsonld",
       "expect": "frame-0024-out.jsonld"
@@ -207,7 +207,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@requireAll with missing values and @default",
       "purpose": "Match if @requireAll is true and frame contains a non-keyword key not present in node, where the value is a JSON object containing only the key @default with any value.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0025-in.jsonld",
       "frame": "frame-0025-frame.jsonld",
       "expect": "frame-0025-out.jsonld"
@@ -216,7 +216,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "explicitly excludes unframed properties (@explicit: true)",
       "purpose": "If property is not in frame, and explicit is true, processors must not add any values for property to output.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0026-in.jsonld",
       "frame": "frame-0026-frame.jsonld",
       "expect": "frame-0026-out.jsonld"
@@ -225,7 +225,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "non-existent framed properties create null property",
       "purpose": "Recursively, replace all key-value pairs in compacted results where the key is @preserve with the value from the key-pair. If the value from the key-pair is @null, replace the value with null.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0027-in.jsonld",
       "frame": "frame-0027-frame.jsonld",
       "expect": "frame-0027-out.jsonld"
@@ -234,7 +234,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "embed matched frames with @reverse",
       "purpose": "If frame has the property @reverse, then for each reverse property and sub frame that are the values of @reverse in frame.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0028-in.jsonld",
       "frame": "frame-0028-frame.jsonld",
       "expect": "frame-0028-out.jsonld"
@@ -243,7 +243,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "embed matched frames with reversed property",
       "purpose": "If frame has the property @reverse, then for each reverse property and sub frame that are the values of @reverse in frame.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0029-in.jsonld",
       "frame": "frame-0029-frame.jsonld",
       "expect": "frame-0029-out.jsonld"
@@ -252,7 +252,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@embed",
       "purpose": "@embed within a frame controls the object embed flag when processing that frame (@always and @never values).",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0030-in.jsonld",
       "frame": "frame-0030-frame.jsonld",
       "expect": "frame-0030-out.jsonld"
@@ -261,7 +261,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "match none @type match",
       "purpose": "Do not match objects with @type, if frame uses @type: [].",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0031-in.jsonld",
       "frame": "frame-0031-frame.jsonld",
       "expect": "frame-0031-out.jsonld"
@@ -270,7 +270,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "single @id match",
       "purpose": "Match on a specific node with frame uses @id.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0032-in.jsonld",
       "frame": "frame-0032-frame.jsonld",
       "expect": "frame-0032-out.jsonld"
@@ -279,7 +279,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "multiple @id match",
       "purpose": "Match on a specific node with frame uses @id with an array of IRIs.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0033-in.jsonld",
       "frame": "frame-0033-frame.jsonld",
       "expect": "frame-0033-out.jsonld"
@@ -288,7 +288,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "wildcard and match none",
       "purpose": "Match/reject properties using both wildcard and match none.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0034-in.jsonld",
       "frame": "frame-0034-frame.jsonld",
       "expect": "frame-0034-out.jsonld"
@@ -297,7 +297,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches a deep node pattern",
       "purpose": "Node patterns that don't match all levels, don't match top level.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0035-in.jsonld",
       "frame": "frame-0035-frame.jsonld",
       "expect": "frame-0035-out.jsonld"
@@ -306,7 +306,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches exact value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0036-in.jsonld",
       "frame": "frame-0036-frame.jsonld",
       "expect": "frame-0036-out.jsonld"
@@ -315,7 +315,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches wildcard @value in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0037-in.jsonld",
       "frame": "frame-0037-frame.jsonld",
       "expect": "frame-0037-out.jsonld"
@@ -324,7 +324,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches wildcard @type in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0038-in.jsonld",
       "frame": "frame-0038-frame.jsonld",
       "expect": "frame-0038-out.jsonld"
@@ -333,7 +333,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches wildcard @language in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0039-in.jsonld",
       "frame": "frame-0039-frame.jsonld",
       "expect": "frame-0039-out.jsonld"
@@ -342,7 +342,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches match none @type in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0040-in.jsonld",
       "frame": "frame-0040-frame.jsonld",
       "expect": "frame-0040-out.jsonld"
@@ -351,7 +351,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches match none @language in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0041-in.jsonld",
       "frame": "frame-0041-frame.jsonld",
       "expect": "frame-0041-out.jsonld"
@@ -360,7 +360,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches some @value in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0042-in.jsonld",
       "frame": "frame-0042-frame.jsonld",
       "expect": "frame-0042-out.jsonld"
@@ -369,7 +369,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches some @type in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0043-in.jsonld",
       "frame": "frame-0043-frame.jsonld",
       "expect": "frame-0043-out.jsonld"
@@ -378,7 +378,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches some @language in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0044-in.jsonld",
       "frame": "frame-0044-frame.jsonld",
       "expect": "frame-0044-out.jsonld"
@@ -387,7 +387,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "excludes non-matched values in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0045-in.jsonld",
       "frame": "frame-0045-frame.jsonld",
       "expect": "frame-0045-out.jsonld"
@@ -399,13 +399,13 @@
       "input": "frame-0046-in.jsonld",
       "frame": "frame-0046-frame.jsonld",
       "expect": "frame-0046-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false, "specVersion": "1.1"}
+      "option": {"pruneBlankNodeIdentifiers": false, "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#t0047",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Frame default graph if outer @graph is used",
       "purpose": "If @graph exists at the top level, framing uses the default graph.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0047-in.jsonld",
       "frame": "frame-0047-frame.jsonld",
       "expect": "frame-0047-out.jsonld"
@@ -414,7 +414,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Merge one graph and preserve another",
       "purpose": "@graph used within a property value frames embedded values from a named graph.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0048-in.jsonld",
       "frame": "frame-0048-frame.jsonld",
       "expect": "frame-0048-out.jsonld"
@@ -423,16 +423,16 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Merge one graph and deep preserve another",
       "purpose": "@graph used within a property value frames embedded values from a named graph.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0049-in.jsonld",
       "frame": "frame-0049-frame.jsonld",
       "expect": "frame-0049-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false, "specVersion": "1.1"}
+      "option": {"pruneBlankNodeIdentifiers": false, "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#t0050",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Library example with named graphs",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0050-in.jsonld",
       "frame": "frame-0050-frame.jsonld",
       "expect": "frame-0050-out.jsonld"
@@ -441,7 +441,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Compacting values of @preserve",
       "purpose": "When compacting the value of a property using @preserve, use the term definition for term to properly compact the value of @preserve.",
-      "option": {"specVersion": "1.1"},
+      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0051-in.jsonld",
       "frame": "frame-0051-frame.jsonld",
       "expect": "frame-0051-out.jsonld"
@@ -453,7 +453,7 @@
       "input": "frame-0010-in.jsonld",
       "frame": "frame-0010-frame.jsonld",
       "expect": "frame-p010-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp020",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -462,7 +462,7 @@
       "input": "frame-0020-in.jsonld",
       "frame": "frame-0020-frame.jsonld",
       "expect": "frame-p020-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp021",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -471,7 +471,7 @@
       "input": "frame-0021-in.jsonld",
       "frame": "frame-0021-frame.jsonld",
       "expect": "frame-p021-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp046",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -480,7 +480,7 @@
       "input": "frame-0046-in.jsonld",
       "frame": "frame-0046-frame.jsonld",
       "expect": "frame-p046-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp049",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -489,6 +489,6 @@
       "input": "frame-0049-in.jsonld",
       "frame": "frame-0049-frame.jsonld",
       "expect": "frame-p049-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
     }]
 }

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -189,6 +189,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "No match on []",
       "purpose": "No match if node has a property where frame has an empty array for that same property.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0023-in.jsonld",
       "frame": "frame-0023-frame.jsonld",
       "expect": "frame-0023-out.jsonld"
@@ -197,6 +198,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "match on any common properties if @requireAll: true",
       "purpose": "Match if @requireAll is false and both node and frame contain common non-keyword properties of any value.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0024-in.jsonld",
       "frame": "frame-0024-frame.jsonld",
       "expect": "frame-0024-out.jsonld"
@@ -205,6 +207,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@requireAll with missing values and @default",
       "purpose": "Match if @requireAll is true and frame contains a non-keyword key not present in node, where the value is a JSON object containing only the key @default with any value.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0025-in.jsonld",
       "frame": "frame-0025-frame.jsonld",
       "expect": "frame-0025-out.jsonld"
@@ -213,6 +216,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "explicitly excludes unframed properties (@explicit: true)",
       "purpose": "If property is not in frame, and explicit is true, processors must not add any values for property to output.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0026-in.jsonld",
       "frame": "frame-0026-frame.jsonld",
       "expect": "frame-0026-out.jsonld"
@@ -221,6 +225,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "non-existent framed properties create null property",
       "purpose": "Recursively, replace all key-value pairs in compacted results where the key is @preserve with the value from the key-pair. If the value from the key-pair is @null, replace the value with null.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0027-in.jsonld",
       "frame": "frame-0027-frame.jsonld",
       "expect": "frame-0027-out.jsonld"
@@ -229,6 +234,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "embed matched frames with @reverse",
       "purpose": "If frame has the property @reverse, then for each reverse property and sub frame that are the values of @reverse in frame.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0028-in.jsonld",
       "frame": "frame-0028-frame.jsonld",
       "expect": "frame-0028-out.jsonld"
@@ -237,6 +243,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "embed matched frames with reversed property",
       "purpose": "If frame has the property @reverse, then for each reverse property and sub frame that are the values of @reverse in frame.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0029-in.jsonld",
       "frame": "frame-0029-frame.jsonld",
       "expect": "frame-0029-out.jsonld"
@@ -245,6 +252,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "@embed",
       "purpose": "@embed within a frame controls the object embed flag when processing that frame (@always and @never values).",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0030-in.jsonld",
       "frame": "frame-0030-frame.jsonld",
       "expect": "frame-0030-out.jsonld"
@@ -253,6 +261,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "match none @type match",
       "purpose": "Do not match objects with @type, if frame uses @type: [].",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0031-in.jsonld",
       "frame": "frame-0031-frame.jsonld",
       "expect": "frame-0031-out.jsonld"
@@ -261,6 +270,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "single @id match",
       "purpose": "Match on a specific node with frame uses @id.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0032-in.jsonld",
       "frame": "frame-0032-frame.jsonld",
       "expect": "frame-0032-out.jsonld"
@@ -269,6 +279,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "multiple @id match",
       "purpose": "Match on a specific node with frame uses @id with an array of IRIs.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0033-in.jsonld",
       "frame": "frame-0033-frame.jsonld",
       "expect": "frame-0033-out.jsonld"
@@ -277,6 +288,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "wildcard and match none",
       "purpose": "Match/reject properties using both wildcard and match none.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0034-in.jsonld",
       "frame": "frame-0034-frame.jsonld",
       "expect": "frame-0034-out.jsonld"
@@ -285,6 +297,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches a deep node pattern",
       "purpose": "Node patterns that don't match all levels, don't match top level.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0035-in.jsonld",
       "frame": "frame-0035-frame.jsonld",
       "expect": "frame-0035-out.jsonld"
@@ -293,6 +306,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches exact value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0036-in.jsonld",
       "frame": "frame-0036-frame.jsonld",
       "expect": "frame-0036-out.jsonld"
@@ -301,6 +315,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches wildcard @value in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0037-in.jsonld",
       "frame": "frame-0037-frame.jsonld",
       "expect": "frame-0037-out.jsonld"
@@ -309,6 +324,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches wildcard @type in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0038-in.jsonld",
       "frame": "frame-0038-frame.jsonld",
       "expect": "frame-0038-out.jsonld"
@@ -317,6 +333,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches wildcard @language in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0039-in.jsonld",
       "frame": "frame-0039-frame.jsonld",
       "expect": "frame-0039-out.jsonld"
@@ -325,6 +342,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches match none @type in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0040-in.jsonld",
       "frame": "frame-0040-frame.jsonld",
       "expect": "frame-0040-out.jsonld"
@@ -333,6 +351,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches match none @language in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0041-in.jsonld",
       "frame": "frame-0041-frame.jsonld",
       "expect": "frame-0041-out.jsonld"
@@ -341,6 +360,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches some @value in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0042-in.jsonld",
       "frame": "frame-0042-frame.jsonld",
       "expect": "frame-0042-out.jsonld"
@@ -349,6 +369,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches some @type in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0043-in.jsonld",
       "frame": "frame-0043-frame.jsonld",
       "expect": "frame-0043-out.jsonld"
@@ -357,6 +378,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "matches some @language in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0044-in.jsonld",
       "frame": "frame-0044-frame.jsonld",
       "expect": "frame-0044-out.jsonld"
@@ -365,6 +387,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "excludes non-matched values in value pattern",
       "purpose": "Value objects matching value patterns are output, others are filtered.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0045-in.jsonld",
       "frame": "frame-0045-frame.jsonld",
       "expect": "frame-0045-out.jsonld"
@@ -376,12 +399,13 @@
       "input": "frame-0046-in.jsonld",
       "frame": "frame-0046-frame.jsonld",
       "expect": "frame-0046-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false}
+      "option": {"pruneBlankNodeIdentifiers": false, "specVersion": "1.1"}
     }, {
       "@id": "#t0047",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Frame default graph if outer @graph is used",
       "purpose": "If @graph exists at the top level, framing uses the default graph.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0047-in.jsonld",
       "frame": "frame-0047-frame.jsonld",
       "expect": "frame-0047-out.jsonld"
@@ -390,6 +414,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Merge one graph and preserve another",
       "purpose": "@graph used within a property value frames embedded values from a named graph.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0048-in.jsonld",
       "frame": "frame-0048-frame.jsonld",
       "expect": "frame-0048-out.jsonld"
@@ -398,14 +423,16 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Merge one graph and deep preserve another",
       "purpose": "@graph used within a property value frames embedded values from a named graph.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0049-in.jsonld",
       "frame": "frame-0049-frame.jsonld",
       "expect": "frame-0049-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false}
+      "option": {"pruneBlankNodeIdentifiers": false, "specVersion": "1.1"}
     }, {
       "@id": "#t0050",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Library example with named graphs",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0050-in.jsonld",
       "frame": "frame-0050-frame.jsonld",
       "expect": "frame-0050-out.jsonld"
@@ -414,6 +441,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Compacting values of @preserve",
       "purpose": "When compacting the value of a property using @preserve, use the term definition for term to properly compact the value of @preserve.",
+      "option": {"specVersion": "1.1"},
       "input": "frame-0051-in.jsonld",
       "frame": "frame-0051-frame.jsonld",
       "expect": "frame-0051-out.jsonld"

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -425,7 +425,7 @@
       "input": "frame-0010-in.jsonld",
       "frame": "frame-0010-frame.jsonld",
       "expect": "frame-p010-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
     }, {
       "@id": "#tp020",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -434,7 +434,7 @@
       "input": "frame-0020-in.jsonld",
       "frame": "frame-0020-frame.jsonld",
       "expect": "frame-p020-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
     }, {
       "@id": "#tp021",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -443,7 +443,7 @@
       "input": "frame-0021-in.jsonld",
       "frame": "frame-0021-frame.jsonld",
       "expect": "frame-p021-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
     }, {
       "@id": "#tp046",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -452,7 +452,7 @@
       "input": "frame-0046-in.jsonld",
       "frame": "frame-0046-frame.jsonld",
       "expect": "frame-p046-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
     }, {
       "@id": "#tp049",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -461,6 +461,6 @@
       "input": "frame-0049-in.jsonld",
       "frame": "frame-0049-frame.jsonld",
       "expect": "frame-p049-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true}
+      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "1.1"}
     }]
 }

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Framing",

--- a/test-suite/tests/fromRdf-manifest.jsonld
+++ b/test-suite/tests/fromRdf-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Transform RDF to JSON-LD",

--- a/test-suite/tests/remote-doc-manifest.jsonld
+++ b/test-suite/tests/remote-doc-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "description": "Tests appropriate document loading behavior as defined in the API",

--- a/test-suite/tests/toRdf-manifest.jsonld
+++ b/test-suite/tests/toRdf-manifest.jsonld
@@ -1,5 +1,5 @@
 {
-  "@context": "http://json-ld.org/test-suite/context.jsonld",
+  "@context": "https://json-ld.org/test-suite/context.jsonld",
   "@id": "",
   "@type": "mf:Manifest",
   "name": "Transform JSON-LD to RDF",

--- a/test-suite/vocab.html
+++ b/test-suite/vocab.html
@@ -372,7 +372,7 @@ range:
 </dd>
 <dt about='jld:specVersion' property='rdfs:label' typeof='rdf:Property'>spec version</dt>
 <dd about='jld:specVersion'>
-<span property='rdfs:comment'><p>Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are &quot;1.0&quot;, and &quot;1.1&quot;. If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a &quot;1.0&quot; and &quot;1.1&quot; version, for example.</p>
+<span property='rdfs:comment'><p>Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are &quot;json-ld-1.0&quot;, and &quot;json-ld-1.1&quot;. If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a &quot;1.0&quot; and &quot;1.1&quot; version, for example.</p>
 </span>
 <div>
 <strong>

--- a/test-suite/vocab.html
+++ b/test-suite/vocab.html
@@ -370,6 +370,23 @@ range:
 <code property='rdfs:range' resource='xsd:boolean'>xsd:boolean</code>
 </div>
 </dd>
+<dt about='jld:specVersion' property='rdfs:label' typeof='rdf:Property'>spec version</dt>
+<dd about='jld:specVersion'>
+<span property='rdfs:comment'><p>Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are &quot;1.0&quot;, and &quot;1.1&quot;. If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a &quot;1.0&quot; and &quot;1.1&quot; version, for example.</p>
+</span>
+<div>
+<strong>
+domain:
+</strong>
+<code property='rdfs:domain' resource='jld:Option'>jld:Option</code>
+</div>
+<div>
+<strong>
+range:
+</strong>
+<code property='rdfs:range' resource='xsd:string'>xsd:string</code>
+</div>
+</dd>
 <dt about='jld:useRdfType' property='rdfs:label' typeof='rdf:Property'>use RDF types</dt>
 <dd about='jld:useRdfType'>
 <span property='rdfs:comment'><p>If the <em>use rdf type</em> flag is set to <code>true</code>, statements with an <code>rdf:type</code> predicate will not use <code>@type</code>, but will be transformed as a normal property.</p>

--- a/test-suite/vocab.jsonld
+++ b/test-suite/vocab.jsonld
@@ -206,6 +206,14 @@
       "rdfs:range": "xsd:boolean"
     },
     {
+      "@id": "jld:specVersion",
+      "@type": "rdf:Property",
+      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"1.0\", and \"1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
+      "rdfs:domain": "jld:Option",
+      "rdfs:label": "spec version",
+      "rdfs:range": "xsd:string"
+    },
+    {
       "@id": "jld:useDocumentLoader",
       "@type": "rdf:Property",
       "rdfs:comment": "Test runners must implement a callback method with a method signature as defined in [LoadDocumentCallback](http://json-ld.org/spec/latest/json-ld-api/index.html#idl-def-LoadDocumentCallback). Specifying this option requires the test runner to provide this callback to the appropriate API method using the `documentLoader` option.",

--- a/test-suite/vocab.jsonld
+++ b/test-suite/vocab.jsonld
@@ -208,7 +208,7 @@
     {
       "@id": "jld:specVersion",
       "@type": "rdf:Property",
-      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"1.0\", and \"1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
+      "rdfs:comment": "Indicates the JSON-LD version to which the test applies, rather than the specific processing mode. Values are \"json-ld-1.0\", and \"json-ld-1.1\". If not set, the test is presumed to be valid for all versions of JSON-LD. In cases where results differ between spec versions for the same test, the test will have both a \"1.0\" and \"1.1\" version, for example.",
       "rdfs:domain": "jld:Option",
       "rdfs:label": "spec version",
       "rdfs:range": "xsd:string"

--- a/test-suite/vocab.ttl
+++ b/test-suite/vocab.ttl
@@ -282,3 +282,15 @@
     """ ;
   rdfs:domain	 :Option ;
   rdfs:range   xsd:boolean .
+
+:specVersion a rdf:Property ;
+  rdfs:label "spec version";
+  rdfs:comment """
+    Indicates the JSON-LD version to which the test applies, rather than the
+    specific processing mode. Values are "1.0", and "1.1". If not set, the
+    test is presumed to be valid for all versions of JSON-LD. In cases where
+    results differ between spec versions for the same test, the test will have
+    both a "1.0" and "1.1" version, for example.
+  """ ;
+  rdfs:domain	 :Option ;
+  rdfs:range   xsd:string .

--- a/test-suite/vocab.ttl
+++ b/test-suite/vocab.ttl
@@ -287,7 +287,7 @@
   rdfs:label "spec version";
   rdfs:comment """
     Indicates the JSON-LD version to which the test applies, rather than the
-    specific processing mode. Values are "1.0", and "1.1". If not set, the
+    specific processing mode. Values are "json-ld-1.0", and "json-ld-1.1". If not set, the
     test is presumed to be valid for all versions of JSON-LD. In cases where
     results differ between spec versions for the same test, the test will have
     both a "1.0" and "1.1" version, for example.


### PR DESCRIPTION
Update test vocabulary location to be https. Add `specVersion`.

Fixes #489.