### PR TITLE
public key in hex

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -865,7 +865,7 @@
       var signed = null;
       var publicKeyFromPrivateKey;
       try {
-        publicKeyFromPrivateKey = new bitcoreMessage.Bitcore.PrivateKey(privateKey).toPublicKey().toAddress('livenet');
+        publicKeyFromPrivateKey = new bitcoreMessage.Bitcore.PrivateKey(privateKey).toPublicKey();
       } catch (e) {
         promise = Promise.reject(e)
       }


### PR DESCRIPTION
Attempts to fix #523.

Live version at: https://peaceful-inlet-31266.herokuapp.com/playground/

Sample testnet keypair for your testing pleasure:

`cPXLG42L3AyiKukbNdzYecS3JVC71gRhbcZEKUWNYtUXWZDnCpkQ`

`myGEzNpxqbVkyDewZuCzEmnse8jExiH2gQ`

@ChristopherA is this what you had in mind?