### PR TITLE
Don't expand non-string native values to node objects.

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1847,6 +1847,7 @@
 
       <p>If <a>active property</a> has a <a>type mapping</a> in the
         <a>active context</a> set to <code>@id</code> or <code>@vocab</code>,
+        <span class="changed">and the value is a <a>string</a>,</span>
         a <a class="changed">dictionary</a> with a single member <code>@id</code> whose
         value is the result of using the
         <a href="#iri-expansion">IRI Expansion algorithm</a> on <em>value</em>
@@ -1868,18 +1869,22 @@
         an <a>active property</a>, and a <em>value</em> to expand.</p>
 
       <ol class="algorithm">
-        <li>If the <a>active property</a> has a <a>type mapping</a>
-          in <a>active context</a> that is <code>@id</code>, return a new
+        <li></span>If the <a>active property</a> has a <a>type mapping</a>
+          in <a>active context</a> that is <code>@id</code>,
+          <span class="changed">and the <em>value</em> is a <a>string</a>,</span>
+          return a new
           <a class="changed">dictionary</a> containing a single key-value pair where the
           key is <code>@id</code> and the value is the result of using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
           <a>active context</a>, <em>value</em>, and <code>true</code> for
           <em>document relative</em>.</li>
         <li>If <a>active property</a> has a <a>type mapping</a> in
-          <a>active context</a> that is <code>@vocab</code>, return
-          a new <a class="changed">dictionary</a> containing a single key-value pair
-          where the key is <code>@id</code> and the value is the result of
-          using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
+          <a>active context</a> that is <code>@vocab</code>,
+          <span class="changed">and the <em>value</em> is a <a>string</a>,</span>
+          return a new
+          <a class="changed">dictionary</a> containing a single key-value pair where the
+          key is <code>@id</code> and the value is the result of using the
+          <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
           <a>active context</a>, <em>value</em>, <code>true</code> for
           <em>vocab</em>, and <code>true</code> for
           <em>document relative</em>.</li>
@@ -1887,7 +1892,9 @@
           with an <code>@value</code> member whose value is set to
           <em>value</em>.</li>
         <li>If <a>active property</a> has a <a>type mapping</a> in
-          <a>active context</a>, add an <code>@type</code> member to
+          <a>active context</a>,
+          <span class="changed">other than <code>@id</code> or <code>@vocab</code>,</span>
+          add an <code>@type</code> member to
           <em>result</em> and set its value to the value associated with the
           <a>type mapping</a>.</li>
         <li>Otherwise, if <em>value</em> is a <a>string</a>:
@@ -4752,6 +4759,8 @@
       the <a href="#compaction-algorithm">Compaction Algorithm</a> allows
       specific forms of graph objects to be compacted back to a set of <a>node
       objects</a>, or maps of <a>node objects</a>.</li>
+    <li><a href="#value-expansion">Value Expansion</a> will not turn native values
+      into <a>node objects</a>.</li>
   </ul>
 </section>
 
@@ -4760,12 +4769,9 @@
   <p>The following is a list of open issues being worked on for the next release.</p>
   <p class="issue" data-number="333"></p>
   <p class="issue" data-number="357"></p>
-  <p class="issue" data-number="470"></p>
   <p class="issue" data-number="480"></p>
   <p class="issue" data-number="488"></p>
   <p class="issue" data-number="495"></p>
-  <p class="issue" data-number="510"></p>
-  <p class="issue" data-number="538"></p>
   <p class="issue" data-number="548"></p>
 </section>
 

--- a/test-suite/tests/expand-0088-in.jsonld
+++ b/test-suite/tests/expand-0088-in.jsonld
@@ -1,0 +1,10 @@
+{
+  "@context": {
+    "@vocab": "http://example.org/",
+    "@base": "http://example.com/",
+    "coerceId": {"@type": "@id"},
+    "coerceVocab": {"@type": "@vocab"}
+  },
+  "coerceId": ["string", true, false, 0, 1],
+  "coerceVocab": ["string", true, false, 0, 1]
+}

--- a/test-suite/tests/expand-0088-out.jsonld
+++ b/test-suite/tests/expand-0088-out.jsonld
@@ -1,0 +1,18 @@
+[
+ {
+   "http://example.org/coerceId": [
+     {"@id": "http://example.com/string"},
+     {"@value": true},
+     {"@value": false},
+     {"@value": 0},
+     {"@value": 1}
+   ],
+   "http://example.org/coerceVocab": [
+     {"@id": "http://example.org/string"},
+     {"@value": true},
+     {"@value": false},
+     {"@value": 0},
+     {"@value": 1}
+   ]
+ }
+]

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -631,6 +631,13 @@
       "expect": "expand-0087-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
+      "@id": "#t0088",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "Do not expand native values to IRIs",
+      "purpose": "Value Expansion does not expand native values, such as booleans, to a node object",
+      "input": "expand-0088-in.jsonld",
+      "expect": "expand-0088-out.jsonld"
+    }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "adding new term",


### PR DESCRIPTION
Fixes #470.