### PR TITLE
Fix expansion algorithm to not reject a node containing only `@id`

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1872,7 +1872,7 @@
         an <a>active property</a>, and a <em>value</em> to expand.</p>
 
       <ol class="algorithm">
-        <li></span>If the <a>active property</a> has a <a>type mapping</a>
+        <li>If the <a>active property</a> has a <a>type mapping</a>
           in <a>active context</a> that is <code>@id</code>,
           <span class="changed">and the <em>value</em> is a <a>string</a>,</span>
           return a new

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1817,7 +1817,10 @@
               the keys <code>@value</code> or <code>@list</code>, set <em>result</em> to
               <code>null</code>.</li>
             <li>Otherwise, if <em>result</em> is a <a class="changed">dictionary</a> whose only
-              key is <code>@id</code>, set <em>result</em> to <code>null</code>.</li>
+              key is <code>@id</code>, set <em>result</em> to <code>null</code>.
+              <span class="changed">
+                When the <code>frame expansion</code> flag is set, a <a>dictionary</a>
+                containing only the <code>@id</code> key is retained.</span></li>
           </ol>
         </li>
         <li>Return <em>result</em>.</li>

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -1089,13 +1089,18 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   of a set of properties, if neither <code>@id</code>, nor <code>@type</code> are in the frame.</p>
 
 <ol class="algorithm">
-  <li><em>Node</em> matches if it has an <code>@id</code> property
-    including any <a>IRI</a> or <a>blank node</a> in the <code>@id</code>
-    property in <em>frame</em>. Otherwise, if <em>frame</em> has a non-empty <code>@id</code> property
-    which is not an empty <a>dictionary</a>, <em>node</em> does not match.
-    <div class="note">Framing works on <a>map of flattened subjects</a>, and the act of flattening ensures
-      that all subjects have an `@id` property; thus the `"@id": []` pattern would never
-      match any <a>node object</a>.</div></li>
+  <li><em>Node</em> matches if it has an <code>@id</code> property value
+    which is also a value of the <code>@id</code> property in <em>frame</em>.
+    Otherwise, <em>node</em> does not match if <em>frame</em> has a non-empty
+    <code>@id</code> property, other than an empty <a>dictionary</a>.
+    Otherwise, frame must not have a <code>@id</code> property; continue to the next step.
+    <div class="note">Framing works on <a>map of flattened subjects</a>,
+      and the act of flattening ensures that all subjects have an
+      <code>@id</code> property; thus the <code>"@id": []</code> pattern would
+      never match any <a>node object</a>. the <code>"@id": [{}]</code> pattern would
+      match any <a>node object</a> and is equivalent to not specifying a
+      <code>@id</code> property in <em>frame</em> at all</div>
+  </li>
   <li><em>Node</em> matches if frame has no non-<code>keyword</code> properties.</li>
   <li>If <em>requireAll</em> is <strong>true</strong>, <em>node</em> matches if all non-<a>keyword</a> properties (<em>property</em>) in <em>frame</em> match any of the following conditions.
     Or, if <em>requireAll</em> is <strong>false</strong>, if any of the non-<a>keyword</a> properties (<em>property</em>) in <em>frame</em> match any of the following conditions.

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -1089,7 +1089,10 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   of a set of properties, if neither <code>@id</code>, nor <code>@type</code> are in the frame.</p>
 
 <ol class="algorithm">
-  <li><em>Node</em> matches if it has an <code>@id</code> property including any <a>IRI</a> or <a>blank node</a> in the <code>@id</code> property in <em>frame</em>.
+  <li><em>Node</em> matches if it has an <code>@id</code> property
+    including any <a>IRI</a> or <a>blank node</a> in the <code>@id</code>
+    property in <em>frame</em>. Otherwise, if <em>frame</em> has a non-empty <code>@id</code> property
+    which is not an empty <a>dictionary</a>, <em>node</em> does not match.
     <div class="note">Framing works on <a>map of flattened subjects</a>, and the act of flattening ensures
       that all subjects have an `@id` property; thus the `"@id": []` pattern would never
       match any <a>node object</a>.</div></li>


### PR DESCRIPTION
 when framing.

Fix frame matching algorithm to not match a node if frame has a non-empty `@id`, which is not an empty dictionary.
Fixes #532.