### PR TITLE
Update relative IRI definition

### DIFF
--- a/spec/latest/common/terms.html
+++ b/spec/latest/common/terms.html
@@ -252,7 +252,10 @@
     <dt><dfn data-lt="triple|triples|RDF triples">RDF triple</dfn></dt><dd>
       A <a data-cite="RDF11-CONCEPTS#dfn-rdf-triple" class="externalDFN">triple</a> as specified by [[RDF11-CONCEPTS]].</dd>
     <dt><dfn data-lt="relative IRIs">relative IRI</dfn></dt><dd>
-      A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>.</dd>
+      A relative IRI is an <a>IRI</a> that is relative to some other <a>absolute IRI</a>,
+      typically the <a>base IRI</a> of the document. Note that
+      <a>properties</a>, values of <code>@type</code>, and values of <a>terms</a> defined to be <em>vocabulary relative</em>
+      are resolved relative to the <a>vocabulary mapping</a>, not the <a>base IRI</a>.</dd>
     <dt><dfn>set object</dfn></dt><dd>
       A <a>set object</a> is a <a>JSON object</a> that has an <code>@set</code>
       member.</dd>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1867,6 +1867,16 @@
         or an <code>@language</code> member if <em>value</em> is a
         <a>string</a> and there is <a>language mapping</a> associated
         with the <a>active property</a>.</p>
+
+      <p>Note that values interpreted as <a>IRIs</a> fall into two categories:
+        those that are <em>document relative</em>, and those that are
+        <em>vocabulary relative</em>. Properties and values of <code>@type</code>,
+        along with terms marked as <code>"@type": "@vocab"</code>
+        are <em>vocabulary relative</em>, meaning that they need to either be
+        defined <a>terms</a>, a <a>compact IRI</a>,
+        where the <a>prefix</a> is a <a>term</a>,
+        or a string which is turned into an <a>absolute IRI</a> using
+        the <a>vocabulary mapping</a>.</p>
     </section>
 
     <section>

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -401,7 +401,8 @@
         that processing should continue deeper into a JSON data structure.
         This keyword is described in <a class="sectionRef" href="#data-indexing"></a>.</dd>
       <dt><code>@base</code></dt>
-      <dd>Used to set the <a>base IRI</a> against which <a>relative IRIs</a>
+      <dd>Used to set the <a>base IRI</a> against which those <a>relative IRIs</a>
+        interpreted relative to the document,
         are resolved. This keyword is described in <a class="sectionRef" href="#base-iri"></a>.</dd>
       <dt><code>@vocab</code></dt>
       <dd>Used to expand properties and values in <code>@type</code> with a common prefix
@@ -663,8 +664,14 @@
     <em>scheme</em> along with <em>path</em> and optional <em>query</em> and
     <em>fragment</em> segments. A <a>relative IRI</a> is an IRI
     that is relative to some other <a>absolute IRI</a>.
-    In JSON-LD all <a>relative IRIs</a> are resolved
-    relative to the <a>base IRI</a>.</p>
+    In JSON-LD all <a>relative IRIs</a>,
+    are resolved relative to the <a>base IRI</a>.</p>
+
+  <p class="note"><a>Properties</a>, values of <code>@type</code>,
+    and values of <a>properties</a> with a <a>term definition</a>
+    that defines them as being relative to the <a>vocabulary mapping</a>,
+    may have the form of a <a>relative IRI</a>, but are resolved using the
+    <a>vocabulary mapping</a>, and not the <a>base IRI</a>.</p>
 
   <p>A <a>string</a> is interpreted as an <a>IRI</a> when it is the
     value of an <code>@id</code> member:</p>
@@ -929,7 +936,8 @@
 <section class="informative">
   <h2>Base IRI</h2>
 
-  <p>JSON-LD allows <a>IRI</a>s to be specified in a relative form which is
+  <p>JSON-LD allows <a>IRIs</a>,
+    to be specified in a relative form which is
     resolved against the document base according
     <a data-cite="RFC3986#section-5.1">section 5.1 Establishing a Base URI</a>
     of [[RFC3986]]. The <a>base IRI</a> may be explicitly set with a <a>context</a>
@@ -1282,8 +1290,8 @@ the data type to be specified with each piece of data.</p>
   by interpreting it as <a>term</a>. If no matching <a>term</a> is found in the
   <a>active context</a>, it tries to expand it as <a>compact IRI</a> or <a>absolute IRI</a>
   if there's a colon in the value; otherwise, it will expand the value using the
-  <a data-lt="active context">active context's</a> <a>vocabulary mapping</a>, if present, or by interpreting it
-  as <a>relative IRI</a>. Values coerced to <code>@id</code> in contrast are expanded as
+  <a data-lt="active context">active context's</a> <a>vocabulary mapping</a>, if present.
+  Values coerced to <code>@id</code> in contrast are expanded as
   <a>compact IRI</a> or <a>absolute IRI</a> if a colon is present; otherwise, they are interpreted
   as <a>relative IRI</a>.</p>
 
@@ -4462,7 +4470,8 @@ specified. The full <a>IRI</a> for
 
     <p>The value associated with the <code>@type</code> key MUST be a
       <a>term</a>, a <a>compact IRI</a>,
-      an <a>absolute IRI</a>, a <a>relative IRI</a>, or <a>null</a>.</p>
+      an <a>absolute IRI</a>, a string which can be turned
+      into an <a>absolute IRI</a> using the <a>vocabulary mapping</a>, or <a>null</a>.</p>
 
     <p>The value associated with the <code>@language</code> key MUST have the
       <a data-cite="BCP47#section-2.1.1">lexical form</a> described in [[!BCP47]], or be <a>null</a>.</p>


### PR DESCRIPTION
to clarify that it describes only IRIs relative to the document base, not the **vocabulary mapping**.

Add additional explanatory text on relative IRIs to distinguish them from properties, values of `@type`, or values of properties defined to be vocabulary relative.

Fixes #488.