### PR TITLE
Remove an errant _document relative_ flag to compact IRI

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -972,7 +972,6 @@
               <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
               <a>active context</a>, <em>type</em> for <em>value</em>,
               <code>true</code> for <em>vocab</em>,
-              <code>false</code> for <em>document relative</em>,
               <a>local context</a>, and <em>defined</em>. If the expanded <em>type</em> is
               neither <code>@id</code>, nor <code>@vocab</code>, nor an <a>absolute IRI</a>, an
               <a data-link-for="JsonLdErrorCode">invalid type mapping</a>
@@ -993,7 +992,7 @@
               result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>,
               passing <a>active context</a>, the value associated with
               the <code>@reverse</code> key for <em>value</em>, <code>true</code>
-              for <em>vocab</em>, <code>false</code> for <em>document relative</em>,
+              for <em>vocab</em>,
               <a>local context</a>, and <em>defined</em>. If the result
               is neither an <a>absolute IRI</a> nor a <a>blank node identifier</a>,
               i.e., it contains no colon (<code>:</code>), an
@@ -1026,7 +1025,6 @@
               result of using the <a href="#iri-expansion">IRI Expansion algorithm</a>, passing
               <a>active context</a>, the value associated with the <code>@id</code> key for
               <em>value</em>, <code>true</code> for <em>vocab</em>,
-              <code>false</code> for <em>document relative</em>,
               <a>local context</a>, and <em>defined</em>. If the resulting
               <a>IRI mapping</a> is neither a <a>keyword</a>, nor an
               <a>absolute IRI</a>, nor a <a>blank node identifier</a>, an
@@ -2857,8 +2855,7 @@
                   <a href="#iri-compaction">IRI compaction algorithm</a>,
                   passing <a>active context</a>, <a>inverse context</a>,
                   the value associated with the <code>@id</code> key in <em>value</em> for
-                  <em>iri</em>, <code>true</code> for <em>vocab</em>, and
-                  <code>true</code> for <em>document relative</em> has a
+                  <em>iri</em>, and <code>true</code> for <em>vocab</em> has a
                   <a>term definition</a> in the <a>active context</a>
                   with an <a>IRI mapping</a> that equals the value associated
                   with the <code>@id</code> key in <em>value</em>,


### PR DESCRIPTION
and all uses where _document relative_ is false, which is the default value.

Fixes #562.