### PR TITLE
Remove ActivityStreams context from contextMap.

### DIFF
--- a/playground/playground.js
+++ b/playground/playground.js
@@ -46,7 +46,6 @@
   playground.contextMap = {
     // be careful when working with redirectors as as Chrome (not firefox)
     // will drop Accept: application/ld+json after redirecting
-    'http://www.w3.org/ns/activitystreams#': 'http://asjsonld.mybluemix.net'
   };
 
   // map of currently active mapped contexts for user feedback use


### PR DESCRIPTION
That was added before AS2 had a real home for its context.  It has one
now, so this is unnecessary.