### PR TITLE
Update editors/authors for framing to be consistent with API document.

### DIFF
--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -45,29 +45,42 @@
       // editors, add as many as you like
       // only "name" is required
       editors:  [
-          { name: "Manu Sporny", url: "http://manu.sporny.org/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" },
-          { name: "Gregg Kellogg", url: "http://greggkellogg.net/",
-            company: "Kellogg Associates", companyURL: "http://kellogg-assoc.com/" },
-          { name: "Dave Longley", url: "https://digitalbazaar.com/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"},
-          { name: "Markus Lanthaler", url: "http://www.markus-lanthaler.com/",
-            company: "Graz University of Technology", companyURL: "http://www.tugraz.at/" }
+        { name:       "Gregg Kellogg",
+          url:        "http://greggkellogg.net/",
+          company:    "Spec-Ops",
+          companyURL: "https://spec-ops.io/",
+          w3cid:      "44770",
+          note:       "v1.0 and v1.1" }
       ],
 
       // authors, add as many as you like.
       // This is optional, uncomment if you have authors as well as editors.
       // only "name" is required. Same format as editors.
-
       authors:  [
-          { name: "Dave Longley", url: "https://digitalbazaar.com/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/"},
-          { name: "Manu Sporny", url: "https://digitalbazaar.com/",
-            company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/" },
-          { name: "Gregg Kellogg", url: "http://greggkellogg.net/",
-            company: "Kellogg Associates", companyURL: "http://kellogg-assoc.com/" },
-          { name: "Markus Lanthaler", url: "http://www.markus-lanthaler.com/",
-            company: "Graz University of Technology", companyURL: "http://www.tugraz.at/" }
+        { name:       "Dave Longley",
+          url:        "https://digitalbazaar.com/",
+          company:    "Digital Bazaar",
+          companyURL: "https://digitalbazaar.com/",
+          note:       "v1.0" },
+        { name:       "Manu Sporny",
+          url:        "http://manu.sporny.org/",
+          company:    "Digital Bazaar",
+          companyURL: "https://digitalbazaar.com/",
+          note:       "v1.0" },
+        { name:       "Gregg Kellogg",
+          url:        "http://greggkellogg.net/",
+          company:    "Spec-Ops",
+          companyURL: "https://spec-ops.io/",
+          w3cid:      "44770",
+          note:       "v1.0 and v1.1" },
+        { name:       "Markus Lanthaler",
+          url:        "http://www.markus-lanthaler.com/",
+          company:    "Graz University of Technology",
+          companyURL: "http://www.tugraz.at/",
+          note:       "v1.0" },
+        { name:       "Niklas Lindström",
+          url:        "http://neverspace.net/",
+          note:       "v1.0" }
       ],
 
       github:    "https://github.com/json-ld/json-ld.org",


### PR DESCRIPTION
This also relates to #486.

As the Framing document is expected to continue for the long term, this PR makes editors and authors consistent with the API document (other than moving @msporny up in the order of authorship contributions).