### PR TITLE
Fix compaction on scoped contexts based on @type

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2109,8 +2109,8 @@
             <li>Return <em>result</em>.</li>
           </ol>
         </li>
-        <li>Otherwise <em>element</em> is a <a class="changed">dictionary</a>.</li>
-        <li>If <em>element</em> has an <code>@value</code> or <code>@id</code>
+        <li>Otherwise <em>element</em> is a <a class="changed">dictionary</a>.
+          If <em>element</em> has an <code>@value</code> or <code>@id</code>
           member and the result of using the
           <a href="#value-compaction">Value Compaction algorithm</a>,
           passing <a>active context</a>, <a>inverse context</a>,
@@ -2120,6 +2120,28 @@
           <a>active property</a> equals <code>@reverse</code>,
           otherwise to <code>false</code>.</li>
         <li>Initialize <em>result</em> to an empty <a class="changed">dictionary</a>.</li>
+        <li class="changed">If <em>element</em> has a <code>@type</code> member,
+          then for each <em>expanded type</em> of that member:
+          <ol class="algorithm">
+            <li>Set <em>term</em> to the result of
+              of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+              passing <a>active context</a>, <a>inverse context</a>,
+              <em>expanded type</em> for <em>iri</em>, and
+              <code>true</code> for <em>vocab</em>.</li>
+            <li>If the <a>term definition</a> for <em>term</em> has a
+              <a>local context</a>:
+              <ol class="algorithm">
+                <li>Set <a>active context</a> to the result of the
+                  <a href="#context-processing-algorithm">Context Processing algorithm</a>,
+                  passing <a>active context</a> and the value of <em>term</em>'s
+                  <a>local context</a> as <a>local context</a>.</li>
+                <li>Set <a>inverse context</a> using the
+                  <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
+                  using <a>active context</a>.</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
         <li>For each key <em>expanded property</em> and value <em>expanded value</em>
           in <em>element</em>,  ordered lexicographically by <em>expanded property</em>:
           <ol class="algorithm">
@@ -2147,18 +2169,6 @@
                             passing <a>active context</a>, <a>inverse context</a>,
                             <em>expanded type</em> for <em>iri</em>, and
                             <code>true</code> for <em>vocab</em>.</li>
-                          <li class="changed">If the <a>term definition</a> for <em>term</em> has a
-                            <a>local context</a>:
-                            <ol class="algorithm">
-                              <li>Set <a>active context</a> to the result of the
-                                <a href="#context-processing-algorithm">Context Processing algorithm</a>,
-                                passing <a>active context</a> and the value of <em>term</em>'s
-                                <a>local context</a> as <a>local context</a>.</li>
-                              <li>Set <a>inverse context</a> using the
-                                <a href="#inverse-context-creation">Inverse Context Creation algorithm</a>
-                                using <a>active context</a>.</li>
-                            </ol>
-                          </li>
                           <li>Append <em>term</em>, to <em>compacted value</em>.</li>
                         </ol>
                       </li>

--- a/test-suite/tests/compact-c011-context.jsonld
+++ b/test-suite/tests/compact-c011-context.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "id": "@id",
+    "type": "@type",
+    "Foo": {"@context": {"id": null, "type": null}}
+  }
+}

--- a/test-suite/tests/compact-c011-in.jsonld
+++ b/test-suite/tests/compact-c011-in.jsonld
@@ -1,0 +1,11 @@
+[
+  {
+    "@id": "http://example.org/id",
+    "@type": ["http://example/type"],
+    "http://example/a": [{
+      "@id": "http://example.org/Foo",
+      "@type": ["http://example/Foo"],
+      "http://example/bar": [{"@id": "http://example.org/baz"}]
+    }]
+  }
+]

--- a/test-suite/tests/compact-c011-out.jsonld
+++ b/test-suite/tests/compact-c011-out.jsonld
@@ -1,0 +1,15 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "id": "@id",
+    "type": "@type",
+    "Foo": {"@context": {"id": null, "type": null}}
+  },
+  "id": "http://example.org/id",
+  "type": "http://example/type",
+  "a": {
+    "@id": "http://example.org/Foo",
+    "@type": "Foo",
+    "bar": {"@id": "http://example.org/baz"}
+  }
+}

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -834,6 +834,15 @@
       "context": "compact-c010-context.jsonld",
       "expect": "compact-c010-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc011",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "applies context for all values",
+      "purpose": "scoped context on @type",
+      "input": "compact-c011-in.jsonld",
+      "context": "compact-c011-context.jsonld",
+      "expect": "compact-c011-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],


### PR DESCRIPTION
Look at term contexts from `@type` before starting to compact object members. Adds test.

Fixes #546.