### PR TITLE
Remove duplicate option property.

### DIFF
--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -424,7 +424,6 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Merge one graph and deep preserve another",
       "purpose": "@graph used within a property value frames embedded values from a named graph.",
-      "option": {"specVersion": "json-ld-1.1"},
       "input": "frame-0049-in.jsonld",
       "frame": "frame-0049-frame.jsonld",
       "expect": "frame-0049-out.jsonld",


### PR DESCRIPTION
I assume this was the one to remove.  But maybe the prune flag isn't needed.