### PR TITLE
When compacting `@graph`, where a container type can't be used

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2447,8 +2447,7 @@
                           passing <a>active context</a>, <code>@graph</code> as
                           <em>iri</em>, and <code>true</code> for
                           <em>vocab</em> using the original <em>compacted
-                          item</em> as a value contained within an
-                          <a>array</a>.</li>
+                          item</em> as a value.</li>
                         <li>If expanded item contains the key <code>@id</code>,
                           add the key resulting from calling the <a
                           href="#iri-compaction">IRI Compaction algorithm</a>

--- a/test-suite/tests/compact-0080-out.jsonld
+++ b/test-suite/tests/compact-0080-out.jsonld
@@ -5,10 +5,6 @@
   },
   "input": {
     "@id": "http://example.org/gid",
-    "@graph": [
-      {
-        "value": "x"
-      }
-    ]
+    "@graph": {"value": "x"}
   }
 }

--- a/test-suite/tests/compact-0083-out.jsonld
+++ b/test-suite/tests/compact-0083-out.jsonld
@@ -6,6 +6,6 @@
   "input": {
     "@id": "http://example.org/id",
     "@index": "g1",
-    "@graph": [{"value": "x"}]
+    "@graph": {"value": "x"}
   }
 }

--- a/test-suite/tests/frame-0047-out.jsonld
+++ b/test-suite/tests/frame-0047-out.jsonld
@@ -5,10 +5,10 @@
     "@type": "Class",
     "preserve": {
       "@id": "urn:gr-1",
-      "@graph": [{
+      "@graph": {
         "@id": "urn:id-2",
         "term": "data"
-      }]
+      }
     }
   }]
 }

--- a/test-suite/tests/frame-0048-out.jsonld
+++ b/test-suite/tests/frame-0048-out.jsonld
@@ -9,10 +9,10 @@
     },
     "preserve": {
       "@id": "urn:graph-1",
-      "@graph": [{
+      "@graph": {
         "@id": "urn:id-3",
         "term": "bar"
-      }]
+      }
     }
   }]
 }

--- a/test-suite/tests/frame-0049-out.jsonld
+++ b/test-suite/tests/frame-0049-out.jsonld
@@ -11,10 +11,10 @@
       "@id": "_:b0",
       "deep": {
         "@id": "_:b1",
-        "@graph": [{
+        "@graph": {
           "@id": "urn:id-3",
           "term": "bar"
-        }]
+        }
       }
     }
   }]

--- a/test-suite/tests/frame-0050-out.jsonld
+++ b/test-suite/tests/frame-0050-out.jsonld
@@ -7,20 +7,18 @@
       "name": "Library",
       "contains": {
         "@id": "http://example.org/graphs/books",
-        "@graph": [
-          {
-            "@id": "http://example.org/library/the-republic",
-            "@type": "Book",
-            "creator": "Plato",
-            "title": "The Republic",
-            "contains": {
-              "@id": "http://example.org/library/the-republic#introduction",
-              "@type": "Chapter",
-              "description": "An introductory chapter on The Republic.",
-              "title": "The Introduction"
-            }
+        "@graph": {
+          "@id": "http://example.org/library/the-republic",
+          "@type": "Book",
+          "creator": "Plato",
+          "title": "The Republic",
+          "contains": {
+            "@id": "http://example.org/library/the-republic#introduction",
+            "@type": "Chapter",
+            "description": "An introductory chapter on The Republic.",
+            "title": "The Introduction"
           }
-        ]
+        }
       }
     }
   ]

--- a/test-suite/tests/frame-p049-out.jsonld
+++ b/test-suite/tests/frame-p049-out.jsonld
@@ -9,10 +9,10 @@
     },
     "preserve": {
       "deep": {
-        "@graph": [{
+        "@graph": {
           "@id": "urn:id-3",
           "term": "bar"
-        }]
+        }
       }
     }
   }]


### PR DESCRIPTION
don't force value into an array.