### PR TITLE
Clarify that term definitions can replace previous scoped contexts.

### DIFF
--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -2317,8 +2317,8 @@ specified. The full <a>IRI</a> for
     value">values</a> of properties defined using that <a>term</a>. This allows
     values to use <a>term definitions</a>, <a>base IRI</a>,
     <a>vocabulary mapping</a> or <a>default language</a> which is different from the
-    <a>node object</a> they are contained in, in as if the
-    <a>context</a> were specified within the value itself.</p>
+    <a>node object</a> they are contained in, as if the
+    <a>context</a> was specified within the value itself.</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
        title="Defining an @context within a term definition">

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -1516,9 +1516,9 @@ the data type to be specified with each piece of data.</p>
   be achieved using JSON-LD. </p>
 
   <p>In general, contexts may be used at any time a
-    <a>JSON object</a> is defined. The only time that one cannot
-    express a context is inside a context definition itself. For example, a
-    <a>JSON-LD document</a> may use more than one context at different
+    <a>JSON object</a> is defined.
+    The only time that one cannot express a context is as a direct child of another context definition.
+    For example, a <a>JSON-LD document</a> may use more than one context at different
     points in a document:</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
@@ -2317,7 +2317,7 @@ specified. The full <a>IRI</a> for
     value">values</a> of properties defined using that <a>term</a>. This allows
     values to use <a>term definitions</a>, <a>base IRI</a>,
     <a>vocabulary mapping</a> or <a>default language</a> which is different from the
-    <a>node object</a> they are contained in, in exactly the same was as if the
+    <a>node object</a> they are contained in, in as if the
     <a>context</a> were specified within the value itself.</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
@@ -2388,6 +2388,14 @@ specified. The full <a>IRI</a> for
   </pre>
 
   <p>Scoping on <code>@type</code> is useful when common properties are used to relate things of different types, where the vocabularies in use within different entities calls for different context scoping. For example, `hasPart`/`partOf` may be common terms used in a document, but mean different things depending on the context.</p>
+
+  <p class="note">If a <a>term</a> defines a scoped context, and then that term
+    is later re-defined, the association of the context defined in the earlier
+    <a>expanded term definition</a> is lost
+    within the scope of that re-definition. This is consistent with
+    <a>term definitions</a> of a term overriding previous term definitions from
+    earlier less deeply nested definitions, as discussed in
+    <a href="#advanced-context-usage" class="sectionRef"></a>.</p>
 
   <p class="note">Scoped Contexts are a new feature in JSON-LD 1.1, requiring
     <a>processing mode</a> set to <code>json-ld-1.1</code>.</p>


### PR DESCRIPTION
Fixes #596.