### PR TITLE
Add `@graph` compactArrays tests.

### DIFF
--- a/test-suite/tests/compact-0091-in.jsonld
+++ b/test-suite/tests/compact-0091-in.jsonld
@@ -1,12 +1,10 @@
 {
   "@context": {
     "@version": 1.1,
-    "input": {"@id": "foo:input", "@container": ["@graph", "@set"]},
+    "input": {"@id": "foo:input", "@container": "@graph"},
     "value": "foo:value"
   },
-  "input": [{
+  "input": {
     "value": "x"
-  }, {
-    "value": "y"
-  }]
+  }
 }

--- a/test-suite/tests/compact-0092-context.jsonld
+++ b/test-suite/tests/compact-0092-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "input": "foo:input",
+    "value": "foo:value"
+  }
+}

--- a/test-suite/tests/compact-0092-in.jsonld
+++ b/test-suite/tests/compact-0092-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "input": {"@id": "foo:input", "@container": ["@graph", "@set"]},
+    "value": "foo:value"
+  },
+  "input": [{
+    "value": "x"
+  }, {
+    "value": "y"
+  }]
+}

--- a/test-suite/tests/compact-0092-out.jsonld
+++ b/test-suite/tests/compact-0092-out.jsonld
@@ -4,11 +4,11 @@
     "input": "foo:input",
     "value": "foo:value"
   },
-  "@graph": [{
-    "input": [{
-      "@graph": [{
-        "value": ["x"]
-      }]
+  "input": {
+    "@graph": [{
+      "value": "x"
+    }, {
+      "value": "y"
     }]
-  }]
+  }
 }

--- a/test-suite/tests/compact-0093-context.jsonld
+++ b/test-suite/tests/compact-0093-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "input": "foo:input",
+    "value": "foo:value"
+  }
+}

--- a/test-suite/tests/compact-0093-in.jsonld
+++ b/test-suite/tests/compact-0093-in.jsonld
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "input": {"@id": "foo:input", "@container": ["@graph", "@set"]},
+    "value": "foo:value"
+  },
+  "input": [{
+    "value": "x"
+  }, {
+    "value": "y"
+  }]
+}

--- a/test-suite/tests/compact-0093-out.jsonld
+++ b/test-suite/tests/compact-0093-out.jsonld
@@ -8,6 +8,8 @@
     "input": [{
       "@graph": [{
         "value": ["x"]
+      }, {
+        "value": ["y"]
       }]
     }]
   }]

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -756,12 +756,30 @@
     }, {
       "@id": "#t0091",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
-      "name": "Compact input with [@graph, @set] container to output without [@graph, @set] container",
-      "purpose": "Ensure @graph appears properly in output",
+      "name": "Compact input with @graph container to output without @graph container with compactArrays unset",
+      "purpose": "Ensure @graph appears properly in output with compactArrays unset",
       "input": "compact-0091-in.jsonld",
       "context": "compact-0091-context.jsonld",
       "expect": "compact-0091-out.jsonld",
+      "option": {"compactArrays": false, "processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0092",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact input with [@graph, @set] container to output without [@graph, @set] container",
+      "purpose": "Ensure @graph appears properly in output",
+      "input": "compact-0092-in.jsonld",
+      "context": "compact-0092-context.jsonld",
+      "expect": "compact-0092-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#t0093",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "Compact input with [@graph, @set] container to output without [@graph, @set] container with compactArrays unset",
+      "purpose": "Ensure @graph appears properly in output with compactArrays unset",
+      "input": "compact-0093-in.jsonld",
+      "context": "compact-0093-context.jsonld",
+      "expect": "compact-0093-out.jsonld",
+      "option": {"compactArrays": false, "processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tc001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],


### PR DESCRIPTION
Compact tests changes:
- Copy 0090 to 0091 and use compactArrays=false.
- Move 0091 to 0092.
- Copy 0091 to 0093 and use compactArrays=false.

This is related to a jsonld.js and pyld fix that was flattening single items in an array without checking compactArrays flag.  Please verify the output.