### PR TITLE
Fix set object description

### DIFF
--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -4596,7 +4596,7 @@ specified. The full <a>IRI</a> for
 
     <p>A <a>set object</a> MUST be a <a>JSON object</a> that contains no
       keys that expand to an <a>absolute IRI</a> or <a>keyword</a> other
-      than <code>@list</code>, <code>@context</code>, and <code>@index</code>.
+      than <code>@set</code>, <code>@context</code>, and <code>@index</code>.
       Please note that the <code>@index</code> key will be ignored when being processed.</p>
 
     <p>In both cases, the value associated with the keys <code>@list</code> and <code>@set</code>


### PR DESCRIPTION
A set object has `@set`, not `@list` as a component.

Fixes #615.