### PR TITLE
 Add text to end of compaction algorithm for empty array

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2571,13 +2571,15 @@
         <li>Return <var>result</var>.</li>
       </ol>
 
-      <p>If, after the algorithm outlined above is run, the result <var>result</var>
-        is an <a>array</a>, replace it with a new
+      <p>If, after the algorithm outlined above is run, <var>result</var>
+        <span class="changed">is an empty <a>array</a>, replace it with a new <a>dictionary</a></span>.
+        Otherwise, if <var>result</var> is an <a>array</a>, replace it with a new
         <a class="changed">dictionary</a> with a single member whose key is the result
         of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
         passing <var>active context</var>, <var>inverse context</var>, and
         <code>@graph</code> as <var>var</var> and whose value is the <a>array</a>
-        <var>result</var>. Finally, if a non-empty <var>context</var> has been passed,
+        <var>result</var>.</p>
+      <p>Finally, if a non-empty <var>context</var> has been passed,
         add an <code>@context</code> member to <var>result</var> and set its value
         to the passed <var>context</var>.</p>
     </section>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -4921,7 +4921,6 @@
   <p class="issue" data-number="530"></p>
   <p class="issue" data-number="571"></p>
   <p class="issue" data-number="607"></p>
-  <p class="issue" data-number="608"></p>
   <p class="issue" data-number="616"></p>
 </section>
 


### PR DESCRIPTION
Add text to end of compaction algorithm for case when result is an empty array.

Fixes #608.

cc/@cwebber