### PR TITLE
Describe that scoped contexts on `@type` are ordered

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -1490,13 +1490,12 @@
           passing <var>active context</var> and the value of the
           <code>@context</code> key as <var>local context</var>.</li>
         <li class="changed">For each <var>key</var>/<var>value</var> pair in <var>element</var>
-          ordered lexicographically by <var>key</var> where <var>key</var> expands
-          to <code>@type</code> using the
+          where <var>key</var> expands to <code>@type</code> using the
           <a href="#iri-expansion">IRI Expansion algorithm</a>,
           passing <var>active context</var>, <var>key</var> for
           <var>value</var>, and <code>true</code> for <var>vocab</var>:
           <ol>
-            <li>For each <var>term</var> which is a value of <var>value</var>,
+            <li>For each <var>term</var> which is a value of <var>value</var> ordered lexicographically,
               if <var>term</var>'s <a>term definition</a> in <var>active context</var>
               has a <a>local context</a>, set <var>active context</var> to the result
               to the result of the
@@ -2149,13 +2148,14 @@
           otherwise to <code>false</code>.</li>
         <li>Initialize <var>result</var> to an empty <a class="changed">dictionary</a>.</li>
         <li class="changed">If <var>element</var> has a <code>@type</code> member,
-          then for each <var>expanded type</var> of that member:
+          create a new array <var>compacted types</var> initialized
+          by transforming each <var>expanded type</var> of that member
+          into it's compacted form using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
+          passing <var>active context</var>, <var>inverse context</var>,
+          <var>expanded type</var> for <var>var</var>, and
+          <code>true</code> for <var>vocab</var>. Then, for each <var>term</var>
+          in <var>compacted types</var> ordered lexicographically:
           <ol>
-            <li>Set <var>term</var> to the result of
-              of using the <a href="#iri-compaction">IRI Compaction algorithm</a>,
-              passing <var>active context</var>, <var>inverse context</var>,
-              <var>expanded type</var> for <var>var</var>, and
-              <code>true</code> for <var>vocab</var>.</li>
             <li>If the <a>term definition</a> for <var>term</var> has a
               <a>local context</a>:
               <ol>
@@ -2171,7 +2171,7 @@
           </ol>
         </li>
         <li>For each key <var>expanded property</var> and value <var>expanded value</var>
-          in <var>element</var>,  ordered lexicographically by <var>expanded property</var>:
+          in <var>element</var>, ordered lexicographically by <var>expanded property</var>:
           <ol>
             <li>If <var>expanded property</var> is <code>@id</code> or
               <code>@type</code>:

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -2481,6 +2481,10 @@ specified. The full <a>IRI</a> for
 
   <p>Scoping on <code>@type</code> is useful when common properties are used to relate things of different types, where the vocabularies in use within different entities calls for different context scoping. For example, `hasPart`/`partOf` may be common terms used in a document, but mean different things depending on the context.</p>
 
+  <p class="note">The values of <code>@type</code> are unordered, so if multiple
+    types are listed, the order that scoped contexts are applied is based on
+    lexicographical ordering.</p>
+
   <p class="note">If a <a>term</a> defines a scoped context, and then that term
     is later re-defined, the association of the context defined in the earlier
     <a>expanded term definition</a> is lost
@@ -5094,7 +5098,6 @@ specified. The full <a>IRI</a> for
   <p>The following is a list of open issues being worked on for the next release.</p>
   <p class="issue" data-number="333"></p>
   <p class="issue" data-number="547"></p>
-  <p class="issue" data-number="564"></p>
   <p class="issue" data-number="584"></p>
   <p class="issue" data-number="595"></p>
   <p class="issue" data-number="598"></p>

--- a/test-suite/tests/compact-c012-context.jsonld
+++ b/test-suite/tests/compact-c012-context.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "t1": {"@context": {"foo": {"@id": "http://example.com/foo"}}},
+    "t2": {"@context": {"foo": {"@id": "http://example.org/foo", "@type": "@id"}}}
+  }
+}

--- a/test-suite/tests/compact-c012-in.jsonld
+++ b/test-suite/tests/compact-c012-in.jsonld
@@ -1,0 +1,6 @@
+[{
+  "@type": ["http://example/t2", "http://example/t1"],
+  "http://example.org/foo": [
+    {"@id": "urn:bar"}
+  ]
+}]

--- a/test-suite/tests/compact-c012-out.jsonld
+++ b/test-suite/tests/compact-c012-out.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "t1": {"@context": {"foo": {"@id": "http://example.com/foo"}}},
+    "t2": {"@context": {"foo": {"@id": "http://example.org/foo", "@type": "@id"}}}
+  },
+  "@type": ["t2", "t1"],
+  "foo": "urn:bar"
+}

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -896,6 +896,15 @@
       "context": "compact-c011-context.jsonld",
       "expect": "compact-c011-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc012",
+      "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
+      "name": "orders @type terms when applying scoped contexts",
+      "purpose": "scoped context on @type",
+      "input": "compact-c012-in.jsonld",
+      "context": "compact-c012-context.jsonld",
+      "expect": "compact-c012-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],

--- a/test-suite/tests/expand-c011-in.jsonld
+++ b/test-suite/tests/expand-c011-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "t1": {"@context": {"foo": {"@id": "http://example.com/foo"}}},
+    "t2": {"@context": {"foo": {"@id": "http://example.org/foo", "@type": "@id"}}}
+  },
+  "@type": ["t2", "t1"],
+  "foo": "urn:bar"
+}

--- a/test-suite/tests/expand-c011-out.jsonld
+++ b/test-suite/tests/expand-c011-out.jsonld
@@ -1,0 +1,6 @@
+[{
+  "@type": ["http://example/t2", "http://example/t1"],
+  "http://example.org/foo": [
+    {"@id": "urn:bar"}
+  ]
+}]

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -754,6 +754,14 @@
       "input": "expand-c010-in.jsonld",
       "expect": "expand-c010-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tc011",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "orders @type terms when applying scoped contexts",
+      "purpose": "scoped context on @type",
+      "input": "expand-c011-in.jsonld",
+      "expect": "expand-c011-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
    }, {
       "@id": "#tm001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],


### PR DESCRIPTION
lexicographicall…y by their compacted value. When compacting, first turn types into their compacted form, and then process by lexicographical ordering. When expanding, simply order the existing values.

Fixes #616