### PR TITLE
Add missing text to compaction algorithm

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2382,7 +2382,7 @@
                           <a href="#iri-compaction">IRI Compaction algorithm</a>,
                           passing <var>active context</var>, <var>inverse context</var>,
                           <code>@list</code> for <var>var</var>, and <var>compacted item</var>
-                          for <var>value</var>.</li>
+                          for <var>value</var> and the value is the original <var>compacted item</var>.</li>
                         <li>If <var>expanded item</var> contains the key
                           <code>@index</code>, then add a key-value pair
                           to <var>compacted item</var> where the key is the
@@ -4921,8 +4921,6 @@
   <p class="issue" data-number="512"></p>
   <p class="issue" data-number="530"></p>
   <p class="issue" data-number="571"></p>
-  <p class="issue" data-number="607"></p>
-  <p class="issue" data-number="616"></p>
 </section>
 
 <section class="appendix informative">


### PR DESCRIPTION
Add missing text to compaction algorithm when a list object is set as the value of a term where the container does not have `@list`.

Fixes #607.