### PR TITLE
Limit the use of `@none` in language and index maps to 1.1 only

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -2944,11 +2944,11 @@
               be the last <a>container mapping</a> value to be checked as it
               is the most generic.</li>
             <li class="changed">
-              If value does not contain the key <code>@index</code>, append
+              If <p>processing mode</p> is <code>json-ld-1.1</code> and value does not contain the key <code>@index</code>, append
               <code>@index</code> and <code>@index@set</code> to <var>containers</var>.
             </li>
             <li class="changed">
-              If value contains only the key <code>@value</code>, append
+              If <p>processing mode</p> is <code>json-ld-1.1</code> and value contains only the key <code>@value</code>, append
               <code>@language</code> and <code>@language@set</code> to <var>containers</var>.
             </li>
             <li>If <var>type/language value</var> is <code>null</code>, set it to
@@ -4870,9 +4870,9 @@
       within the enclosing <a>node object</a> directly.</li>
     <li><code>@container</code> values within an <a>expanded term definition</a> may now
       include <code>@id</code> and <code>@type</code>, corresponding to <a>id maps</a> and <a>type maps</a>.</li>
-    <li>A <a>language map</a> may legitimately have a <code>null</code> value, but
-      the algorithm only allowed <a>string</a> values. This has been updated
-      to allow (and ignore) <code>null</code> values.</li>
+    <li>Both <a>language maps</a> and <a>index maps</a> may legitimately have an <code>@none</code> value, but
+      JSON-LD 1.0 only allowed <a>string</a> values. This has been updated
+      to allow (and ignore) <code>@none</code> values.</li>
     <li>The JSON syntax has been abstracted into an <a>internal representation</a>
       to allow for other serialization formats that are functionally equivalent
       to JSON.</li>

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -3074,7 +3074,8 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p class="changed">The special index <code>@none</code> is used for indexing
+  <p class="changed">If the <a>processing mode</a> is set to <code>json-ld-1.1</code>,
+    the special index <code>@none</code> is used for indexing
     data which does not have an associated index, which is useful to maintain
     a normalized representation.</p>
 
@@ -3268,7 +3269,8 @@ specified. The full <a>IRI</a> for
   <p>As with <a>index maps</a>, when used with <code>@graph</code>, a container may also
     include <code>@set</code> to ensure that key values are always contained in an array.</p>
 
-  <p class="changed">The special index <code>@none</code> is used for indexing
+  <p class="changed">If the <a>processing mode</a> is set to <code>json-ld-1.1</code>,
+    the special index <code>@none</code> is used for indexing
     graphs which does not have an <code>@index</code> key, which is useful to maintain
     a normalized representation. <span class="note">Note, however, that
       compacting a document where multiple unidentified named graphs are
@@ -3405,7 +3407,8 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p class="changed">The special index <code>@none</code> is used for indexing
+  <p class="changed">If the <a>processing mode</a> is set to <code>json-ld-1.1</code>,
+    the special index <code>@none</code> is used for indexing
     data which does not have a language, which is useful to maintain
     a normalized representation.</p>
 
@@ -3521,7 +3524,7 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p class="changed">The special index <code>@none</code> is used for indexing
+  <p>The special index <code>@none</code> is used for indexing
     <a>node objects</a> which do not have an <code>@id</code>, which is useful to maintain
     a normalized representation. The <code>@none</code> index may also be
     a term which expands to <code>@none</code>, such as the term <em>none</em>
@@ -3869,7 +3872,7 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p class="changed">The special index <code>@none</code> is used for indexing
+  <p>The special index <code>@none</code> is used for indexing
     <a>node objects</a> which do not have an <code>@type</code>, which is useful to maintain
     a normalized representation. The <code>@none</code> index may also be
     a term which expands to <code>@none</code>, such as the term <em>none</em>
@@ -5065,7 +5068,10 @@ specified. The full <a>IRI</a> for
     <li>The JSON syntax has been abstracted into an <a>internal representation</a>
       to allow for other serializations that are functionally equivalent
       to JSON.</li>
-    <li>Added <a href="#language-indexing" class="sectionRef"></a>.</li>
+    <li>Added <a href="#node-identifier-indexing" class="sectionRef"></a> and <a href="#node-type-indexing" class="sectionRef"></a>.</li>
+    <li>Both <a>language maps</a> and <a>index maps</a> may legitimately have an <code>@none</code> value, but
+      JSON-LD 1.0 only allowed <a>string</a> values. This has been updated
+      to allow (and ignore) <code>@null</code> values.</li>
     <li>The value for <code>@container</code> in an <a>expanded term definition</a>
       can also be an <a>array</a> containing any appropriate container
       keyword along with <code>@set</code> (other than <code>@list</code>).


### PR DESCRIPTION
this affects only the term selection algorithm in _IRI Compaction_.

Fixes #571.