### PR TITLE
Remove the `pruneBlankNodeIdentifiers` option for framing

### DIFF
--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -372,7 +372,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     -->
     </pre>
 
-    <p>If <a>processing mode</a> is <code>json-ld-1.1</code> or greater, or the <a>omit graph flag</a> is <code>true</code>,
+    <p>If <a>processing mode</a> is <code>json-ld-1.1</code>, or the <a>omit graph flag</a> is <code>true</code>,
       the top-level <code>@graph</code> member may be omitted.</p>
     <pre class="example nohighlight" data-transform="updateExample"
          title="Framed library objects with omitGraph set to false">
@@ -1109,7 +1109,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
   </li>
 </ol>
 
-<p class="changed">If the <a data-link-for="JsonLdOptions">pruneBlankNodeIdentifiers</a> is <code>true</code>,
+<p class="changed">If the <a>processing mode</a> is <code>json-ld-1.1</code>,
   remove the <code>@id</code> member of each <a>node object</a> where the
   member value is a <a>blank node identifier</a> which appears only once
   in any property value within <var>result</var>.</p>
@@ -1398,7 +1398,6 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         boolean omitGraph;
         boolean requireAll  = false;
         boolean frameDefault  = false;
-        boolean pruneBlankNodeIdentifiers = true;
       };
 
       enum JsonLdEmbed {
@@ -1435,9 +1434,6 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
         <a href="#framing-algorithm">Framing Algorithm</a>.</dd>
       <dt><dfn data-dfn-for="JsonLdOptions">frameDefault</dfn></dt>
       <dd>Instead of framing a <var>merged graph</var>, frame only the <a>default graph</a>.</dd>
-      <dt><dfn data-dfn-for="JsonLdOptions">pruneBlankNodeIdentifiers</dfn></dt>
-      <dd>Removes <code>@id</code> from <a>node objects</a> where the value
-        is a <a>blank node identifier</a> used only once within the document.</dd>
     </dl>
 
     <p><dfn>JsonLdEmbed</dfn> enumerates the values of the <a data-link-for="JsonLdOptions">embed</a> option:</p>
@@ -1556,11 +1552,9 @@ becomes a W3C Recommendation.</p>
       object.</li>
     <li>Frames can use one or more values for <code>@id</code> to allow for matching
       specific objects in a frame.</li>
-    <li>There is a new API option <a data-link-for="JsonLdOptions">pruneBlankNodeIdentifiers</a>
-      defaulting to <code>true</code>, which causes the
-      <a href="#framing-algorithm">Framing Algorithm</a> to remove
+    <li>If <a>processing mode</a> is <code>json-ld-1.1</code>,
       <code>@id</code> members who's value is a <a>blank node identifier</a>
-      used only for that <code>@id</code>.</li>
+      used only for that <code>@id</code> are removed.</li>
     <li>The JSON syntax has been abstracted into an <a>internal representation</a>
       to allow for other serialization formats that are functionally equivalent
       to JSON.</li>

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -441,7 +441,7 @@
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "Compacting values of @preserve",
       "purpose": "When compacting the value of a property using @preserve, use the term definition for term to properly compact the value of @preserve.",
-      "option": {"specVersion": "json-ld-1.1"},
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.1"},
       "input": "frame-0051-in.jsonld",
       "frame": "frame-0051-frame.jsonld",
       "expect": "frame-0051-out.jsonld"
@@ -462,7 +462,7 @@
       "input": "frame-0010-in.jsonld",
       "frame": "frame-0010-frame.jsonld",
       "expect": "frame-p010-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp020",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -471,7 +471,7 @@
       "input": "frame-0020-in.jsonld",
       "frame": "frame-0020-frame.jsonld",
       "expect": "frame-p020-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp021",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -480,7 +480,7 @@
       "input": "frame-0021-in.jsonld",
       "frame": "frame-0021-frame.jsonld",
       "expect": "frame-p021-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp046",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -489,7 +489,7 @@
       "input": "frame-0046-in.jsonld",
       "frame": "frame-0046-frame.jsonld",
       "expect": "frame-p046-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }, {
       "@id": "#tp049",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -498,7 +498,7 @@
       "input": "frame-0049-in.jsonld",
       "frame": "frame-0049-frame.jsonld",
       "expect": "frame-p049-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": true, "specVersion": "json-ld-1.1"}
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }
   ]
 }


### PR DESCRIPTION
and make it dependent on **processing mode**.

Fixes #627.