### PR TITLE
Relax to allow `@version` to be set in any context

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -954,8 +954,6 @@
                   error has been detected and processing is aborted.</li>
               </ol>
             </li>
-            <li class="changed">Set <a>processing mode</a>,
-              to <code>json-ld-1.0</code>, if not already set.</li>
             <li>Create a <a class="changed">dictionary</a> <var>defined</var> to use to keep
               track of whether or not a <a>term</a> has already been defined
               or currently being defined during recursion.</li>
@@ -1040,10 +1038,12 @@
           key <var>term</var> to <code>true</code>, and return.</li>
         <li>Otherwise, if <var>value</var> is a <a>string</a>, convert it
           to a <a class="changed">dictionary</a> consisting of a single member whose
-          key is <code>@id</code> and whose value is <var>value</var>.</li>
+          key is <code>@id</code> and whose value is <var>value</var>.
+          <span class="changed">Set <var>simple term</var> to <code>true</code></span>.</li>
         <li>Otherwise, <var>value</var> must be a <a class="changed">dictionary</a>, if not, an
           <a data-link-for="JsonLdErrorCode">invalid term definition</a>
-          error has been detected and processing is aborted.</li>
+          error has been detected and processing is aborted.
+          <span class="changed">Set <var>simple term</var> to <code>false</code></span>.</li>
         <li>Create a new <a>term definition</a>, <var>definition</var>.</li>
         <li>If <var>value</var> contains the key <code>@type</code>:
           <ol>
@@ -1116,14 +1116,10 @@
               <a data-link-for="JsonLdErrorCode">invalid keyword alias</a>
               error has been detected and processing is aborted.</li>
             <li class="changed">If <var>term</var> does not contain a colon (<code>:</code>),
-              and if <a>processing mode</a> is <code>json-ld-1.0</code>, and the,
+              <span class="changed"><var>simple term</var> is <code>true</code></span>, and the,
               <a>IRI mapping</a> of <var>definition</var> ends with a URI
               <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
-              set the <a>prefix flag</a> in <var>definition</var> to <code>true</code>.
-              If <a>processing mode</a> is not <code>json-ld-1.0</code>, and the <a>IRI mapping</a> ends with a URI
-              <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
-              set the <a>prefix flag</a> in <var>definition</var> to <code>true</code>, only if
-              <var>value</var> was originally a <a>string</a>.</li>
+              set the <a>prefix flag</a> in <var>definition</var> to <code>true</code>.</li>
           </ol>
         </li>
         <li>

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -1196,7 +1196,7 @@
     URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character (e.g, <code>/</code>,
     <code>#</code> and others, see [[!RFC3986]]).
     <span class="note">The previous specification allows any term to be chosen as
-      a compact IRI prefix, which lead to a poor experience.</span></p>
+      a compact IRI prefix, which led to a poor experience.</span></p>
 
   <p class="changed">In JSON-LD 1.1, terms may be chosen as <a>compact IRI</a> prefixes
     when compacting only if

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -972,7 +972,7 @@
   </pre>
 
   <p>The first <code>context</code> encountered when processing a
-    document determines the <code>processing mode</code>,
+    document which contains <code>@version</code> determines the <code>processing mode</code>,
     unless it is defined explicitly through an API option.</p>
 
   <p class="note">Setting the <a>processing mode</a> explicitly
@@ -1191,10 +1191,18 @@
   -->
   </pre>
 
-  <p class="changed">In JSON-LD 1.0, terms will be used as <a>compact IRI</a> prefixes when
-  compacting only if they map to a value that ends with a URI <a
-  data-cite="RFC3986#section-2.2">gen-delim</a> character (e.g, <code>/</code>,
-  <code>#</code> and others, see [[!RFC3986]]).</p>
+  <p class="changed">In JSON-LD 1.0, terms may be chosen as <a>compact IRI</a> prefixes when
+    compacting only if a <a>simple term definition</a> is used where the value ends with a
+    URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character (e.g, <code>/</code>,
+    <code>#</code> and others, see [[!RFC3986]]).
+    <span class="note">The previous specification allows any term to be chosen as
+      a compact IRI prefix, which lead to a poor experience.</span></p>
+
+  <p class="changed">In JSON-LD 1.1, terms may be chosen as <a>compact IRI</a> prefixes
+    when compacting only if
+    a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
+    or if their <a>expanded term definition</a> contains
+    a <code>@prefix</code> member with the value <a>true</a>.</p>
 
   <p class="note">This represents a small change to the 1.0 algorithm to prevent IRIs
     that are not really intended to be used as prefixes from being used for creating
@@ -5070,6 +5078,7 @@ specified. The full <a>IRI</a> for
 <section class="appendix informative">
   <h2>Changes since 1.0 Recommendation of 16 January 2014</h2>
   <ul>
+    <li>A context may contain a <code>@version</code> member which is used to set the <a>processing mode</a>.</li>
     <li>An <a>expanded term definition</a> can now have an
       <code>@context</code> property, which defines a <a>context</a> used for values of
       a <a>property</a> identified with such a <a>term</a>.</li>
@@ -5093,7 +5102,7 @@ specified. The full <a>IRI</a> for
       keyword along with <code>@set</code> (other than <code>@list</code>).
       This allows a way to ensure that such property values will always
       be expressed in <a>array</a> form.</li>
-    <li>In JSON-LD 1.1, terms will be used as <a>compact IRI</a> prefixes
+    <li>In JSON-LD 1.1, terms will be chosen as <a>compact IRI</a> prefixes
       when compacting only if
       a <a>simple term definition</a> is used where the value ends with a URI <a data-cite="RFC3986#section-2.2">gen-delim</a> character,
       or if their <a>expanded term definition</a> contains

--- a/test-suite/tests/compact-manifest.jsonld
+++ b/test-suite/tests/compact-manifest.jsonld
@@ -1241,8 +1241,8 @@
     }, {
       "@id": "#tp001",
       "@type": ["jld:PositiveEvaluationTest", "jld:CompactTest"],
-      "name": "Compact IRI may use an expanded term definition in 1.0",
-      "purpose": "Terms with an expanded term definition may be used for creating compact IRIs",
+      "name": "Compact IRI will not use an expanded term definition in 1.0",
+      "purpose": "Terms with an expanded term definition are not used for creating compact IRIs",
       "option": {"processingMode": "json-ld-1.0", "specVersion": "json-ld-1.1"},
       "input": "compact-p001-in.jsonld",
       "context": "compact-p001-context.jsonld",

--- a/test-suite/tests/compact-p001-out.jsonld
+++ b/test-suite/tests/compact-p001-out.jsonld
@@ -2,7 +2,7 @@
   "@context": {
     "ex": {"@id": "http://example.org/"}
   },
-  "@id": "ex:id1",
-  "@type": ["ex:Type1", "ex:Type2"],
-  "ex:term": {"@id": "ex:id2"}
+  "@id": "http://example.org/id1",
+  "@type": ["http://example.org/Type1", "http://example.org/Type2"],
+  "http://example.org/term": {"@id": "http://example.org/id2"}
 }

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -1082,6 +1082,30 @@
       "option": {"specVersion": "json-ld-1.1"},
       "input": "expand-p001-in.jsonld",
       "expect": "expand-p001-out.jsonld"
+    }, {
+      "@id": "#tp002",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@version setting [1.0, 1.1, 1.0]",
+      "purpose": "If processing mode is not set through API, it is set by the first context containing @version.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand-p002-in.jsonld",
+      "expect": "expand-p002-out.jsonld"
+    }, {
+      "@id": "#tp003",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@version setting [1.1, 1.0]",
+      "purpose": "If processing mode is not set through API, it is set by the first context containing @version.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand-p003-in.jsonld",
+      "expect": "expand-p003-out.jsonld"
+    }, {
+      "@id": "#tp004",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@version setting [1.1, 1.0, 1.1]",
+      "purpose": "If processing mode is not set through API, it is set by the first context containing @version.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand-p004-in.jsonld",
+      "expect": "expand-p004-out.jsonld"
    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],

--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -1074,6 +1074,14 @@
       "input": "expand-n007-in.jsonld",
       "expect": "expand-n007-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tp001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "@version may be specified after first context",
+      "purpose": "If processing mode is not set through API, it is set by the first context containing @version.",
+      "option": {"specVersion": "json-ld-1.1"},
+      "input": "expand-p001-in.jsonld",
+      "expect": "expand-p001-out.jsonld"
    }, {
       "@id": "#tl001",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],

--- a/test-suite/tests/expand-p001-in.jsonld
+++ b/test-suite/tests/expand-p001-in.jsonld
@@ -1,0 +1,7 @@
+{
+  "@context": [
+    {"@vocab": "http://example/"},
+    {"@version": 1.1, "a": {"@type": "@id"}}
+  ],
+  "a": "http://example.org/foo"
+}

--- a/test-suite/tests/expand-p001-out.jsonld
+++ b/test-suite/tests/expand-p001-out.jsonld
@@ -1,0 +1,3 @@
+[{
+ "http://example/a": [{"@id": "http://example.org/foo"}]
+}]

--- a/test-suite/tests/expand-p002-in.jsonld
+++ b/test-suite/tests/expand-p002-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": [
+    {"@vocab": "http://example/"},
+    {"@version": 1.1, "a": {"@type": "@id"}},
+    {"b": {"@type": "@id"}}
+  ],
+  "a": "http://example.org/foo",
+  "b": "http://example.org/bar"
+}

--- a/test-suite/tests/expand-p002-out.jsonld
+++ b/test-suite/tests/expand-p002-out.jsonld
@@ -1,0 +1,4 @@
+[{
+ "http://example/a": [{"@id": "http://example.org/foo"}],
+ "http://example/b": [{"@id": "http://example.org/bar"}]
+}]

--- a/test-suite/tests/expand-p003-in.jsonld
+++ b/test-suite/tests/expand-p003-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": [
+    {"@version": 1.1, "a": {"@id": "http://example/a", "@type": "@id"}},
+    {"@vocab": "http://example/", "b": {"@type": "@id"}}
+  ],
+  "a": "http://example.org/foo",
+  "b": "http://example.org/bar"
+}

--- a/test-suite/tests/expand-p003-out.jsonld
+++ b/test-suite/tests/expand-p003-out.jsonld
@@ -1,0 +1,4 @@
+[{
+ "http://example/a": [{"@id": "http://example.org/foo"}],
+ "http://example/b": [{"@id": "http://example.org/bar"}]
+}]

--- a/test-suite/tests/expand-p004-in.jsonld
+++ b/test-suite/tests/expand-p004-in.jsonld
@@ -1,0 +1,9 @@
+{
+  "@context": [
+    {"@version": 1.1, "a": {"@id": "http://example/a", "@type": "@id"}},
+    {"@vocab": "http://example/"},
+    {"@version": 1.1, "b": {"@type": "@id"}}
+  ],
+  "a": "http://example.org/foo",
+  "b": "http://example.org/bar"
+}

--- a/test-suite/tests/expand-p004-out.jsonld
+++ b/test-suite/tests/expand-p004-out.jsonld
@@ -1,0 +1,4 @@
+[{
+ "http://example/a": [{"@id": "http://example.org/foo"}],
+ "http://example/b": [{"@id": "http://example.org/bar"}]
+}]


### PR DESCRIPTION
it only conflicts… if `processingMode` is set to something else in the API. Also changes term selection for compact IRIs in 1.0 mode as a necessary byproduct of this approach.

Fixes #581