### PR TITLE
Clarify that scoped contexts on `@type` use the term used

### DIFF
--- a/spec/latest/common/terms.html
+++ b/spec/latest/common/terms.html
@@ -69,7 +69,7 @@
     <a>IRI</a>, nor a <a>JSON-LD value</a>, nor a <a>list</a>.
     A <a data-cite="RDF11-CONCEPTS#dfn-blank-node" class="externalDFN">blank node</a> does not contain a de-referenceable
     identifier because it is either ephemeral in nature or does not contain information that needs to be
-    linked to from outside of the linked data graph. A blank node is assigned an identifier starting with
+    linked to from outside of the <a>linked data graph</a>. A blank node is assigned an identifier starting with
     the prefix <code>_:</code>.</dd>
   <dt><dfn data-lt="blank node identifiers">blank node identifier</dfn></dt><dd>
     A <a data-cite="RDF11-CONCEPTS#dfn-blank-node-identifier" class="externalDFN">blank node identifier</a> is a string that can be used as an identifier for a
@@ -180,7 +180,7 @@
     connected by <a>edges</a>,
     as specified in the <a data-cite="JSON-LD11CG#data-model">Data Model</a>
     section of the JSON-LD specification [[JSON-LD11CG]].
-    A <a>linked data graph</a> is a generalized representation of a
+    A <a>linked data graph</a> is a generalized representation of an
     <a data-cite="RDF11-CONCEPTS#dfn-rdf-graph">RDF graph</a>
     as defined in [[!RDF-CONCEPTS]].</dd>
   <dt><dfn data-lt="lists">list</dfn></dt><dd>

--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -4918,30 +4918,28 @@
 <section class="appendix informative">
   <h2>Open Issues</h2>
   <p>The following is a list of issues open at the time of publication.</p>
-  <p class="issue" data-number="246"></p>
-  <p class="issue" data-number="333"></p>
-  <p class="issue" data-number="338"></p>
+  <p class="issue defer" data-number="246"></p>
+  <p class="issue defer" data-number="333"></p>
+  <p class="issue defer" data-number="338"></p>
   <p class="issue" data-number="357"></p>
-  <p class="issue" data-number="368"></p>
-  <p class="issue" data-number="371"></p>
-  <p class="issue" data-number="397"></p>
-  <p class="issue" data-number="402"></p>
-  <p class="issue" data-number="434"></p>
-  <p class="issue" data-number="460"></p>
+  <p class="issue defer" data-number="368"></p>
+  <p class="issue defer" data-number="371"></p>
+  <p class="issue defer" data-number="397"></p>
+  <p class="issue defer" data-number="402"></p>
+  <p class="issue defer" data-number="434"></p>
+  <p class="issue defer" data-number="460"></p>
   <p class="issue" data-number="495"></p>
-  <p class="issue" data-number="495"></p>
-  <p class="issue" data-number="507"></p>
+  <p class="issue defer" data-number="507"></p>
   <p class="issue" data-number="512"></p>
-  <p class="issue" data-number="526"></p>
+  <p class="issue defer" data-number="526"></p>
   <p class="issue" data-number="530"></p>
-  <p class="issue" data-number="542"></p>
+  <p class="issue defer" data-number="542"></p>
+  <p class="issue defer" data-number="548"></p>
   <p class="issue" data-number="581"></p>
-  <p class="issue" data-number="583"></p>
-  <p class="issue" data-number="581"></p>
-  <p class="issue" data-number="583"></p>
-  <p class="issue" data-number="595"></p>
-  <p class="issue" data-number="589"></p>
-  <p class="issue" data-number="601"></p>
+  <p class="issue defer" data-number="583"></p>
+  <p class="issue defer" data-number="595"></p>
+  <p class="issue defer" data-number="589"></p>
+  <p class="issue" data-number="611"></p>
 </section>
 
 <section class="appendix informative">

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -1569,7 +1569,7 @@ becomes a W3C Recommendation.</p>
 <section class="appendix informative">
   <h4>Open Issues</h4>
   <p>The following is a list of issues open at the time of publication.</p>
-  <p class="issue" data-number="542"></p>
+  <p class="issue defer" data-number="542"></p>
   <p class="issue" data-number="550"></p>
   <p class="issue" data-number="579"></p>
   <p class="issue" data-number="588"></p>

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -2405,7 +2405,7 @@ specified. The full <a>IRI</a> for
   <h2>Scoped Contexts</h2>
 
   <p>An <a>expanded term definition</a> can include a <code>@context</code>
-    property, which defines a <a>context</a> for <a data-lt="JSON-LD
+    property, which defines a <a>context</a> (an <dfn>embedded context</dfn>) for <a data-lt="JSON-LD
     value">values</a> of properties defined using that <a>term</a>. This allows
     values to use <a>term definitions</a>, <a>base IRI</a>,
     <a>vocabulary mapping</a> or <a>default language</a> which is different from the
@@ -2436,7 +2436,7 @@ specified. The full <a>IRI</a> for
 
   <p>In this case, the social profile is defined using the schema.org vocabulary, but interest is imported from FOAF, and is used to define a node describing one of Manu's interests where those properties now come from the FOAF vocabulary.</p>
 
-  <p>Expanding this document, uses a combination of terms defined in the outer context, and those defined specifically for that term.</p>
+  <p>Expanding this document, uses a combination of terms defined in the outer context, and those defined specifically for that term in an <a>embedded context</a>.</p>
 
   <pre class="example nohighlight" data-transform="updateExample"
        title="Expanded document using a scoped context">
@@ -2482,15 +2482,15 @@ specified. The full <a>IRI</a> for
   <p>Scoping on <code>@type</code> is useful when common properties are used to
     relate things of different types, where the vocabularies in use within
     different entities calls for different context scoping. For example,
-    `hasPart`/`partOf` may be common terms used in a document, but mean
+    <code>hasPart</code>/<code>partOf</code> may be common terms used in a document, but mean
     different things depending on the context.</p>
 
   <p>When expanding, each value of <code>@type</code> is considered
     (ordering them lexographically) where that value is also a <a>term</a> in
-    the <a>active context</a> having its own <a>context</a>. If so, that
-    <a>context</a> as applied to the <a>active context</a>. When compacting, if
+    the <a>active context</a> having its own <a>embedded context</a>. If so, that
+    <a>embedded context</a> is applied to the <a>active context</a>. When compacting, if
     a <a>term</a> is chosen to represent an IRI used as a value of <code>@type</code> where that
-    <a>term definition</a> also has a <a>context</a>, it is then applied to the
+    <a>term definition</a> also has an <a>embedded context</a>, it is then applied to the
     <a>active context</a> to affect further compaction.</p>
 
   <p class="note">The values of <code>@type</code> are unordered, so if multiple

--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
 <title>JSON-LD 1.1</title>
@@ -2479,7 +2479,19 @@ specified. The full <a>IRI</a> for
   -->
   </pre>
 
-  <p>Scoping on <code>@type</code> is useful when common properties are used to relate things of different types, where the vocabularies in use within different entities calls for different context scoping. For example, `hasPart`/`partOf` may be common terms used in a document, but mean different things depending on the context.</p>
+  <p>Scoping on <code>@type</code> is useful when common properties are used to
+    relate things of different types, where the vocabularies in use within
+    different entities calls for different context scoping. For example,
+    `hasPart`/`partOf` may be common terms used in a document, but mean
+    different things depending on the context.</p>
+
+  <p>When expanding, each value of <code>@type</code> is considered
+    (ordering them lexographically) where that value is also a <a>term</a> in
+    the <a>active context</a> having its own <a>context</a>. If so, that
+    <a>context</a> as applied to the <a>active context</a>. When compacting, if
+    a <a>term</a> is chosen to represent an IRI used as a value of <code>@type</code> where that
+    <a>term definition</a> also has a <a>context</a>, it is then applied to the
+    <a>active context</a> to affect further compaction.</p>
 
   <p class="note">The values of <code>@type</code> are unordered, so if multiple
     types are listed, the order that scoped contexts are applied is based on
@@ -5102,25 +5114,23 @@ specified. The full <a>IRI</a> for
 <section class="appendix informative">
   <h4>Open Issues</h4>
   <p>The following is a list of issues open at the time of publication.</p>
-  <p class="issue" data-number="246"></p>
+  <p class="issue defer" data-number="246"></p>
   <p class="issue" data-number="316"></p>
-  <p class="issue" data-number="333"></p>
-  <p class="issue" data-number="368"></p>
-  <p class="issue" data-number="371"></p>
-  <p class="issue" data-number="397"></p>
-  <p class="issue" data-number="443"></p>
-  <p class="issue" data-number="491"></p>
-  <p class="issue" data-number="521"></p>
-  <p class="issue" data-number="527"></p>
+  <p class="issue defer" data-number="333"></p>
+  <p class="issue defer" data-number="368"></p>
+  <p class="issue defer" data-number="371"></p>
+  <p class="issue defer" data-number="397"></p>
+  <p class="issue defer" data-number="443"></p>
+  <p class="issue defer" data-number="491"></p>
   <p class="issue" data-number="543"></p>
-  <p class="issue" data-number="547"></p>
-  <p class="issue" data-number="548"></p>
-  <p class="issue" data-number="583"></p>
-  <p class="issue" data-number="584"></p>
-  <p class="issue" data-number="585"></p>
-  <p class="issue" data-number="590"></p>
-  <p class="issue" data-number="595"></p>
-  <p class="issue" data-number="598"></p>
+  <p class="issue defer" data-number="547"></p>
+  <p class="issue defer" data-number="548"></p>
+  <p class="issue defer" data-number="583"></p>
+  <p class="issue defer" data-number="584"></p>
+  <p class="issue defer" data-number="585"></p>
+  <p class="issue defer" data-number="590"></p>
+  <p class="issue defer" data-number="595"></p>
+  <p class="issue defer" data-number="598"></p>
 </section>
 
 <section class="appendix informative">


### PR DESCRIPTION
rather than it's expanded IRI, to find a scoped context.

Fixes #521.