### PR TITLE
Add text to the grammar to restrict the content model of `@reverse`

### DIFF
--- a/spec/latest/json-ld/index.html
+++ b/spec/latest/json-ld/index.html
@@ -4818,11 +4818,6 @@ specified. The full <a>IRI</a> for
     <code>@container</code>. An
     <a>expanded term definition</a> SHOULD NOT contain any other keys.</p>
 
-  <p>If an <a>expanded term definition</a> has an <code>@reverse</code> member,
-    it MUST NOT have <code>@id</code> or <code>@nest</code> members at the same time. If an
-    <code>@container</code> member exists, its value MUST be <a>null</a>,
-    <code>@set</code>, or <code>@index</code>.</p>
-
   <p>If the term being defined is not a <a>compact IRI</a> or
     <a>absolute IRI</a> and the <a>active context</a> does not have an
     <code>@vocab</code> mapping, the <a>expanded term definition</a> MUST
@@ -4832,6 +4827,13 @@ specified. The full <a>IRI</a> for
     <a>keyword</a>, its value MUST be <a>null</a>, an <a>absolute IRI</a>,
     a <a>blank node identifier</a>, a <a>compact IRI</a>, a <a>term</a>,
     or a <a>keyword</a>.</p>
+
+  <p>If an <a>expanded term definition</a> has an <code>@reverse</code> member,
+    it MUST NOT have <code>@id</code> or <code>@nest</code> members at the same time,
+    its value MUST be an <a>absolute IRI</a>,
+    a <a>blank node identifier</a>, a <a>compact IRI</a>, or a <a>term</a>. If an
+    <code>@container</code> member exists, its value MUST be <a>null</a>,
+    <code>@set</code>, or <code>@index</code>.</p>
 
   <p>If the <a>expanded term definition</a> contains the <code>@type</code>
     <a>keyword</a>, its value MUST be an <a>absolute IRI</a>, a


### PR DESCRIPTION
 to be consistent with API processing.

Fixes #636.