### PR TITLE
Clarify BNode pruning with keyword aliases

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -737,6 +737,9 @@
     so long as the end result is indistinguishable from the result that would
     be obtained by the specification's algorithms.</p>
 
+  <p>In algorithm steps that describe operations on <a>keywords</a>, those steps
+    also apply to <a>keyword aliases</a>.</p>
+
   <p class="note">Implementers can partially check their level of conformance to
     this specification by successfully passing the test cases of the JSON-LD test
     suite [[JSON-LD-TESTS]]. Note, however, that passing all the tests in the test

--- a/spec/latest/json-ld-framing/index.html
+++ b/spec/latest/json-ld-framing/index.html
@@ -806,6 +806,9 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
     so long as the end result is indistinguishable from the result that would
     be obtained by the specification's algorithms.</p>
 
+  <p>In algorithm steps that describe operations on <a>keywords</a>, those steps
+    also apply to <a>keyword aliases</a>.</p>
+
   <p class="note">Implementers can partially check their level of conformance to
     this specification by successfully passing the test cases of the JSON-LD test
     suite [[JSON-LD-TESTS]]. Note, however, that passing all the tests in the test

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -86,7 +86,7 @@
       "input": "frame-0010-in.jsonld",
       "frame": "frame-0010-frame.jsonld",
       "expect": "frame-0010-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false}
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#t0011",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -167,7 +167,7 @@
       "input": "frame-0020-in.jsonld",
       "frame": "frame-0020-frame.jsonld",
       "expect": "frame-0020-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false}
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#t0021",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -176,7 +176,7 @@
       "input": "frame-0021-in.jsonld",
       "frame": "frame-0021-frame.jsonld",
       "expect": "frame-0021-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false}
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#t0022",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -400,7 +400,7 @@
       "input": "frame-0046-in.jsonld",
       "frame": "frame-0046-frame.jsonld",
       "expect": "frame-0046-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false, "specVersion": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#t0047",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -427,7 +427,7 @@
       "input": "frame-0049-in.jsonld",
       "frame": "frame-0049-frame.jsonld",
       "expect": "frame-0049-out.jsonld",
-      "option": {"pruneBlankNodeIdentifiers": false, "specVersion": "json-ld-1.1"}
+      "option": {"specVersion": "json-ld-1.1", "processingMode": "json-ld-1.0"}
     }, {
       "@id": "#t0050",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
@@ -570,6 +570,15 @@
       "input": "frame-0049-in.jsonld",
       "frame": "frame-0049-frame.jsonld",
       "expect": "frame-p049-out.jsonld",
+      "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
+    }, {
+      "@id": "#tp050",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Prune blank nodes with alias of @id",
+      "purpose": "If @id is aliased in a frame, an unreferenced blank node is still pruned.",
+      "input": "frame-p050-in.jsonld",
+      "frame": "frame-p050-frame.jsonld",
+      "expect": "frame-p050-out.jsonld",
       "option": {"processingMode": "json-ld-1.1", "specVersion": "json-ld-1.1"}
     }
   ]

--- a/test-suite/tests/frame-p050-frame.jsonld
+++ b/test-suite/tests/frame-p050-frame.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "id": "@id"
+  },
+  "id": {},
+  "name": {}
+}

--- a/test-suite/tests/frame-p050-in.jsonld
+++ b/test-suite/tests/frame-p050-in.jsonld
@@ -1,0 +1,8 @@
+{
+  "@context": {
+    "@vocab": "http://example/",
+    "id": "@id"
+  },
+  "id": "_:bnode0",
+  "name": "foo"
+}

--- a/test-suite/tests/frame-p050-out.jsonld
+++ b/test-suite/tests/frame-p050-out.jsonld
@@ -1,0 +1,7 @@
+{
+ "@context": {
+   "@vocab": "http://example/",
+   "id": "@id"
+ },
+ "@graph": [{"name": "foo"}]
+}


### PR DESCRIPTION
* Add statement to Conformance sections of API and Framing that algorithm steps describing operations on keywords also apply to aliases of those keywords to make it clear.
* Add example using alias of `@id`.

Fixes #611.