### PR TITLE
Require that a remote context only be dereferenced once.

### DIFF
--- a/spec/latest/json-ld-api/index.html
+++ b/spec/latest/json-ld-api/index.html
@@ -873,7 +873,11 @@
                   <a data-link-for="JsonLdErrorCode">recursive context inclusion</a>
                   error has been detected and processing is aborted;
                   otherwise, add <var>context</var> to <var>remote contexts</var>.</li>
-                <li>Dereference <var>context</var>, <span class="changed">transforming into the <a>internal representation</a></span>.
+                <li class="changed">If <var>context</var> was previously dereferenced,
+                  then the processor MUST NOT do a further dereference, and
+                  <a>context</a> is set to the
+                  previously established <a>internal representation</a>.</li>
+                <li>Otherwise, dereference <var>context</var>, <span class="changed">transforming into the <a>internal representation</a></span>.
                   If <var>context</var> cannot be dereferenced,
                   <span class="changed">or cannot be transformed into the <a>internal representation</a></span>,
                   a <a data-link-for="JsonLdErrorCode">loading remote context failed</a>
@@ -884,7 +888,7 @@
                   set <var>context</var> to the value of that member.</li>
                 <li>Set <var>result</var> to the result of recursively calling this algorithm,
                   passing <var>result</var> for <var>active context</var>,
-                  <var>context</var> for <var>local context</var>, and <var>remote contexts</var>.</li>
+                  <var>context</var> for <var>local context</var>, and <span class="changed">a copy of</span> <var>remote contexts</var>.</li>
                 <li>Continue with the next <var>context</var>.</li>
               </ol>
             </li>


### PR DESCRIPTION
Fixes #638.