### PR TITLE
New test: frame-g010: Multiple named graphs

### DIFF
--- a/test-suite/tests/frame-g010-frame.jsonld
+++ b/test-suite/tests/frame-g010-frame.jsonld
@@ -1,0 +1,31 @@
+{
+  "@context": {
+    "@vocab": "http://example.com/",
+    "loves": {
+      "@type": "@id"
+    },
+    "unionOf": {
+      "@type": "@id",
+      "@id": "owl:unionOf",
+      "@container": "@list"
+    },
+    "Class": "owl:Class"
+  },
+  "@graph": [
+    {
+      "@explicit": false,
+      "@embed": "@last",
+      "@type": [
+        "Act",
+        "Class"
+      ],
+      "@graph": [{
+        "@explicit": true,
+        "@embed": "@always",
+        "@type": "Person",
+        "@id": {},
+        "loves": {"@embed": "@never"}
+      }]
+    }
+  ]
+}

--- a/test-suite/tests/frame-g010-in.jsonld
+++ b/test-suite/tests/frame-g010-in.jsonld
@@ -1,0 +1,61 @@
+{
+  "@context": {
+    "@vocab": "http://example.com/",
+    "loves": {
+      "@type": "@id"
+    },
+    "unionOf": {
+      "@type": "@id",
+      "@id": "owl:unionOf",
+      "@container": "@list"
+    },
+    "Class": "owl:Class"
+  },
+  "@graph": [
+    {
+      "@type": "Act",
+      "@graph": [
+        {
+          "@id": "Romeo",
+          "@type": "Person"
+        },
+        {
+          "@id": "Juliet",
+          "@type": "Person"
+        }
+      ]
+    },
+    {
+      "@id": "ActTwo",
+      "@type": "Act",
+      "@graph": [
+        {
+          "@id": "Romeo",
+          "@type": "Person",
+          "loves": "Juliet"
+        },
+        {
+          "@id": "Juliet",
+          "@type": "Person",
+          "loves": "Romeo"
+        }
+      ]
+    },
+    {
+      "@id": "Person",
+      "@type": "Class",
+      "unionOf": {
+        "@list": [
+          {
+            "@id": "Montague",
+            "@type": "Class"
+          },
+          {
+            "@id": "Capulet",
+            "@type": "Class"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test-suite/tests/frame-g010-out.jsonld
+++ b/test-suite/tests/frame-g010-out.jsonld
@@ -17,21 +17,6 @@
         {
           "@id": "Juliet",
           "@type": "Person",
-          "loves": null
-        },
-        {
-          "@id": "Romeo",
-          "@type": "Person",
-          "loves": null
-        }
-      ],
-      "@type": "Act"
-    },
-    {
-      "@graph": [
-        {
-          "@id": "Juliet",
-          "@type": "Person",
           "loves": "Romeo"
         },
         {
@@ -64,6 +49,21 @@
           "@type": "Class"
         }
       ]
+    },
+    {
+      "@graph": [
+        {
+          "@id": "Juliet",
+          "@type": "Person",
+          "loves": null
+        },
+        {
+          "@id": "Romeo",
+          "@type": "Person",
+          "loves": null
+        }
+      ],
+      "@type": "Act"
     }
   ]
 }

--- a/test-suite/tests/frame-g010-out.jsonld
+++ b/test-suite/tests/frame-g010-out.jsonld
@@ -1,0 +1,69 @@
+{
+  "@context": {
+    "@vocab": "http://example.com/",
+    "loves": {
+      "@type": "@id"
+    },
+    "unionOf": {
+      "@type": "@id",
+      "@id": "owl:unionOf",
+      "@container": "@list"
+    },
+    "Class": "owl:Class"
+  },
+  "@graph": [
+    {
+      "@graph": [
+        {
+          "@id": "Juliet",
+          "@type": "Person",
+          "loves": null
+        },
+        {
+          "@id": "Romeo",
+          "@type": "Person",
+          "loves": null
+        }
+      ],
+      "@type": "Act"
+    },
+    {
+      "@graph": [
+        {
+          "@id": "Juliet",
+          "@type": "Person",
+          "loves": "Romeo"
+        },
+        {
+          "@id": "Romeo",
+          "@type": "Person",
+          "loves": "Juliet"
+        }
+      ],
+      "@id": "ActTwo",
+      "@type": "Act"
+    },
+    {
+      "@id": "Capulet",
+      "@type": "Class"
+    },
+    {
+      "@id": "Montague",
+      "@type": "Class"
+    },
+    {
+      "@id": "Person",
+      "@type": "Class",
+      "unionOf": [
+        {
+          "@id": "Montague",
+          "@type": "Class"
+        },
+        {
+          "@id": "Capulet",
+          "@type": "Class"
+        }
+      ]
+    }
+  ]
+}

--- a/test-suite/tests/frame-manifest.jsonld
+++ b/test-suite/tests/frame-manifest.jsonld
@@ -526,7 +526,17 @@
       "frame": "frame-g009-frame.jsonld",
       "expect": "frame-g009-out.jsonld",
       "option": {"specVersion": "json-ld-1.1"}
-    }, {
+    },{
+      "@id": "#tg010",
+      "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
+      "name": "Multiple named graphs",
+      "purpose": "Test embedded graphs",
+      "input": "frame-g010-in.jsonld",
+      "frame": "frame-g010-frame.jsonld",
+      "expect": "frame-g010-out.jsonld",
+      "option": {"pruneBlankNodeIdentifiers": true}
+    },
+    {
       "@id": "#tp010",
       "@type": ["jld:PositiveEvaluationTest", "jld:FrameTest"],
       "name": "property CURIE conflict (prune bnodes)",


### PR DESCRIPTION
This follows on from a bug and fix i filed on [pyld](https://github.com/digitalbazaar/pyld): [issue 81](https://github.com/digitalbazaar/pyld/pull/81). At @davidlehn 's request i am submitting the test so that future implementations don't make the same mistake. 

As far as i can tell there aren't any tests that deal with multiple named graphs yet, so i hope this is useful. Please note that none of the following implementations currently comply with what i think should be the results:

* [Stable JSON-LD playground](https://json-ld.org/playground/#startTab=tab-framed&copyContext=true&json-ld=%7B%22%40context%22%3A%7B%22%40vocab%22%3A%22http%3A%2F%2Fexample.com%2F%22%2C%22loves%22%3A%7B%22%40type%22%3A%22%40id%22%7D%2C%22unionOf%22%3A%7B%22%40type%22%3A%22%40id%22%2C%22%40id%22%3A%22owl%3AunionOf%22%2C%22%40container%22%3A%22%40list%22%7D%2C%22Class%22%3A%22owl%3AClass%22%7D%2C%22%40graph%22%3A%5B%7B%22%40type%22%3A%22Act%22%2C%22%40graph%22%3A%5B%7B%22%40id%22%3A%22Romeo%22%2C%22%40type%22%3A%22Person%22%7D%2C%7B%22%40id%22%3A%22Juliet%22%2C%22%40type%22%3A%22Person%22%7D%5D%7D%2C%7B%22%40id%22%3A%22ActTwo%22%2C%22%40type%22%3A%22Act%22%2C%22%40graph%22%3A%5B%7B%22%40id%22%3A%22Romeo%22%2C%22%40type%22%3A%22Person%22%2C%22loves%22%3A%22Juliet%22%7D%2C%7B%22%40id%22%3A%22Juliet%22%2C%22%40type%22%3A%22Person%22%2C%22loves%22%3A%22Romeo%22%7D%5D%7D%2C%7B%22%40id%22%3A%22Person%22%2C%22%40type%22%3A%22Class%22%2C%22unionOf%22%3A%7B%22%40list%22%3A%5B%7B%22%40id%22%3A%22Montague%22%2C%22%40type%22%3A%22Class%22%7D%2C%7B%22%40id%22%3A%22Capulet%22%2C%22%40type%22%3A%22Class%22%7D%5D%7D%7D%5D%7D&frame=%7B%22%40context%22%3A%7B%22%40vocab%22%3A%22http%3A%2F%2Fexample.com%2F%22%2C%22loves%22%3A%7B%22%40type%22%3A%22%40id%22%7D%2C%22unionOf%22%3A%7B%22%40type%22%3A%22%40id%22%2C%22%40id%22%3A%22owl%3AunionOf%22%2C%22%40container%22%3A%22%40list%22%7D%2C%22Class%22%3A%22owl%3AClass%22%7D%2C%22%40graph%22%3A%5B%7B%22%40explicit%22%3Afalse%2C%22%40embed%22%3A%22%40last%22%2C%22%40type%22%3A%5B%22Act%22%2C%22Class%22%5D%2C%22%40graph%22%3A%5B%7B%22%40explicit%22%3Atrue%2C%22%40embed%22%3A%22%40always%22%2C%22%40type%22%3A%22Person%22%2C%22%40id%22%3A%7B%7D%2C%22loves%22%3A%7B%22%40embed%22%3A%22%40never%22%7D%7D%5D%7D%5D%7D) processes the data OK, but omits the children of the two named graphs' `@graph`s.
* [Dev JSON-LD playground](https://json-ld.org/playground-dev/#startTab=tab-framed&copyContext=true&json-ld=%7B%22%40context%22%3A%7B%22%40vocab%22%3A%22http%3A%2F%2Fexample.com%2F%22%2C%22loves%22%3A%7B%22%40type%22%3A%22%40id%22%7D%2C%22unionOf%22%3A%7B%22%40type%22%3A%22%40id%22%2C%22%40id%22%3A%22owl%3AunionOf%22%2C%22%40container%22%3A%22%40list%22%7D%2C%22Class%22%3A%22owl%3AClass%22%7D%2C%22%40graph%22%3A%5B%7B%22%40type%22%3A%22Act%22%2C%22%40graph%22%3A%5B%7B%22%40id%22%3A%22Romeo%22%2C%22%40type%22%3A%22Person%22%7D%2C%7B%22%40id%22%3A%22Juliet%22%2C%22%40type%22%3A%22Person%22%7D%5D%7D%2C%7B%22%40id%22%3A%22ActTwo%22%2C%22%40type%22%3A%22Act%22%2C%22%40graph%22%3A%5B%7B%22%40id%22%3A%22Romeo%22%2C%22%40type%22%3A%22Person%22%2C%22loves%22%3A%22Juliet%22%7D%2C%7B%22%40id%22%3A%22Juliet%22%2C%22%40type%22%3A%22Person%22%2C%22loves%22%3A%22Romeo%22%7D%5D%7D%2C%7B%22%40id%22%3A%22Person%22%2C%22%40type%22%3A%22Class%22%2C%22unionOf%22%3A%7B%22%40list%22%3A%5B%7B%22%40id%22%3A%22Montague%22%2C%22%40type%22%3A%22Class%22%7D%2C%7B%22%40id%22%3A%22Capulet%22%2C%22%40type%22%3A%22Class%22%7D%5D%7D%7D%5D%7D&frame=%7B%22%40context%22%3A%7B%22%40vocab%22%3A%22http%3A%2F%2Fexample.com%2F%22%2C%22loves%22%3A%7B%22%40type%22%3A%22%40id%22%7D%2C%22unionOf%22%3A%7B%22%40type%22%3A%22%40id%22%2C%22%40id%22%3A%22owl%3AunionOf%22%2C%22%40container%22%3A%22%40list%22%7D%2C%22Class%22%3A%22owl%3AClass%22%7D%2C%22%40graph%22%3A%5B%7B%22%40explicit%22%3Afalse%2C%22%40embed%22%3A%22%40last%22%2C%22%40type%22%3A%5B%22Act%22%2C%22Class%22%5D%2C%22%40graph%22%3A%5B%7B%22%40explicit%22%3Atrue%2C%22%40embed%22%3A%22%40always%22%2C%22%40type%22%3A%22Person%22%2C%22%40id%22%3A%7B%7D%2C%22loves%22%3A%7B%22%40embed%22%3A%22%40never%22%7D%7D%5D%7D%5D%7D) barfs. Unless i am missing something in the frame definition (entirely possible), the error message seems to indicate it has lost a property in its lookup table somewhere in applying the framing algorithm. I saw this on some occasions in pyld, though i cannot currently reproduce it there.

> TypeError: Cannot read property 'https://json-ld.org/playground-dev/Montague' of undefined

* For pyld, for it to pass i had to explicitly add `{"pruneBlankNodeIdentifiers": true}` to the framing tests, as well as applying my proposed fix. Since this is being removed from the spec, i figure the implementation itself will catch up in a future iteration.