### PR TITLE
Update jsonld-signatures.

### DIFF
--- a/playground-dev/index.html
+++ b/playground-dev/index.html
@@ -424,12 +424,13 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
     <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/d3-tip/0.6.7/d3-tip.min.js"></script>
     <script src="../playground/jsonld-vis.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jsonld-signatures@2.3.1/dist/jsonld-signatures.min.js"></script>
 
     <!-- local scripts -->
 <!--    <script src="./jsonld.js"></script> -->
     <script src="../playground/forge.min.js"></script>
     <script src="../playground/bitcore-message.js"></script>
-    <script src="../playground/jsonld-signatures.js"></script>
+    <!--<script src="../playground/jsonld-signatures.js"></script>-->
     <script src="../playground/jsonlint.js"></script>
     <script src="../playground/tv4.min.js"></script>
     <script src="../playground/json-schema-lint.js"></script>


### PR DESCRIPTION
- Use updated version on dev playground. Old version on main playground
  due to 1.1 feature usage.
- Use context api from jsigs. This uses v2 for newer versions.
- Add temporary fix for json-ld 1.1 support.
- Use CDN for jsonld-signatures.