### PR TITLE
Fix incorrect context reference in error-0042

### DIFF
--- a/test-suite/tests/error-0042-in.jsonld
+++ b/test-suite/tests/error-0042-in.jsonld
@@ -1,3 +1,3 @@
 {
-  "http://example/list": [{"@list": ["foo"]}, {"@list": ["bar"]}]
+  "list": [{"@list": ["foo"]}, {"@list": ["bar"]}]
 }


### PR DESCRIPTION
As far as I understand the goal of this test, I think this test may be incorrectly defined.
Currently, jsonld.js seems to accept this input, and this fails the test.
I assume this is because the `list` context entry is not used in the JSON-LD document.