### PR TITLE
Add jsonld-streaming-parser.js to list of implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,6 +186,11 @@
                   <span property="schema:name">jsonld.js</span>
                 </a>
               </li>
+              <li typeof="schema:SoftwareSourceCode">
+                <a property="schema:codeRepository" href="https://github.com/rubensworks/jsonld-streaming-parser.js">
+                  <span property="schema:name">jsonld-streaming-parser.js</span>
+                </a>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
This adds https://github.com/rubensworks/jsonld-streaming-parser.js to the list of JS implementations.