### PR TITLE
Add jsonld-streaming-serializer.js to list of implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,11 @@
                   <span property="schema:name">jsonld-streaming-parser.js</span>
                 </a>
               </li>
+              <li typeof="schema:SoftwareSourceCode">
+                <a property="schema:codeRepository" href="https://github.com/rubensworks/jsonld-streaming-serializer.js">
+                  <span property="schema:name">jsonld-streaming-serializer.js</span>
+                </a>
+              </li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
This PR adds [jsonld-streaming-serializer.js](https://github.com/rubensworks/jsonld-streaming-serializer.js) to the list of JavaScript implementations.