### PR TITLE
Update to https://schema.org.

### DIFF
--- a/contexts/event
+++ b/contexts/event
@@ -1,10 +1,10 @@
 {
    "@context":
    {
-      "Event": "http://schema.org/Event",
+      "Event": "https://schema.org/Event",
       "name": "http://purl.org/dc/terms/title",
       "description": "http://purl.org/dc/terms/description",
-      "telephone": "http://schema.org/telephone",
+      "telephone": "https://schema.org/telephone",
       "email": "http://xmlns.com/foaf/0.1/mbox",
 
       "latitude": "http://www.w3.org/2003/01/geo/wgs84_pos#lat",

--- a/contexts/event.jsonld
+++ b/contexts/event.jsonld
@@ -1,10 +1,10 @@
 {
    "@context":
    {
-      "Event": "http://schema.org/Event",
+      "Event": "https://schema.org/Event",
       "name": "http://purl.org/dc/terms/title",
       "description": "http://purl.org/dc/terms/description",
-      "telephone": "http://schema.org/telephone",
+      "telephone": "https://schema.org/telephone",
       "email": "http://xmlns.com/foaf/0.1/mbox",
 
       "latitude": "http://www.w3.org/2003/01/geo/wgs84_pos#lat",

--- a/contexts/person
+++ b/contexts/person
@@ -5,7 +5,7 @@
       "xsd": "http://www.w3.org/2001/XMLSchema#",
       "name": "http://xmlns.com/foaf/0.1/name",
       "nickname": "http://xmlns.com/foaf/0.1/nick",
-      "affiliation": "http://schema.org/affiliation",
+      "affiliation": "https://schema.org/affiliation",
       "depiction":
       {
          "@id": "http://xmlns.com/foaf/0.1/depiction",
@@ -18,17 +18,17 @@
       },
       "born":
       {
-         "@id": "http://schema.org/birthDate",
+         "@id": "https://schema.org/birthDate",
          "@type": "xsd:date"
       },
       "child":
       {
-         "@id": "http://schema.org/children",
+         "@id": "https://schema.org/children",
          "@type": "@id"
       },
       "colleague":
       {
-         "@id": "http://schema.org/colleagues",
+         "@id": "https://schema.org/colleagues",
          "@type": "@id"
       },
       "knows":
@@ -38,7 +38,7 @@
       },
       "died":
       {
-         "@id": "http://schema.org/deathDate",
+         "@id": "https://schema.org/deathDate",
          "@type": "xsd:date"
       },
       "email":
@@ -48,32 +48,32 @@
       },
       "familyName": "http://xmlns.com/foaf/0.1/familyName",
       "givenName": "http://xmlns.com/foaf/0.1/givenName",
-      "gender": "http://schema.org/gender",
+      "gender": "https://schema.org/gender",
       "homepage":
       {
          "@id": "http://xmlns.com/foaf/0.1/homepage",
          "@type": "@id"
       },
-      "honorificPrefix": "http://schema.org/honorificPrefix",
-      "honorificSuffix": "http://schema.org/honorificSuffix",
+      "honorificPrefix": "https://schema.org/honorificPrefix",
+      "honorificSuffix": "https://schema.org/honorificSuffix",
       "jobTitle": "http://xmlns.com/foaf/0.1/title",
-      "nationality": "http://schema.org/nationality",
+      "nationality": "https://schema.org/nationality",
       "parent":
       {
-         "@id": "http://schema.org/parent",
+         "@id": "https://schema.org/parent",
          "@type": "@id"
       },
       "sibling":
       {
-         "@id": "http://schema.org/sibling",
+         "@id": "https://schema.org/sibling",
          "@type": "@id"
       },
       "spouse":
       {
-         "@id": "http://schema.org/spouse",
+         "@id": "https://schema.org/spouse",
          "@type": "@id"
       },
-      "telephone": "http://schema.org/telephone",
+      "telephone": "https://schema.org/telephone",
       "Address": "http://www.w3.org/2006/vcard/ns#Address",
       "address": "http://www.w3.org/2006/vcard/ns#address",
       "street": "http://www.w3.org/2006/vcard/ns#street-address",

--- a/contexts/person.html
+++ b/contexts/person.html
@@ -8,7 +8,7 @@
          "@context":
          {
            "foaf": "http://xmlns.com/foaf/0.1/",
-           "schema": "http://schema.org/",
+           "schema": "https://schema.org/",
            "vcard": "http://www.w3.org/2006/vcard/ns#",
            "xsd": "http://www.w3.org/2001/XMLSchema#",
            "Address": "vcard:Address",
@@ -49,12 +49,12 @@
   <body>
     <h1>The Person context</h1>
     <p>The Person context is based on a combination of <a href="http://xmlns.com/foaf/0.1/">FOAF</a>,
-      <a href="http://schema.org/">schema.org </a>,
+      <a href="https://schema.org/">schema.org </a>,
       and <a href="http://www.w3.org/2006/vcard/ns#">vcard</a> vocabularies. It defines the following terms:</p>
 
     <dl>
       <dt>foaf</dt><dd><code>http://xmlns.com/foaf/0.1/</code></dd>
-      <dt>schema</dt><dd><code>http://schema.org/</code></dd>
+      <dt>schema</dt><dd><code>https://schema.org/</code></dd>
       <dt>vcard</dt><dd><code>http://www.w3.org/2006/vcard/ns#</code></dd>
       <dt>xsd</dt><dd><code>http://www.w3.org/2001/XMLSchema#</code></dd>
       <dt>Address</dt><dd><code>vcard:Address</code></dd>

--- a/contexts/person.jsonld
+++ b/contexts/person.jsonld
@@ -5,7 +5,7 @@
       "xsd": "http://www.w3.org/2001/XMLSchema#",
       "name": "http://xmlns.com/foaf/0.1/name",
       "nickname": "http://xmlns.com/foaf/0.1/nick",
-      "affiliation": "http://schema.org/affiliation",
+      "affiliation": "https://schema.org/affiliation",
       "depiction":
       {
          "@id": "http://xmlns.com/foaf/0.1/depiction",
@@ -18,17 +18,17 @@
       },
       "born":
       {
-         "@id": "http://schema.org/birthDate",
+         "@id": "https://schema.org/birthDate",
          "@type": "xsd:date"
       },
       "child":
       {
-         "@id": "http://schema.org/children",
+         "@id": "https://schema.org/children",
          "@type": "@id"
       },
       "colleague":
       {
-         "@id": "http://schema.org/colleagues",
+         "@id": "https://schema.org/colleagues",
          "@type": "@id"
       },
       "knows":
@@ -38,7 +38,7 @@
       },
       "died":
       {
-         "@id": "http://schema.org/deathDate",
+         "@id": "https://schema.org/deathDate",
          "@type": "xsd:date"
       },
       "email":
@@ -48,32 +48,32 @@
       },
       "familyName": "http://xmlns.com/foaf/0.1/familyName",
       "givenName": "http://xmlns.com/foaf/0.1/givenName",
-      "gender": "http://schema.org/gender",
+      "gender": "https://schema.org/gender",
       "homepage":
       {
          "@id": "http://xmlns.com/foaf/0.1/homepage",
          "@type": "@id"
       },
-      "honorificPrefix": "http://schema.org/honorificPrefix",
-      "honorificSuffix": "http://schema.org/honorificSuffix",
+      "honorificPrefix": "https://schema.org/honorificPrefix",
+      "honorificSuffix": "https://schema.org/honorificSuffix",
       "jobTitle": "http://xmlns.com/foaf/0.1/title",
-      "nationality": "http://schema.org/nationality",
+      "nationality": "https://schema.org/nationality",
       "parent":
       {
-         "@id": "http://schema.org/parent",
+         "@id": "https://schema.org/parent",
          "@type": "@id"
       },
       "sibling":
       {
-         "@id": "http://schema.org/sibling",
+         "@id": "https://schema.org/sibling",
          "@type": "@id"
       },
       "spouse":
       {
-         "@id": "http://schema.org/spouse",
+         "@id": "https://schema.org/spouse",
          "@type": "@id"
       },
-      "telephone": "http://schema.org/telephone",
+      "telephone": "https://schema.org/telephone",
       "Address": "http://www.w3.org/2006/vcard/ns#Address",
       "address": "http://www.w3.org/2006/vcard/ns#address",
       "street": "http://www.w3.org/2006/vcard/ns#street-address",

--- a/contexts/place
+++ b/contexts/place
@@ -1,13 +1,13 @@
 {
    "@context":
    {
-      "Place": "http://schema.org/Place",
+      "Place": "https://schema.org/Place",
       "name": "http://purl.org/dc/terms/title",
       "description": "http://purl.org/dc/terms/description",
-      "geo": "http://schema.org/geo",
+      "geo": "https://schema.org/geo",
       "image":
       {
-        "@id": "http://schema.org/image",
+        "@id": "https://schema.org/image",
         "@type": "@id"
       },
       "latitude":
@@ -21,7 +21,7 @@
         "@type": "xsd:decimal"
       },
       "elevation": "http://www.w3.org/2003/01/geo/wgs84_pos#alt",
-      "telephone": "http://schema.org/telephone",
+      "telephone": "https://schema.org/telephone",
 
       "Address": "http://www.w3.org/2006/vcard/ns#Address",
       "address": "http://www.w3.org/2006/vcard/ns#address",

--- a/contexts/place.jsonld
+++ b/contexts/place.jsonld
@@ -1,13 +1,13 @@
 {
    "@context":
    {
-      "Place": "http://schema.org/Place",
+      "Place": "https://schema.org/Place",
       "name": "http://purl.org/dc/terms/title",
       "description": "http://purl.org/dc/terms/description",
-      "geo": "http://schema.org/geo",
+      "geo": "https://schema.org/geo",
       "image":
       {
-        "@id": "http://schema.org/image",
+        "@id": "https://schema.org/image",
         "@type": "@id"
       },
       "latitude":
@@ -21,7 +21,7 @@
         "@type": "xsd:decimal"
       },
       "elevation": "http://www.w3.org/2003/01/geo/wgs84_pos#alt",
-      "telephone": "http://schema.org/telephone",
+      "telephone": "https://schema.org/telephone",
 
       "Address": "http://www.w3.org/2006/vcard/ns#Address",
       "address": "http://www.w3.org/2006/vcard/ns#address",

--- a/contexts/rdfa11.jsonld
+++ b/contexts/rdfa11.jsonld
@@ -40,7 +40,7 @@
     "sioc": "http://rdfs.org/sioc/ns#",
     "v": "http://rdf.data-vocabulary.org/#",
     "vcard": "http://www.w3.org/2006/vcard/ns#",
-    "schema": "http://schema.org/",
+    "schema": "https://schema.org/",
     "describedby": "http://www.w3.org/2007/05/powder-s#describedby",
     "license": "http://www.w3.org/1999/xhtml/vocab#license",
     "role": "http://www.w3.org/1999/xhtml/vocab#role"

--- a/contexts/recipe
+++ b/contexts/recipe
@@ -1,17 +1,17 @@
 {
    "@context":
    {
-      "Recipe": "http://schema.org/Recipe",
+      "Recipe": "https://schema.org/Recipe",
       "title": "http://purl.org/dc/terms/title",
       "author": "http://purl.org/dc/terms/creator",
       "description": "http://purl.org/dc/terms/description",
-      "cookTime": "http://schema.org/cookTime",
-      "ingredient": "http://schema.org/ingredient",
-      "prepTime": "http://schema.org/prepTime",
-      "category": "http://schema.org/category",
-      "cuisine": "http://schema.org/cuisine",
-      "step": "http://schema.org/recipeInstructions",
-      "yield": "http://schema.org/recipeYield",
+      "cookTime": "https://schema.org/cookTime",
+      "ingredient": "https://schema.org/ingredient",
+      "prepTime": "https://schema.org/prepTime",
+      "category": "https://schema.org/category",
+      "cuisine": "https://schema.org/cuisine",
+      "step": "https://schema.org/recipeInstructions",
+      "yield": "https://schema.org/recipeYield",
 
       "pinch": "http://purl.org/measurement#pinch",
       "teaspoon": "http://purl.org/measurement#teaspoon",

--- a/contexts/recipe.jsonld
+++ b/contexts/recipe.jsonld
@@ -1,17 +1,17 @@
 {
    "@context":
    {
-      "Recipe": "http://schema.org/Recipe",
+      "Recipe": "https://schema.org/Recipe",
       "title": "http://purl.org/dc/terms/title",
       "author": "http://purl.org/dc/terms/creator",
       "description": "http://purl.org/dc/terms/description",
-      "cookTime": "http://schema.org/cookTime",
-      "ingredient": "http://schema.org/ingredient",
-      "prepTime": "http://schema.org/prepTime",
-      "category": "http://schema.org/category",
-      "cuisine": "http://schema.org/cuisine",
-      "step": "http://schema.org/recipeInstructions",
-      "yield": "http://schema.org/recipeYield",
+      "cookTime": "https://schema.org/cookTime",
+      "ingredient": "https://schema.org/ingredient",
+      "prepTime": "https://schema.org/prepTime",
+      "category": "https://schema.org/category",
+      "cuisine": "https://schema.org/cuisine",
+      "step": "https://schema.org/recipeInstructions",
+      "yield": "https://schema.org/recipeYield",
 
       "pinch": "http://purl.org/measurement#pinch",
       "teaspoon": "http://purl.org/measurement#teaspoon",

--- a/examples/syntax/example-002-Sample-JSON-LD-document-using-full-IRIs-instead-of-terms.json
+++ b/examples/syntax/example-002-Sample-JSON-LD-document-using-full-IRIs-instead-of-terms.json
@@ -1,6 +1,6 @@
 {
-    "http://schema.org/name": "Manu Sporny",
-    "http://schema.org/url": { "@id": "http://manu.sporny.org/" },  
-    "http://schema.org/image": { "@id": "http://manu.sporny.org/images/manu.png" }
+    "https://schema.org/name": "Manu Sporny",
+    "https://schema.org/url": { "@id": "http://manu.sporny.org/" },  
+    "https://schema.org/image": { "@id": "http://manu.sporny.org/images/manu.png" }
   }
   

--- a/examples/syntax/example-003-Context-for-the-sample-document-in-the-previous-section.json
+++ b/examples/syntax/example-003-Context-for-the-sample-document-in-the-previous-section.json
@@ -1,12 +1,12 @@
 {
       "@context": {
-        "name": "http://schema.org/name",   
+        "name": "https://schema.org/name",   
         "image": {
-          "@id": "http://schema.org/image",   
+          "@id": "https://schema.org/image",   
           "@type": "@id"   
         },
         "homepage": {
-          "@id": "http://schema.org/url",   
+          "@id": "https://schema.org/url",   
           "@type": "@id"   
         }
       }

--- a/examples/syntax/example-005-In-line-context-definition.json
+++ b/examples/syntax/example-005-In-line-context-definition.json
@@ -1,12 +1,12 @@
 {
       "@context": {
-        "name": "http://schema.org/name",
+        "name": "https://schema.org/name",
         "image": {
-          "@id": "http://schema.org/image",
+          "@id": "https://schema.org/image",
           "@type": "@id"
         },
         "homepage": {
-          "@id": "http://schema.org/url",
+          "@id": "https://schema.org/url",
           "@type": "@id"
         }
       },

--- a/examples/syntax/example-008-IRI-as-a-key.json
+++ b/examples/syntax/example-008-IRI-as-a-key.json
@@ -1,5 +1,5 @@
 {
     
-    "http://schema.org/name": "Manu Sporny"
+    "https://schema.org/name": "Manu Sporny"
   }
   

--- a/examples/syntax/example-009-Term-expansion-from-context-definition.json
+++ b/examples/syntax/example-009-Term-expansion-from-context-definition.json
@@ -1,6 +1,6 @@
 {
     "@context": {
-      "name": "http://schema.org/name"
+      "name": "https://schema.org/name"
     },
     "name": "Manu Sporny",
     "status": "trollin'"

--- a/examples/syntax/example-010-Type-coercion.json
+++ b/examples/syntax/example-010-Type-coercion.json
@@ -2,7 +2,7 @@
     "@context": {
       
       "homepage": {
-        "@id": "http://schema.org/url",
+        "@id": "https://schema.org/url",
         "@type": "@id"
       }
       

--- a/examples/syntax/example-011-Identifying-a-node.json
+++ b/examples/syntax/example-011-Identifying-a-node.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       
-      "name": "http://schema.org/name"
+      "name": "https://schema.org/name"
     },
     "@id": "http://me.markus-lanthaler.com/",
     "name": "Markus Lanthaler"

--- a/examples/syntax/example-012-Specifying-the-type-for-a-node.json
+++ b/examples/syntax/example-012-Specifying-the-type-for-a-node.json
@@ -1,5 +1,5 @@
 {
   
   "@id": "http://example.org/places#BrewEats",
-  "@type": "http://schema.org/Restaurant"
+  "@type": "https://schema.org/Restaurant"
 }

--- a/examples/syntax/example-013-Specifying-multiple-types-for-a-node.json
+++ b/examples/syntax/example-013-Specifying-multiple-types-for-a-node.json
@@ -1,5 +1,5 @@
 {
   
   "@id": "http://example.org/places#BrewEats",
-  "@type": [ "http://schema.org/Restaurant", "http://schema.org/Brewery" ]
+  "@type": [ "https://schema.org/Restaurant", "https://schema.org/Brewery" ]
 }

--- a/examples/syntax/example-014-Using-a-term-to-specify-the-type.json
+++ b/examples/syntax/example-014-Using-a-term-to-specify-the-type.json
@@ -1,8 +1,8 @@
 {
   "@context": {
     
-    "Restaurant": "http://schema.org/Restaurant", 
-    "Brewery": "http://schema.org/Brewery"
+    "Restaurant": "https://schema.org/Restaurant", 
+    "Brewery": "https://schema.org/Brewery"
   },
   "@id": "http://example.org/places#BrewEats",
   "@type": [ "Restaurant", "Brewery" ]

--- a/examples/syntax/example-018-Using-a-common-vocabulary-prefix.json
+++ b/examples/syntax/example-018-Using-a-common-vocabulary-prefix.json
@@ -1,6 +1,6 @@
 {
       "@context": {
-        "@vocab": "http://schema.org/"
+        "@vocab": "https://schema.org/"
       },
       "@id": "http://example.org/places#BrewEats",
       "@type": "Restaurant",

--- a/examples/syntax/example-019-Using-the-null-keyword-to-ignore-data.json
+++ b/examples/syntax/example-019-Using-the-null-keyword-to-ignore-data.json
@@ -1,6 +1,6 @@
 {
       "@context": {
-         "@vocab": "http://schema.org/",
+         "@vocab": "https://schema.org/",
          "databaseId": null
       },
       "@id": "http://example.org/places#BrewEats",

--- a/examples/syntax/example-024-Example-demonstrating-the-context-sensitivity-for-type.json
+++ b/examples/syntax/example-024-Example-demonstrating-the-context-sensitivity-for-type.json
@@ -1,7 +1,7 @@
 {
   
   "@id": "http://example.org/posts#TripToWestVirginia",
-  "@type": "http://schema.org/BlogPosting",  
+  "@type": "https://schema.org/BlogPosting",  
   "modified": {
     "@value": "2010-05-29T14:17:39+02:00",
     "@type": "http://www.w3.org/2001/XMLSchema#dateTime"  

--- a/examples/syntax/example-027-Referencing-node-objects.json
+++ b/examples/syntax/example-027-Referencing-node-objects.json
@@ -1,6 +1,6 @@
 [{
     "@context": {
-      "@vocab": "http://schema.org/",
+      "@vocab": "https://schema.org/",
       "knows": {"@type": "@id"}
     },
     "name": "Manu Sporny",

--- a/examples/syntax/example-028-Embedding-a-node-object-as-property-value-of-another-node-object.json
+++ b/examples/syntax/example-028-Embedding-a-node-object-as-property-value-of-another-node-object.json
@@ -1,6 +1,6 @@
 {
     "@context": {
-      "@vocab": "http://schema.org/"
+      "@vocab": "https://schema.org/"
     },
     "name": "Manu Sporny",
     "knows": {

--- a/examples/syntax/example-052-Defining-an-context-within-a-term-definition.json
+++ b/examples/syntax/example-052-Defining-an-context-within-a-term-definition.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "name": "http://schema.org/name",
+      "name": "https://schema.org/name",
       "interest": {
         "@id": "http://xmlns.com/foaf/0.1/interest",
         "@context": {"@vocab": "http://xmlns.com/foaf/0.1/"}

--- a/examples/syntax/example-053-Expanded-document-using-a-scoped-context.json
+++ b/examples/syntax/example-053-Expanded-document-using-a-scoped-context.json
@@ -1,8 +1,8 @@
 [{
-    "http://schema.org/name": [{"@value": "Manu Sporny"}],
+    "https://schema.org/name": [{"@value": "Manu Sporny"}],
     "http://xmlns.com/foaf/0.1/interest": [{
       "@id": "https://www.w3.org/TR/json-ld/",
-      "http://schema.org/name": [{"@value": "JSON-LD"}],
+      "https://schema.org/name": [{"@value": "JSON-LD"}],
       "http://xmlns.com/foaf/0.1/topic": [{"@value": "Linking Data"}]
     }]
   }]

--- a/examples/syntax/example-054-Defining-an-context-within-a-term-definition-used-on-type.json
+++ b/examples/syntax/example-054-Defining-an-context-within-a-term-definition-used-on-type.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "name": "http://schema.org/name",
+      "name": "https://schema.org/name",
       "interest": "http://xmlns.com/foaf/0.1/interest",
       "Document": {
         "@id": "http://xmlns.com/foaf/0.1/Document",

--- a/examples/syntax/example-062-Indexing-data-in-JSON-LD.json
+++ b/examples/syntax/example-062-Indexing-data-in-JSON-LD.json
@@ -1,6 +1,6 @@
 {
     "@context": {
-      "schema": "http://schema.org/",
+      "schema": "https://schema.org/",
       "name": "schema:name",
       "body": "schema:articleBody",
       "words": "schema:wordCount",

--- a/examples/syntax/example-063-Indexing-data-in-JSON-LD-with-set-representation.json
+++ b/examples/syntax/example-063-Indexing-data-in-JSON-LD-with-set-representation.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "schema": "http://schema.org/",
+      "schema": "https://schema.org/",
       "name": "schema:name",
       "body": "schema:articleBody",
       "words": "schema:wordCount",

--- a/examples/syntax/example-064-Indexing-data-using-none.json
+++ b/examples/syntax/example-064-Indexing-data-using-none.json
@@ -1,6 +1,6 @@
 {
     "@context": {
-       "schema": "http://schema.org/",
+       "schema": "https://schema.org/",
        "name": "schema:name",
        "body": "schema:articleBody",
        "words": "schema:wordCount",

--- a/examples/syntax/example-065-Indexing-graph-data-in-JSON-LD.json
+++ b/examples/syntax/example-065-Indexing-graph-data-in-JSON-LD.json
@@ -1,7 +1,7 @@
 {
     "@context": {
        "@version": 1.1,
-       "schema": "http://schema.org/",
+       "schema": "https://schema.org/",
        "name": "schema:name",
        "body": "schema:articleBody",
        "words": "schema:wordCount",

--- a/examples/syntax/example-066-Indexed-graph-data-after-expansion.json
+++ b/examples/syntax/example-066-Indexed-graph-data-after-expansion.json
@@ -1,25 +1,25 @@
 [{
     "@id": "http://example.com/",
-    "@type": ["http://schema.org/Blog"],
-    "http://schema.org/blogPost": [{
+    "@type": ["https://schema.org/Blog"],
+    "https://schema.org/blogPost": [{
       "@graph": [{
         "@id": "http://example.com/posts/1/de",
-        "http://schema.org/articleBody": [{
+        "https://schema.org/articleBody": [{
           "@value": "Die Werte an Warenbörsen stiegen im Sog eines starken Handels von Rohöl..."
         }],
-        "http://schema.org/wordCount": [{"@value": 1204}]
+        "https://schema.org/wordCount": [{"@value": 1204}]
       }],
       "@index": "de"
     }, {
       "@graph": [{
         "@id": "http://example.com/posts/1/en",
-        "http://schema.org/articleBody": [{
+        "https://schema.org/articleBody": [{
           "@value": "World commodities were up today with heavy trading of crude oil..."
         }],
-        "http://schema.org/wordCount": [{"@value": 1539}]
+        "https://schema.org/wordCount": [{"@value": 1539}]
       }],
       "@index": "en"
     }],
-    "http://schema.org/name": [{"@value": "World Financial News"}]
+    "https://schema.org/name": [{"@value": "World Financial News"}]
   }]
   

--- a/examples/syntax/example-067-Indexing-graphs-using-none-for-no-index.json
+++ b/examples/syntax/example-067-Indexing-graphs-using-none-for-no-index.json
@@ -1,7 +1,7 @@
 {
     "@context": {
        "@version": 1.1,
-       "schema": "http://schema.org/",
+       "schema": "https://schema.org/",
        "name": "schema:name",
        "body": "schema:articleBody",
        "words": "schema:wordCount",

--- a/examples/syntax/example-068-Indexed-languaged-tagged-strings-with-none-after-expansion.json
+++ b/examples/syntax/example-068-Indexed-languaged-tagged-strings-with-none-after-expansion.json
@@ -1,24 +1,24 @@
 [{
     "@id": "http://example.com/",
-    "@type": ["http://schema.org/Blog"],
-    "http://schema.org/blogPost": [{
+    "@type": ["https://schema.org/Blog"],
+    "https://schema.org/blogPost": [{
       "@graph": [{
         "@id": "http://example.com/posts/1/de",
-        "http://schema.org/articleBody": [{
+        "https://schema.org/articleBody": [{
           "@value": "Die Werte an Warenbörsen stiegen im Sog eines starken Handels von Rohöl..."
         }],
-        "http://schema.org/wordCount": [{"@value": 1204}]
+        "https://schema.org/wordCount": [{"@value": 1204}]
       }]
     }, {
       "@graph": [{
         "@id": "http://example.com/posts/1/en",
-        "http://schema.org/articleBody": [{
+        "https://schema.org/articleBody": [{
           "@value": "World commodities were up today with heavy trading of crude oil..."
         }],
-        "http://schema.org/wordCount": [{"@value": 1539}]
+        "https://schema.org/wordCount": [{"@value": 1539}]
       }],
       "@index": "en"
     }],
-    "http://schema.org/name": [{"@value": "World Financial News"}]
+    "https://schema.org/name": [{"@value": "World Financial News"}]
   }]
   

--- a/examples/syntax/example-072-Indexing-data-in-JSON-LD-by-node-identifiers.json
+++ b/examples/syntax/example-072-Indexing-data-in-JSON-LD-by-node-identifiers.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "schema": "http://schema.org/",
+      "schema": "https://schema.org/",
       "name": "schema:name",
       "body": "schema:articleBody",
       "words": "schema:wordCount",

--- a/examples/syntax/example-073-Indexing-data-in-JSON-LD-by-node-identifiers-with-set-representation.json
+++ b/examples/syntax/example-073-Indexing-data-in-JSON-LD-by-node-identifiers-with-set-representation.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "schema": "http://schema.org/",
+      "schema": "https://schema.org/",
       "name": "schema:name",
       "body": "schema:articleBody",
       "words": "schema:wordCount",

--- a/examples/syntax/example-074-Indexing-data-in-JSON-LD-by-node-identifiers-using-none.json
+++ b/examples/syntax/example-074-Indexing-data-in-JSON-LD-by-node-identifiers-using-none.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "schema": "http://schema.org/",
+      "schema": "https://schema.org/",
       "name": "schema:name",
       "body": "schema:articleBody",
       "words": "schema:wordCount",

--- a/examples/syntax/example-078-Indexing-data-in-JSON-LD-by-type.json
+++ b/examples/syntax/example-078-Indexing-data-in-JSON-LD-by-type.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "schema": "http://schema.org/",
+      "schema": "https://schema.org/",
       "name": "schema:name",
       "affiliation": {
         "@id": "schema:affiliation",

--- a/examples/syntax/example-079-Indexing-data-in-JSON-LD-by-type-with-set-representation.json
+++ b/examples/syntax/example-079-Indexing-data-in-JSON-LD-by-type-with-set-representation.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "schema": "http://schema.org/",
+      "schema": "https://schema.org/",
       "name": "schema:name",
       "affiliation": {
         "@id": "schema:affiliation",

--- a/examples/syntax/example-080-Indexing-data-in-JSON-LD-by-type-using-none.json
+++ b/examples/syntax/example-080-Indexing-data-in-JSON-LD-by-type-using-none.json
@@ -1,7 +1,7 @@
 {
     "@context": {
       "@version": 1.1,
-      "schema": "http://schema.org/",
+      "schema": "https://schema.org/",
       "name": "schema:name",
       "affiliation": {
         "@id": "schema:affiliation",

--- a/examples/syntax/example-081-Nested-properties.json
+++ b/examples/syntax/example-081-Nested-properties.json
@@ -5,7 +5,7 @@
       "labels": "@nest",
       "main_label": {"@id": "skos:prefLabel"},
       "other_label": {"@id": "skos:altLabel"},
-      "homepage": {"@id": "http://schema.org/description", "@type": "@id"}
+      "homepage": {"@id": "https://schema.org/description", "@type": "@id"}
     },
     "@id": "http://example.org/myresource",
     "homepage": "http://example.org",

--- a/examples/syntax/example-082-Nested-properties-folded-into-containing-object.json
+++ b/examples/syntax/example-082-Nested-properties-folded-into-containing-object.json
@@ -3,7 +3,7 @@
       "skos": "http://www.w3.org/2004/02/skos/core#",
       "main_label": {"@id": "skos:prefLabel"},
       "other_label": {"@id": "skos:altLabel"},
-      "homepage": {"@id": "http://schema.org/description", "@type": "@id"}
+      "homepage": {"@id": "https://schema.org/description", "@type": "@id"}
     },
     "@id": "http://example.org/myresource",
     "homepage": "http://example.org",

--- a/examples/syntax/example-083-Defining-property-nesting.json
+++ b/examples/syntax/example-083-Defining-property-nesting.json
@@ -5,7 +5,7 @@
      "labels": "@nest",
      "main_label": {"@id": "skos:prefLabel", "@nest": "labels"},
      "other_label": {"@id": "skos:altLabel", "@nest": "labels"},
-     "homepage": {"@id": "http://schema.org/description", "@type": "@id"}
+     "homepage": {"@id": "https://schema.org/description", "@type": "@id"}
    },
    "@id": "http://example.org/myresource",
    "homepage": "http://example.org",

--- a/playground/1.0/playground-examples.js
+++ b/playground/1.0/playground-examples.js
@@ -15,7 +15,7 @@
 
   // add the example of a Person
   playground.examples["Person"] = {
-    "@context": "http://schema.org/",
+    "@context": "https://schema.org/",
     "@type": "Person",
     "name": "Jane Doe",
     "jobTitle": "Professor",
@@ -26,19 +26,19 @@
   // add the example of a Place
   playground.examples["Place"] = {
     "@context": {
-      "name": "http://schema.org/name",
-      "description": "http://schema.org/description",
+      "name": "https://schema.org/name",
+      "description": "https://schema.org/description",
       "image": {
-        "@id": "http://schema.org/image",
+        "@id": "https://schema.org/image",
         "@type": "@id"
       },
-      "geo": "http://schema.org/geo",
+      "geo": "https://schema.org/geo",
       "latitude": {
-        "@id": "http://schema.org/latitude",
+        "@id": "https://schema.org/latitude",
         "@type": "xsd:float"
       },
       "longitude": {
-        "@id": "http://schema.org/longitude",
+        "@id": "https://schema.org/longitude",
         "@type": "xsd:float"
       },
       "xsd": "http://www.w3.org/2001/XMLSchema#"

--- a/playground/playground-examples.js
+++ b/playground/playground-examples.js
@@ -15,7 +15,7 @@
 
   // add the example of a Person
   playground.examples["Person"] = {
-    "@context": "http://schema.org/",
+    "@context": "https://schema.org/",
     "@type": "Person",
     "name": "Jane Doe",
     "jobTitle": "Professor",
@@ -26,19 +26,19 @@
   // add the example of a Place
   playground.examples["Place"] = {
     "@context": {
-      "name": "http://schema.org/name",
-      "description": "http://schema.org/description",
+      "name": "https://schema.org/name",
+      "description": "https://schema.org/description",
       "image": {
-        "@id": "http://schema.org/image",
+        "@id": "https://schema.org/image",
         "@type": "@id"
       },
-      "geo": "http://schema.org/geo",
+      "geo": "https://schema.org/geo",
       "latitude": {
-        "@id": "http://schema.org/latitude",
+        "@id": "https://schema.org/latitude",
         "@type": "xsd:float"
       },
       "longitude": {
-        "@id": "http://schema.org/longitude",
+        "@id": "https://schema.org/longitude",
         "@type": "xsd:float"
       },
       "xsd": "http://www.w3.org/2001/XMLSchema#"


### PR DESCRIPTION
Update most contexts, examples and playground entries to use https://schema.org instead of http://schema.org.

Fixes #422.