### PR TITLE
Update link to RDF Dataset Canonicalization

### DIFF
--- a/spec/latest/.htaccess
+++ b/spec/latest/.htaccess
@@ -4,4 +4,5 @@ RewriteBase /spec/latest/
 RewriteRule ^json-ld-syntax(.*) json-ld$1 [R=301,NC,L]
 
 RewriteRule ^rdf-graph-normalization(.*) rdf-dataset-normalization$1 [R=301,NC,L]
-RewriteRule ^rdf-dataset-normalization/(.*) https://json-ld.github.io/normalization/spec/$1 [R=307,NC,L]
+RewriteRule ^rdf-dataset-normalization/(.*) rdf-dataset-canonicalization/$1 [R=301,NC,L]
+RewriteRule ^rdf-dataset-canonicalization/(.*) https://json-ld.github.io/rdf-dataset-canonicalization/spec/$1 [R=307,NC,L]


### PR DESCRIPTION
RDF Dataset Normalization (`json-ld/normalization`) was renamed to RDF Dataset Canonicalization (`json-ld/rdf-dataset-canonicalization`): https://github.com/json-ld/rdf-dataset-canonicalization/commit/0522d97b3d60af85f270e78be7166cece4959091, https://github.com/json-ld/rdf-dataset-canonicalization/pull/20.

The redirect at `/spec/latest/rdf-dataset-normalization/` currently points to the old URL which is a broken link now. This PR
adds a new redirect at `/spec/latest/rdf-dataset-canonicalization/` to reflect the document's new name and repo id, and updates the existing route `/spec/latest/rdf-dataset-normalization/`, to redirect to this new route. This is intended to fix the broken link, following the pattern of how `rdf-graph-normalization` redirects to `rdf-dataset-normalization`.