### PR TITLE
Add "Specification Moved" warning to the old best practices document.

### DIFF
--- a/spec/latest/json-ld-api-best-practices/index.html
+++ b/spec/latest/json-ld-api-best-practices/index.html
@@ -37,6 +37,14 @@
     </section>
 
     <section id='sotd'>
+  <details class="annoying-warning" open="">
+    <summary>Specification Moved</summary>
+    <p>
+      The Community Group completed work on this specification, the
+      work is being continued by the <a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working group</a>,
+      see <a href="https://w3c.github.io/json-ld-bp/">https://w3c.github.io/json-ld-bp/</a> for the Editor's draft.      
+    </p>
+  </details>
       <p>
         This is an unofficial document of the Linking Data in JSON Community Group.
       </p>


### PR DESCRIPTION
Add "annoying warning" to redirect readers to the WG version of the best-practices document.

Searching for "JSON-LD Best Practices" still favors the old CG version of the document.