### PR TITLE
Add JSON Schema URI in $id

### DIFF
--- a/schemas/jsonld-schema.json
+++ b/schemas/jsonld-schema.json
@@ -1,7 +1,7 @@
 {
     "title": "Schema for JSON-LD",
     "$schema": "http://json-schema.org/draft-04/schema#",
-
+    "$id": "https://json-ld.org/schemas/jsonld-schema.json",
     "definitions":{
         "context": {
             "additionalProperties": true,


### PR DESCRIPTION
The JSON-Schema should have an official URI in `$id` for referencing.