### PR TITLE
Update jsonld js and add safe mode support.

### DIFF
--- a/playground/dev/index.html
+++ b/playground/dev/index.html
@@ -425,7 +425,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
 
     <!-- sccdn scripts -->
     <script src="https://cdn.jsdelivr.net/g/async@1.5.0,jquery@1.11.0,es6-promise@1.0.0,bootstrap@2.3.2,codemirror@3.22.0(codemirror.min.js+addon/lint/lint.js+addon/edit/matchbrackets.js+addon/edit/closebrackets.js+addon/display/placeholder.js+addon/hint/show-hint.js+mode/ntriples/ntriples.js+mode/javascript/javascript.js)"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jsonld@8.0.0/dist/jsonld.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jsonld@8.1.0/dist/jsonld.min.js"></script>
     <!--<script src="https://unpkg.com/jsonld@x.y.z/dist/jsonld.js"></script>-->
     <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/jsonld/x.y.z/jsonld.js"></script>-->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>

--- a/playground/dev/index.html
+++ b/playground/dev/index.html
@@ -423,7 +423,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
 
     <!-- sccdn scripts -->
     <script src="https://cdn.jsdelivr.net/g/async@1.5.0,jquery@1.11.0,es6-promise@1.0.0,bootstrap@2.3.2,codemirror@3.22.0(codemirror.min.js+addon/lint/lint.js+addon/edit/matchbrackets.js+addon/edit/closebrackets.js+addon/display/placeholder.js+addon/hint/show-hint.js+mode/ntriples/ntriples.js+mode/javascript/javascript.js)"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jsonld@3.2.0/dist/jsonld.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jsonld@8.0.0/dist/jsonld.min.js"></script>
     <!--<script src="https://unpkg.com/jsonld@x.y.z/dist/jsonld.js"></script>-->
     <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/jsonld/x.y.z/jsonld.js"></script>-->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>

--- a/playground/dev/index.html
+++ b/playground/dev/index.html
@@ -348,6 +348,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
                 <span>Visualized</span>
               </a>
             </li>
+            <!--
             <li>
               <a id="tab-signed-rsa" href="#pane-signed-rsa" data-toggle="tab" name="tab-signed-rsa">
                 <i class="icon-pencil"></i>
@@ -360,6 +361,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
                 <span>Signed with Bitcoin</span>
               </a>
             </li>
+            -->
           </ul>
 
           <div class="tab-content">

--- a/playground/index.html
+++ b/playground/index.html
@@ -506,9 +506,9 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
               </a>
             </li>
             <li>
-              <a id="tab-normalized" href="#pane-normalized" data-toggle="tab" name="tab-normalized">
+              <a id="tab-canonized" href="#pane-canonized" data-toggle="tab" name="tab-canonized">
                 <i class="icon-archive"></i>
-                <span>Normalized</span>
+                <span>Canonized</span>
               </a>
             </li>
             <li>
@@ -561,8 +561,8 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
             <div id="pane-nquads" class="tab-pane">
               <textarea id="nquads" class="codemirror-output"></textarea>
             </div>
-            <div id="pane-normalized" class="tab-pane">
-              <textarea id="normalized" class="codemirror-output"></textarea>
+            <div id="pane-canonized" class="tab-pane">
+              <textarea id="canonized" class="codemirror-output"></textarea>
             </div>
             <div id="pane-table" class="tab-pane">
               <table id="table" class="table table-condensed">

--- a/playground/index.html
+++ b/playground/index.html
@@ -542,7 +542,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
 
     <!-- sccdn scripts -->
     <script src="https://cdn.jsdelivr.net/g/async@1.5.0,jquery@1.11.0,es6-promise@1.0.0,bootstrap@2.3.2,codemirror@3.22.0(codemirror.min.js+addon/lint/lint.js+addon/edit/matchbrackets.js+addon/edit/closebrackets.js+addon/display/placeholder.js+addon/hint/show-hint.js+mode/ntriples/ntriples.js+mode/javascript/javascript.js)"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jsonld@3.2.0/dist/jsonld.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jsonld@8.0.0/dist/jsonld.min.js"></script>
     <!--<script src="https://unpkg.com/jsonld@x.y.z/dist/jsonld.js"></script>-->
     <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/jsonld/x.y.z/jsonld.js"></script>-->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>

--- a/playground/index.html
+++ b/playground/index.html
@@ -86,18 +86,26 @@
         of the examples below to get started.
       </p>
       <div class="alert alert-info">
-        <strong>NOTE</strong>:
-        The playground uses <a href="https://github.com/digitalbazaar/jsonld.js">jsonld.js</a>
-        which <a href="https://github.com/digitalbazaar/jsonld.js#conformance">conforms</a>
-        to JSON-LD 1.1
-        <a href="https://www.w3.org/TR/json-ld11/">syntax</a>
-        (<a href="https://w3c.github.io/json-ld-syntax/errata/">errata</a>),
-        <a href="https://www.w3.org/TR/json-ld11-api/">API</a>
-        (<a href="https://w3c.github.io/json-ld-api/errata/">errata</a>), and 
-        <a href="https://www.w3.org/TR/json-ld11-framing/">framing</a>
-        (<a href="https://w3c.github.io/json-ld-framing/errata/">errata</a>).
-        Also see the classic <a href="./1.0/">JSON-LD 1.0 playground</a> and
-        the <a href="http://rdf.greggkellogg.net/distiller">RDF Distiller</a>.
+        <strong>NOTES</strong>:
+        <ul>
+          <li>
+            The playground uses <a href="https://github.com/digitalbazaar/jsonld.js">jsonld.js</a>
+            which <a href="https://github.com/digitalbazaar/jsonld.js#conformance">conforms</a>
+            to JSON-LD 1.1
+            <a href="https://www.w3.org/TR/json-ld11/">syntax</a>
+            (<a href="https://w3c.github.io/json-ld-syntax/errata/">errata</a>),
+            <a href="https://www.w3.org/TR/json-ld11-api/">API</a>
+            (<a href="https://w3c.github.io/json-ld-api/errata/">errata</a>), and
+            <a href="https://www.w3.org/TR/json-ld11-framing/">framing</a>
+            (<a href="https://w3c.github.io/json-ld-framing/errata/">errata</a>).
+          </li>
+          <li>
+            Other related playgrounds:
+            <a href="./1.0/">Classic JSON-LD 1.0 Playground</a> |
+            <a href="http://rdf.greggkellogg.net/distiller">RDF Distiller</a> |
+            <a href="https://playground.chapi.io/">CHAPI Playground</a>
+          </li>
+        </ul>
       </div>
     </div>
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -487,6 +487,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
                 <span>Visualized</span>
               </a>
             </li>
+            <!--
             <li>
               <a id="tab-signed-rsa" href="#pane-signed-rsa" data-toggle="tab" name="tab-signed-rsa">
                 <i class="icon-pencil"></i>
@@ -499,6 +500,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
                 <span>Signed with Bitcoin</span>
               </a>
             </li>
+            -->
           </ul>
 
           <div class="tab-content">

--- a/playground/index.html
+++ b/playground/index.html
@@ -234,6 +234,26 @@
                         <input type="checkbox" id="options-api-compactToRelative"></input>
                       </div>
                     </div>
+
+                    <div class="control-group">
+                      <label class="control-label" for="options-api-safe">Safe</label>
+                      <div class="controls">
+                        <label class="radio inline">
+                          <input type="radio" id="options-api-safeDefault" name="safe" value="" checked/>
+                          Default
+                        </label>
+
+                        <label class="radio inline">
+                          <input type="radio" id="options-api-safeFalse" name="safe" value="false" />
+                          False
+                        </label>
+
+                        <label class="radio inline">
+                          <input type="radio" id="options-api-safeTrue" name="safe" value="true" />
+                          True
+                        </label>
+                      </div>
+                    </div>
                   </form>
                 </div>
               </div> <!-- /.tab-content -->

--- a/playground/index.html
+++ b/playground/index.html
@@ -509,6 +509,12 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
               </a>
             </li>
             -->
+            <li>
+              <a id="tab-signatures" href="#pane-signatures" data-toggle="tab" name="tab-signatures">
+                <i class="icon-pencil"></i>
+                <span>Signatures</span>
+              </a>
+            </li>
           </ul>
 
           <div class="tab-content">
@@ -548,11 +554,22 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
             <div id="pane-visualized" class="tab-pane">
               <div id="visualized" style="background: white"></div>
             </div>
+            <!--
             <div id="pane-signed-rsa" class="tab-pane">
               <textarea id="signed-rsa" class="codemirror-output"></textarea>
             </div>
             <div id="pane-signed-koblitz" class="tab-pane">
               <textarea id="signed-koblitz" class="codemirror-output"></textarea>
+            </div>
+            -->
+            <div id="pane-signatures" class="tab-pane">
+              <div class="alert alert-info">
+                <strong>NOTE</strong>:
+                As of 2022-08-25 the former RSA and Bitcoin signature demos are
+                temporarilly unavailable. For a demo involving JSON-LD
+                signatures and other related technology, please see the
+                <a href="https://playground.chapi.io/">CHAPI Playground</a>.
+              </div>
             </div>
           </div><!-- /.tab-content -->
         </div>

--- a/playground/index.html
+++ b/playground/index.html
@@ -220,12 +220,40 @@
                   <form class="form-horizontal">
                     <div class="control-group">
                       <label class="control-label" for="options-api-processingMode">Processing Mode</label>
-                      <div class="controls">
-                        <select id="options-api-processingMode">
-                          <option value="" selected="selected">Default</option>
-                          <option value="json-ld-1.0">JSON-LD 1.0</option>
-                          <option value="json-ld-1.1">JSON-LD 1.1</option>
-                        </select>
+
+                      <div class="controls" id="options-api-processingMode">
+                        <label class="radio inline">
+                          <input type="radio" id="options-api-processingMode-default" name="processingMode" value="" checked/>
+                          Default
+                        </label>
+
+                        <label class="radio inline">
+                          <input type="radio" id="options-api-processingMode-1-0" name="processingMode" value="json-ld-1.0" />
+                          JSON-LD 1.0
+                        </label>
+
+                        <label class="radio inline">
+                          <input type="radio" id="options-api-processingMode-1-1" name="processingMode" value="json-ld-1.1" />
+                          JSON-LD 1.1
+                        </label>
+                      </div>
+                    </div>
+
+                    <div class="control-group">
+                      <label class="control-label" for="options-api-base">Base</label>
+                      <div class="controls" id="options-api-base">
+                        <label class="radio inline">
+                          <input type="radio" id="options-api-base-default" name="base" value="" checked/>
+                          Default
+                        </label>
+
+                        <label class="radio inline">
+                          <input type="radio" id="options-api-base-custom" name="base" value="custom" />
+                          Custom URL
+                        </label>
+                      </div>
+                      <div class="controls" id="options-api-base2">
+                        <input type="text" id="options-api-base-url" placeholder="URL">
                       </div>
                     </div>
 
@@ -245,19 +273,19 @@
 
                     <div class="control-group">
                       <label class="control-label" for="options-api-safe">Safe</label>
-                      <div class="controls">
+                      <div class="controls" id="options-api-safe">
                         <label class="radio inline">
-                          <input type="radio" id="options-api-safeDefault" name="safe" value="" checked/>
+                          <input type="radio" id="options-api-safe-default" name="safe" value="" checked/>
                           Default
                         </label>
 
                         <label class="radio inline">
-                          <input type="radio" id="options-api-safeFalse" name="safe" value="false" />
+                          <input type="radio" id="options-api-safe-false" name="safe" value="false" />
                           False
                         </label>
 
                         <label class="radio inline">
-                          <input type="radio" id="options-api-safeTrue" name="safe" value="true" />
+                          <input type="radio" id="options-api-safe-true" name="safe" value="true" />
                           True
                         </label>
                       </div>

--- a/playground/index.html
+++ b/playground/index.html
@@ -589,7 +589,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
 
     <!-- sccdn scripts -->
     <script src="https://cdn.jsdelivr.net/g/async@1.5.0,jquery@1.11.0,es6-promise@1.0.0,bootstrap@2.3.2,codemirror@3.22.0(codemirror.min.js+addon/lint/lint.js+addon/edit/matchbrackets.js+addon/edit/closebrackets.js+addon/display/placeholder.js+addon/hint/show-hint.js+mode/ntriples/ntriples.js+mode/javascript/javascript.js)"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jsonld@8.0.0/dist/jsonld.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jsonld@8.1.0/dist/jsonld.min.js"></script>
     <!--<script src="https://unpkg.com/jsonld@x.y.z/dist/jsonld.js"></script>-->
     <!--<script src="https://cdnjs.cloudflare.com/ajax/libs/jsonld/x.y.z/jsonld.js"></script>-->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js"></script>

--- a/playground/index.html
+++ b/playground/index.html
@@ -565,7 +565,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
             <div id="pane-signatures" class="tab-pane">
               <div class="alert alert-info">
                 <strong>NOTE</strong>:
-                As of 2022-08-25, the former RSA and Bitcoin signature demos are
+                As of 2022-08-25, the demos of RSA and Bitcoin signatures are
                 temporarily unavailable. For a demo involving JSON-LD
                 signatures and other related technology, please see the
                 <a href="https://playground.chapi.io/">CHAPI Playground</a>.

--- a/playground/index.html
+++ b/playground/index.html
@@ -565,8 +565,8 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
             <div id="pane-signatures" class="tab-pane">
               <div class="alert alert-info">
                 <strong>NOTE</strong>:
-                As of 2022-08-25 the former RSA and Bitcoin signature demos are
-                temporarilly unavailable. For a demo involving JSON-LD
+                As of 2022-08-25, the former RSA and Bitcoin signature demos are
+                temporarily unavailable. For a demo involving JSON-LD
                 signatures and other related technology, please see the
                 <a href="https://playground.chapi.io/">CHAPI Playground</a>.
               </div>

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -93,9 +93,16 @@
       case 'string':
         return value;
       case 'error':
+        // TODO: limit output size
         var str = value.toString();
         if('details' in value) {
-          str += '\n' + JSON.stringify(value.details, null, 2);
+          // TODO: improve error handling
+          // special cases as of jsonld.js 8.0.0
+          if('event' in value.details) {
+            str += '\n' + JSON.stringify(value.details.event, null, 2);
+          }
+          // some error and event details can be verbose and need good handling
+          // all errors and events should have type codes that can be used
         }
         return str;
       default:

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -256,7 +256,8 @@
         // TODO: add other API options
         processingMode: '',
         compactArrays: true,
-        compactToRelative: true
+        compactToRelative: true,
+        safe: ''
       }
     };
 
@@ -330,6 +331,12 @@
       'checked', playground.options.api.compactArrays);
     $("#options-api-compactToRelative").prop(
       'checked', playground.options.api.compactToRelative);
+    $("#options-api-safeDefault").prop(
+      'checked', playground.options.api.safe === '');
+    $("#options-api-safeFalse").prop(
+      'checked', playground.options.api.safe === false);
+    $("#options-api-safeTrue").prop(
+      'checked', playground.options.api.safe === true);
 
     // process on option changes
     $("#options-api-processingMode").change(function(e) {
@@ -342,6 +349,18 @@
     });
     $("#options-api-compactToRelative").change(function(e) {
       playground.options.api.compactToRelative = e.target.checked;
+      playground.process();
+    });
+    $("#options-api-safeDefault").change(function(e) {
+      playground.options.api.safe = '';
+      playground.process();
+    });
+    $("#options-api-safeFalse").change(function(e) {
+      playground.options.api.safe = false;
+      playground.process();
+    });
+    $("#options-api-safeTrue").change(function(e) {
+      playground.options.api.safe = true;
       playground.process();
     });
 
@@ -843,6 +862,9 @@
     }
     options.compactArrays = playground.options.api.compactArrays;
     options.compactToRelative = playground.options.api.compactToRelative;
+    if(playground.options.api.safe !== '') {
+      options.safe = playground.options.api.safe;
+    }
 
     var promise;
     if(playground.activeTab === 'tab-compacted') {

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -576,7 +576,7 @@
       output = playground.outputs[key] = CodeMirror.fromTextArea(node, {
         readOnly: true,
         lineWrapping: true,
-        mode: ["normalized", "nquads"].indexOf(key) > -1 ?
+        mode: ["canonized", "nquads"].indexOf(key) > -1 ?
           "text/n-triples" :
           "application/ld+json",
         theme: playground.theme
@@ -932,9 +932,9 @@
       options.format = 'application/n-quads';
       promise = jsonld.toRDF(input, options);
     }
-    else if(playground.activeTab === 'tab-normalized') {
+    else if(playground.activeTab === 'tab-canonized') {
       options.format = 'application/n-quads';
-      promise = jsonld.normalize(input, options);
+      promise = jsonld.canonize(input, options);
     }
     else if(playground.activeTab === 'tab-table') {
       return jsonld.toRDF(input, options)

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -805,7 +805,7 @@
     var id = playground.activeTab = evt.target.id;
 
     if(['tab-compacted', 'tab-flattened', 'tab-framed',
-      'tab-signed-rsa', 'tab-signed-koblitz', ].indexOf(id) > -1) {
+      /*'tab-signed-rsa', 'tab-signed-koblitz'*/].indexOf(id) > -1) {
       // these options require more UI inputs, so compress UI space
       $('#markup-div').removeClass('span12').addClass('span6');
       $('#frame-div, #privatekey-rsa-div, #privatekey-koblitz-div, ' +
@@ -998,14 +998,19 @@
         throw(e)
       });
     }
+    else if(playground.activeTab === 'tab-signatures') {
+      promise = Promise.resolve();
+    }
     else {
       promise = Promise.reject(new Error('Invalid tab selection.'));
     }
 
     return promise.then(function(result) {
       var outputTab = playground.activeTab.substr('tab-'.length);
-      result = playground.humanize(result);
-      playground.outputs[outputTab].setValue(result);
+      if(outputTab in playground.outputs) {
+        result = playground.humanize(result);
+        playground.outputs[outputTab].setValue(result);
+      }
     });
   };
 

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -262,6 +262,8 @@
       api: {
         // TODO: add other API options
         processingMode: '',
+        base: '',
+        baseUrl: '',
         compactArrays: true,
         compactToRelative: true,
         safe: ''
@@ -332,41 +334,78 @@
     });
 
     // setup options
-    $("#options-api-processingMode")[0].value =
-      playground.options.api.processingMode;
+    $("#options-api-processingMode-default").prop(
+      'checked', playground.options.api.processingMode === '');
+    $("#options-api-processingMode-1-0").prop(
+      'checked', playground.options.api.processingMode === 'json-ld-1.0');
+    $("#options-api-processingMode-1-1").prop(
+      'checked', playground.options.api.processingMode === 'json-ld-1.1');
+
+    $("#options-api-base-default").prop(
+      'checked', playground.options.api.base === '');
+    $("#options-api-base-custom").prop(
+      'checked', playground.options.api.base === 'custom');
+
+    $("#options-api-base-url").value = playground.options.api.baseUrl;
+
     $("#options-api-compactArrays").prop(
       'checked', playground.options.api.compactArrays);
+
     $("#options-api-compactToRelative").prop(
       'checked', playground.options.api.compactToRelative);
-    $("#options-api-safeDefault").prop(
+
+    $("#options-api-safe-default").prop(
       'checked', playground.options.api.safe === '');
-    $("#options-api-safeFalse").prop(
+    $("#options-api-safe-false").prop(
       'checked', playground.options.api.safe === false);
-    $("#options-api-safeTrue").prop(
+    $("#options-api-safe-true").prop(
       'checked', playground.options.api.safe === true);
 
     // process on option changes
-    $("#options-api-processingMode").change(function(e) {
+    $("#options-api-processingMode-default, " +
+      "#options-api-processingMode-1-0, " +
+      "#options-api-processingMode-1-1").change(function(e) {
       playground.options.api.processingMode = e.target.value;
       playground.process();
     });
+
+    $("#options-api-base-default, " +
+      "#options-api-base-custom").change(function(e) {
+      playground.options.api.base = e.target.value;
+      playground.process();
+    });
+
+    $("#options-api-base-url").on('keypress', function(e) {
+      var keyPressed = e.keyCode || e.which;
+      if(keyPressed === 13) {
+        e.preventDefault();
+        return false;
+      }
+    });
+    $("#options-api-base-url").on('input', function(e) {
+      playground.options.api.baseUrl = e.target.value;
+      playground.process();
+    });
+
     $("#options-api-compactArrays").change(function(e) {
       playground.options.api.compactArrays = e.target.checked;
       playground.process();
     });
+
     $("#options-api-compactToRelative").change(function(e) {
       playground.options.api.compactToRelative = e.target.checked;
       playground.process();
     });
-    $("#options-api-safeDefault").change(function(e) {
+
+    $("#options-api-safe-default" ).change(function(e) {
       playground.options.api.safe = '';
       playground.process();
     });
-    $("#options-api-safeFalse").change(function(e) {
+    $("#options-api-safe-false").change(function(e) {
       playground.options.api.safe = false;
       playground.process();
     });
-    $("#options-api-safeTrue").change(function(e) {
+    $("#options-api-safe-true").change(function(e) {
       playground.options.api.safe = true;
       playground.process();
     });
@@ -859,13 +898,16 @@
    */
   playground.performAction = function(input, param) {
     // set options
-    var options = {
-      // base IRI
-      base: (playground.useRemote.markup && playground.remoteUrl.markup) ||
-        document.baseURI || document.URL
-    };
+    var options = {};
     if(playground.options.api.processingMode !== '') {
       options.processingMode = playground.options.api.processingMode;
+    }
+    if(playground.options.api.base === 'custom') {
+      options.base = playground.options.api.baseUrl || '';
+    } else {
+      // default base IRI is based on remote url or set to null
+      options.base =
+        (playground.useRemote.markup && playground.remoteUrl.markup) || null;
     }
     options.compactArrays = playground.options.api.compactArrays;
     options.compactToRelative = playground.options.api.compactToRelative;

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -90,9 +90,16 @@
    */
   playground.humanize = function(value) {
     switch($.type(value)) {
-      case 'string': return value;
-      case 'error': return value.toString();
-      default: return JSON.stringify(value, null, 2);
+      case 'string':
+        return value;
+      case 'error':
+        var str = value.toString();
+        if('details' in value) {
+          str += '\n' + JSON.stringify(value.details, null, 2);
+        }
+        return str;
+      default:
+        return JSON.stringify(value, null, 2);
     }
   };
 


### PR DESCRIPTION
- Updates jsonld.js to 8.0.0.
- Add safe mode option UI.
- Show error details if available.  Hopefully this doesn't have degenerate cases involving huge errors or recursive serialization.  A built project would use other libraries to avoid that but this is difficult for now.
- Disables signature tabs since old jsonld-signatures no longer works with newer jsonld.js.  Bundled code and default suites are not distributed.  Need to move this to a build process if that functionality is to be kept.