### PR TITLE
Add back forwarding rules for latest specs to /TR.

### DIFF
--- a/spec/latest/.htaccess
+++ b/spec/latest/.htaccess
@@ -3,6 +3,10 @@ RewriteEngine On
 RewriteBase /spec/latest/
 RewriteRule ^json-ld-syntax(.*) json-ld$1 [R=301,NC,L]
 
-RewriteRule ^rdf-graph-normalization(.*) rdf-dataset-normalization$1 [R=301,NC,L]
-RewriteRule ^rdf-dataset-normalization/(.*) rdf-dataset-canonicalization/$1 [R=301,NC,L]
-RewriteRule ^rdf-dataset-canonicalization/(.*) https://json-ld.github.io/rdf-dataset-canonicalization/spec/$1 [R=307,NC,L]
+RewriteRule ^json-ld/(.*) https://www.w3.org/TR/json-ld/$1 [R=301,NC,L]
+RewriteRule ^json-ld-api/(.*) https://www.w3.org/TR/json-ld-api/$1 [R=301,NC,L]
+RewriteRule ^json-ld-framing/(.*) https://www.w3.org/TR/json-ld-framing/$1 [R=301,NC,L]
+
+RewriteRule ^rdf-graph-normalization(.*) https://w3c-ccg.github.io/rdf-dataset-canonicalization/spec/$1 [R=307,NC,L]
+RewriteRule ^rdf-dataset-normalization/(.*) https://w3c-ccg.github.io/rdf-dataset-canonicalization/spec/$1 [R=307,NC,L]
+RewriteRule ^rdf-dataset-canonicalization/(.*) https://w3c-ccg.github.io/rdf-dataset-canonicalization/spec/$1 [R=307,NC,L]


### PR DESCRIPTION
This will forward (301) requests for the latest versions of specs to their /TR locations. Note that the site menu drop-downs already do this, as well as forward the latest drafts to w3c.github.io/...

I didn't actually remove the latest versions of the specs from the repo, but they shouldn't be accessible via HTTP. Neither did I attempt to add any robots.txt to keep them from being indexed.