### PR TITLE
Rename 'Github' to 'GitHub'

### DIFF
--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@
         It is a <a href="http://www.w3.org/TR/json-ld/">W3C Recommendation</a>
         as of 16 January 2014. Participation is open
         to the public. There is a <a href="https://github.com/json-ld">JSON-LD
-        Github repository</a>. If you need immediate help, we have a <a
+        GitHub repository</a>. If you need immediate help, we have a <a
         href="https://irc.w3.org/?channels=#json-ld">#json-ld</a> IRC
         support channel on irc.w3.org
         and a <a href="https://gitter.im/json-ld/json-ld.org">Gitter channel</a>.
@@ -425,7 +425,7 @@
           <div class="well" style="padding: 8px 0;">
             <ul class="nav nav-list">
               <li class="nav-header"><h3>Code</h3></li>
-              <li><a href="https://github.com/json-ld/json-ld.org">json-ld on Github</a></li>
+              <li><a href="https://github.com/json-ld/json-ld.org">json-ld on GitHub</a></li>
             </ul>
           </div>
         </div>

--- a/spec/latest/json-ld-api-best-practices/index.html
+++ b/spec/latest/json-ld-api-best-practices/index.html
@@ -161,8 +161,8 @@
       <div class="practice">
         <p><span id="typed-objects" class="practicelab">Provide one or more types for JSON objects</span></p>
         <p class="practicedesc">Principles of <a>Linked Data</a> dictate that messages SHOULD be self describing, which includes adding a <code>type</code> to such messages.</p>
-        <p>Many APIs use JSON messages where the type of information being conveyed is inferred from the retrieval endpoint. For example, when retrieving information about a Github Commit, you might see the following response:</p>
-        <pre class="example" title="Github Commit message">
+        <p>Many APIs use JSON messages where the type of information being conveyed is inferred from the retrieval endpoint. For example, when retrieving information about a GitHub Commit, you might see the following response:</p>
+        <pre class="example" title="GitHub Commit message">
           {
             "sha": "7638417db6d59f3c431d3e1f261cc637155684cd",
             "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd",

--- a/spec/latest/json-ld-connect/index.html
+++ b/spec/latest/json-ld-connect/index.html
@@ -253,7 +253,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
       <a href="https://github.com/json-ld/json-ld.org/issues">issue tracker</a>.</li>
 
     <li><a href="https://github.com/json-ld/json-ld.org/tree/main/spec">Source code</a> for the
-      specification can be found on Github.</li>
+      specification can be found on GitHub.</li>
 
     <li>The <a href="https://webchat.freenode.net/?channels=json-ld">#json-ld</a>
       IRC channel is available for real-time discussion on irc.freenode.net.</li>

--- a/spec/latest/json-ld-rdf/index.html
+++ b/spec/latest/json-ld-rdf/index.html
@@ -254,7 +254,7 @@ familiar with the basic RDF concepts [[!RDF-CONCEPTS]].</p>
       <a href="https://github.com/json-ld/json-ld.org/issues">issue tracker</a>.</li>
 
     <li><a href="https://github.com/json-ld/json-ld.org/tree/main/spec">Source code</a> for the
-      specification can be found on Github.</li>
+      specification can be found on GitHub.</li>
 
     <li>The <a href="https://webchat.freenode.net/?channels=json-ld">#json-ld</a>
       IRC channel is available for real-time discussion on irc.freenode.net.</li>


### PR DESCRIPTION
GitHub should be stylized with a capital "H".

Generated the PR by executed `find . -type f -exec sed -i '' "s/Github/GitHub/g" {} +` from the project root.