### PR TITLE
Fix "http://schema.org" processing.

### DIFF
--- a/playground/1.0/playground.js
+++ b/playground/1.0/playground.js
@@ -1467,7 +1467,7 @@
         }
       }
       // rewrite URLs that we know have secure JSON-LD Contexts
-      if(url === 'http://schema.org/') {
+      if(url === 'http://schema.org/' || url === 'http://schema.org') {
         url = 'https://schema.org/';
       }
 

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -1597,7 +1597,7 @@
         }
       }
       // rewrite URLs that we know have secure JSON-LD Contexts
-      if(url === 'http://schema.org/') {
+      if(url === 'http://schema.org/' || url === 'http://schema.org') {
         url = 'https://schema.org/';
       }
 


### PR DESCRIPTION
Convert both "http://schema.org/" and "http://schema.org" to "https://schema.org/".

This covers up lower level issues, but will help address a common use case.

Closes: https://github.com/json-ld/json-ld.org/issues/798