### PR TITLE
Remove reference to deleted `prettify.css`

### DIFF
--- a/images/index.html
+++ b/images/index.html
@@ -19,7 +19,6 @@
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/bootstrap.css">
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/bootstrap-responsive.css">
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/font-awesome.css">
-    <link rel="stylesheet" href="../common/prettify.css" type="text/css" />
     <link rel="shortcut icon" href="../favicon.ico" />
 
     <!-- script tags -->

--- a/primer/index.php
+++ b/primer/index.php
@@ -21,7 +21,6 @@
       <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/bootstrap.css">
       <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/bootstrap-responsive.css">
       <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/font-awesome.css">
-      <link rel="stylesheet" href="../common/prettify.css" type="text/css" />
       <link rel="shortcut icon" href="../favicon.ico" />
 
       <!-- script tags -->

--- a/requirements/index.php
+++ b/requirements/index.php
@@ -21,7 +21,6 @@ print <<< htmlcode
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/bootstrap.css">
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/bootstrap-responsive.css">
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/font-awesome.css">
-    <link rel="stylesheet" href="../common/prettify.css" type="text/css" />
     <link rel="shortcut icon" href="../favicon.ico" />
 
     <!-- script tags -->

--- a/spec/index.php
+++ b/spec/index.php
@@ -19,7 +19,6 @@
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/bootstrap.css">
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/bootstrap-responsive.css">
     <link rel="stylesheet" type="text/css" href="../static/css/bootstrap/font-awesome.css">
-    <link rel="stylesheet" href="../common/prettify.css" type="text/css" />
     <link rel="shortcut icon" href="../favicon.ico" />
 
     <!-- script tags -->


### PR DESCRIPTION
`common/prettify.css` was deleted in 0702a1819008995a1052a675ea526d477c01feac, but some of those references remained.