### PR TITLE
Change CHAPI Playground links.

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -103,7 +103,7 @@
             Other related playgrounds:
             <a href="./1.0/">Classic JSON-LD 1.0 Playground</a> |
             <a href="http://rdf.greggkellogg.net/distiller">RDF Distiller</a> |
-            <a href="https://playground.chapi.io/">CHAPI Playground</a>
+            <a href="https://vcplayground.org/">Verifiable Credentials Playground</a>
           </li>
         </ul>
       </div>
@@ -618,7 +618,7 @@ yT2IMAWbY76Bmi8TeQJAfdLJGwiDNIhTVYHxvDz79ANzgRAd1kPKPddJZ/w7Gfhm
                 As of 2022-08-25, the demos of RSA and Bitcoin signatures are
                 temporarily unavailable. For a demo involving JSON-LD
                 signatures and other related technology, please see the
-                <a href="https://playground.chapi.io/">CHAPI Playground</a>.
+                <a href="https://vcplayground.org/">Verifiable Credentials Playground</a>.
               </div>
             </div>
           </div><!-- /.tab-content -->


### PR DESCRIPTION
The CHAPI Playground has moved to be the Verifiable Credentials Playground at https://vcplayground.org/