### PR TITLE
Add ld-cli native executable for Ubuntu,MacOS, and Win

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,6 +311,13 @@
                 </a>
                 <span property="schema:programmingLanguage" content="JavaScript"></span>
               </li>
+              <li typeof="schema:SoftwareSourceCode">
+                <a property="schema:codeRepository" href="https://github.com/filip26/ld-cli">
+                  <span property="schema:name">ld-cli (Ubuntu, MacOS, Windows)</span>
+                  <span class="badge badge-success">1.1</span>
+                </a>
+                <span property="schema:programmingLanguage" content="Java"></span>
+              </li>                
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Hi,
please add ld-cli on the list, I've just noticed there is a new section `Command Line`. 
Thank you