### PR TITLE
Add missing purpose field to t0041

### DIFF
--- a/test-suite/tests/expand-manifest.jsonld
+++ b/test-suite/tests/expand-manifest.jsonld
@@ -290,7 +290,7 @@
       "@id": "#t0041",
       "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
       "name": "@language: null",
-      "name": "@language: null resets the default language",
+      "purpose": "@language: null resets the default language",
       "input": "expand-0041-in.jsonld",
       "expect": "expand-0041-out.jsonld"
     }, {


### PR DESCRIPTION
Test `t0041` had two `name` fields and no `purpose` field, which was causing my code to break. I assume it was a mistake. I've fixed that here.