### PR TITLE
Setup 301 redirect for /test-suite/.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -5,6 +5,8 @@
 /spec/latest/json-ld-syntax https://www.w3.org/TR/json-ld/ 301
 /spec/latest/json-ld-syntax/ https://www.w3.org/TR/json-ld/ 301
 
+/test-suite/ https://w3c.github.io/json-ld-api/tests/ 301
+
 # Tests 0005-0007, status redirect to 0001
 /test-suite/remote-doc-0005-in.jsonld /test-suite/tests/remote-doc-0001-in.jsonld 301
 /test-suite/remote-doc-0006-in.jsonld /test-suite/tests/remote-doc-0001-in.jsonld 303


### PR DESCRIPTION
The current page uses a meta refresh (after 5 seconds) to go to the API test suite. Consequently, this page serves little purpose now, so converting it to a full 301 redirect seems to make the most sense.

Additionally, I'm not sure we need the `test-suite/` directory here at all sense it seems all test suite work is no in each spec's specific repo.

Thoughts?