### PR TITLE
Parse YAML workaround. See #875.

### DIFF
--- a/playground/next/editor.mjs
+++ b/playground/next/editor.mjs
@@ -98,7 +98,7 @@ function editorListener(docName) {
           return;
         } else {
           try {
-            const parsed = JSON.parse(latestChange);
+            const parsed = YAML.parse(latestChange);
             this[docName] = parsed;
             this.parseError = {};
             this.setOutputTab(this.outputTab);


### PR DESCRIPTION
## This PR

- modify the parser to accept YAML instead of JSON

## Notes

I tried to bundle the editor with npm run build:editor, but it does not seem to work on my PC, while just modifying the .js works.