### PR TITLE
Remove auto-setting compaction context.

### DIFF
--- a/playground/next/editor.mjs
+++ b/playground/next/editor.mjs
@@ -446,14 +446,6 @@ window.app = createApp({
         }
         break;
       case 'compacted':
-        if (JSON.stringify(context) === '{}' && '@context' in this.doc) {
-          // no context set yet, so copy in the main document's
-          context = {
-            '@context': this.doc['@context']
-          };
-          this.contextDoc = context;
-          setEditorValue(this.sideEditor, this.contextDoc);
-        }
         try {
           const compacted = await jsonld.compact(this.doc, {'@context': context['@context'] || {}}, this.options);
           setEditorValue(readOnlyEditor, compacted);


### PR DESCRIPTION
There are good reasons to leave it as `{}` and this code prevented that value ever being possible, so removing it.

This PR can be tested at https://fix-compaction-context.json-ld-org.pages.dev/playground/next/
