### PR TITLE
Fix broken YAML-LD Specification link

### DIFF
--- a/_layouts/bs2.liquid
+++ b/_layouts/bs2.liquid
@@ -78,7 +78,7 @@
                   <li><a href="https://json-ld.github.io/json-ld-star/">JSON-LD-star</a></li>
                   <li><a href="https://w3c.github.io/json-ld-cbor/">CBOR</a></li>
                   <li><a href="https://github.com/w3c/json-ld-rc/">Recommended Context</a></li>
-                  <li><a href="https://json-ld.github.io/yaml-ld/">YAML-LD</a></li>
+                  <li><a href="https://w3c.github.io/yaml-ld/spec/">YAML-LD</a></li>
                   <li><a href="/spec/">1.0 drafts (historic)</a></li>
               </ul>
             </li>

--- a/_layouts/bs5.liquid
+++ b/_layouts/bs5.liquid
@@ -72,7 +72,7 @@
                 <li><a class="dropdown-item" href="https://json-ld.github.io/json-ld-star/">JSON-LD-star</a></li>
                 <li><a class="dropdown-item" href="https://w3c.github.io/json-ld-cbor/">CBOR</a></li>
                 <li><a class="dropdown-item" href="https://github.com/w3c/json-ld-rc/">Recommended Context</a></li>
-                <li><a class="dropdown-item" href="https://json-ld.github.io/yaml-ld/">YAML-LD</a></li>
+                <li><a class="dropdown-item" href="https://w3c.github.io/yaml-ld/spec/">YAML-LD</a></li>
                 <li><a class="dropdown-item" href="/spec/">1.0 drafts (historic)</a></li>
               </ul>
             </li>

--- a/_layouts/fomantic.liquid
+++ b/_layouts/fomantic.liquid
@@ -94,7 +94,7 @@
             <a class="item" href="https://json-ld.github.io/json-ld-star/">JSON-LD-star</a>
             <a class="item" href="https://w3c.github.io/json-ld-cbor/">CBOR</a>
             <a class="item" href="https://github.com/w3c/json-ld-rc/">Recommended Context</a>
-            <a class="item" href="https://json-ld.github.io/yaml-ld/">YAML-LD</a>
+            <a class="item" href="https://w3c.github.io/yaml-ld/spec/">YAML-LD</a>
             <a class="item" href="/spec/">1.0 drafts (historic)</a>
           </div>
         </div>

--- a/playground/1.0/index.html
+++ b/playground/1.0/index.html
@@ -66,7 +66,7 @@
                   <li><a href="https://w3c.github.io/json-ld-cbor/">CBOR</a></li>
                   <li><a href="https://json-ld.github.io/json-ld-star/">JSON-LD-star</a></li>
                   <li><a href="https://github.com/w3c/json-ld-rc/">Recommended Context</a></li>
-                  <li><a href="https://json-ld.github.io/yaml-ld/">YAML-LD</a></li>
+                  <li><a href="https://w3c.github.io/yaml-ld/spec/">YAML-LD</a></li>
                   <li><a href="/spec/">1.0 drafts (historic)</a></li>
               </ul>
             </li>

--- a/playground/dev/index.html
+++ b/playground/dev/index.html
@@ -66,7 +66,7 @@
                   <li><a href="https://json-ld.github.io/json-ld-star/">JSON-LD-star</a></li>
                   <li><a href="https://w3c.github.io/json-ld-cbor/">CBOR</a></li>
                   <li><a href="https://github.com/w3c/json-ld-rc/">Recommended Context</a></li>
-                  <li><a href="https://json-ld.github.io/yaml-ld/">YAML-LD</a></li>
+                  <li><a href="https://w3c.github.io/yaml-ld/spec/">YAML-LD</a></li>
                   <li><a href="/spec/">1.0 drafts (historic)</a></li>
               </ul>
             </li>

--- a/playground/index.html
+++ b/playground/index.html
@@ -66,7 +66,7 @@
                   <li><a href="https://json-ld.github.io/json-ld-star/">JSON-LD-star</a></li>
                   <li><a href="https://w3c.github.io/json-ld-cbor/">CBOR</a></li>
                   <li><a href="https://github.com/w3c/json-ld-rc/">Recommended Context</a></li>
-                  <li><a href="https://json-ld.github.io/yaml-ld/">YAML-LD</a></li>
+                  <li><a href="https://w3c.github.io/yaml-ld/spec/">YAML-LD</a></li>
                   <li><a href="/spec/">1.0 drafts (historic)</a></li>
               </ul>
             </li>


### PR DESCRIPTION
Fixes #912 

**Please check this is correct**: 
- :heavy_check_mark: I used the "**Draft Community Group Report**" specification found in https://github.com/w3c/yaml-ld: https://w3c.github.io/yaml-ld/spec/
- :x: I did not use the "**Final Community Group Report**" link: https://www.w3.org/community/reports/json-ld/CG-FINAL-yaml-ld-20231206/

My choice is based on https://github.com/json-ld/json-ld.org/issues/789#issuecomment-1409872614 which has been posted before the publication of the Final Community Group Report