### PR TITLE
Add info about YAML-LD and CBOR-LD

### DIFF
--- a/index.liquid
+++ b/index.liquid
@@ -110,9 +110,9 @@ masthead:
   </div>
 </div>
 <p class="ui basic large center aligned segment">
-  The data model and conventions introduced in JSON-LD can also apply to
-  formats other than JSON. The JSON-LD Working Group is expanding the list
-  of interoperable JSON-LD inspired formats to include YAML-LD and CBOR-LD.
+  The data model and conventions introduced in JSON-LD are now being
+  expanded to other formats including YAML-LD (for human-friendly authoring)
+  and CBOR-LD (for compression and space constrained use cases).
 </p>
 
 <div class="ui large basic padded segment">


### PR DESCRIPTION
- **Add Expanding Ecosystem section.**
- **Add YAML-LD and CBOR-LD implementations.**

Replaces #789 (in part). I still hope to bring over the YAML-LD "learn" page and also create one for CBOR-LD. This at least boosts signal from the homepage.